### PR TITLE
Text UI V1

### DIFF
--- a/frontend/build/webpack.base.conf.js
+++ b/frontend/build/webpack.base.conf.js
@@ -95,7 +95,6 @@ module.exports = {
           id: 'font-loader',
           name: '[name].[hash:7].[ext]',
           outputPath: utils.assetsPath('fonts'),
-          publicPath: './../fonts',
           limit: 10000
         }
       },

--- a/frontend/build/webpack.dev.conf.js
+++ b/frontend/build/webpack.dev.conf.js
@@ -71,13 +71,7 @@ const devWebpackConfig = merge(baseWebpackConfig, {
   ]
 })
 
-const fontRule = devWebpackConfig.module.rules.filter(rule => {
-  if(rule.options &&  rule.options.id === 'font-loader'){
-    return true
-  }
-  return false
-})[0];
-fontRule.options.publicPath = './../static/fonts';
+
 module.exports = new Promise((resolve, reject) => {
   portfinder.basePort = process.env.PORT || config.dev.port
   portfinder.getPort((err, port) => {

--- a/frontend/src/components/annotation/annotation_full.vue
+++ b/frontend/src/components/annotation/annotation_full.vue
@@ -32,7 +32,7 @@
         <v-card>
           <v-card-title>
             Welcome!
-            Images can be annotated here. :)
+            Images/Text can be annotated here. :)
 
           </v-card-title>
           <v-btn @click="upload_link">
@@ -73,7 +73,6 @@
         },
 
       },
-
       data() {
         return {
 
@@ -83,14 +82,11 @@
           request_project_change: null,
           view_only: false,
           current_image: null,
-
-
           download_annotations_loading: false,
           annotation_example: false,
 
         }
       },
-
       watch: {
         '$route'(to, from) {
           this.images_found = true,
@@ -104,13 +100,11 @@
         if (this.$route.query.view_only) {
           this.view_only = true;
         }
-        if(this.$props.task_id_prop){
+        if (this.$props.task_id_prop) {
           this.add_visit_history_event('task')
-        }
-        else if(this.$props.file_id_prop){
+        } else if (this.$props.file_id_prop) {
           this.add_visit_history_event('file')
-        }
-        else{
+        } else {
           this.add_visit_history_event('page')
         }
       },
@@ -118,13 +112,11 @@
         if (this.$route.query.view_only) {
           this.view_only = true;
         }
-
-
       },
       computed: {
-        file_id: function(){
+        file_id: function () {
           let file_id = this.$props.file_id_prop;
-          if(this.$route.query.file){
+          if (this.$route.query.file) {
             file_id = this.$route.query.file;
           }
           return file_id;
@@ -137,21 +129,13 @@
           }
         }
       },
-      beforeRouteLeave(to, from, next) {
-        if (this.$refs.annotation_core && this.$refs.annotation_core.has_changed) {
-          if (!window.confirm("Leave without saving?")) {
-            return;
-          }
-        }
-        next();
-      },
       methods: {
-        add_visit_history_event: async function(object_type){
+        add_visit_history_event: async function (object_type) {
           let page_name = 'data_explorer'
-          if(this.$props.file_id_prop){
+          if (this.$props.file_id_prop) {
             page_name = 'file_detail'
           }
-          if(this.$props.task_id_prop){
+          if (this.$props.task_id_prop) {
             page_name = 'task_detail'
           }
           const event_data = await create_event(this.get_project_string_id(), {
@@ -162,8 +146,8 @@
             user_visit: 'user_visit',
           })
         },
-        get_project_string_id: function(){
-          if(this.$props.project_string_id){
+        get_project_string_id: function () {
+          if (this.$props.project_string_id) {
             return this.$props.project_string_id;
           }
           return this.$store.state.project.current.project_string_id;
@@ -201,6 +185,7 @@
             String(this.project_string_id) + '/annotation_project/versions')
         }
 
-      }
+      },
     }
-  ) </script>
+  )
+</script>

--- a/frontend/src/components/annotation/text_annotation/text_annotation_core.vue
+++ b/frontend/src/components/annotation/text_annotation/text_annotation_core.vue
@@ -1,0 +1,13 @@
+<template>
+  <text_highlighter :text="`text hello world diffgram `"></text_highlighter>
+</template>
+
+<script>
+  export default {
+    name: "text_annotation_core"
+  }
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/components/annotation/text_annotation/text_highlighter.vue
+++ b/frontend/src/components/annotation/text_annotation/text_highlighter.vue
@@ -1,0 +1,19 @@
+<template>
+  <v-container>
+    {{text}}
+  </v-container>
+</template>
+
+<script>
+  import Vue from "vue";
+
+  export default Vue.extend({
+    name: 'text_highlighter',
+    props: ['text']
+  })
+
+</script>
+
+<style scoped>
+
+</style>

--- a/local_dispatcher/local_dispatch.py
+++ b/local_dispatcher/local_dispatch.py
@@ -36,7 +36,7 @@ def route_same_host(path):
         host = 'http://127.0.0.1:8082/'
 
     # JS local dev server
-    if path[: 3] != "api":
+    if path[: 3] != "api" or path[: 6] == "static":
         return requests.get('http://localhost:8081/{}'.format(path_with_params)).text
 
     # https://stackoverflow.com/questions/6656363/proxying-to-another-web-service-with-flask
@@ -68,7 +68,6 @@ def route_multi_host(path):
     if path[: 10] == "api/walrus":
         host = 'http://walrus:8082/'
 
-    print('PATHHH', path_with_params)
     # JS local dev server
     if path[:3] != "api":
         logging.warning('FRONTENDDD')


### PR DESCRIPTION
In the context of this feature, I created a dependent PR:

The reason for this is that in order to keep the text, and Image interfaces maintainable and decoupled enough, we first need to separated the file manager from the Annotation UI.

This will allow annotation_core or text_annotation_core to receive a single file and assume this is the single source of truth for the current working file. When changing a file or selecting a new one, we should only emit events to delegate that responsibility to media_core