### PR TITLE
(tiny) Fix report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ shared/settings/secrets.py
 .env
 .idea/
 git_ignore/*
+run_dev/*

--- a/default/methods/report/report_runner.py
+++ b/default/methods/report/report_runner.py
@@ -505,6 +505,7 @@ class Report_Runner():
 		return self.results
 
 	def serialize_stats(self, stats):
+		if stats is None: return None
 		result = {}
 		result = stats.copy()
 		if len(stats['labels']) > 0 and type(stats['labels'][0]) == datetime.datetime:


### PR DESCRIPTION
Context that `stats.copy()` throws exception if stats is None