### PR TITLE
fix: Labelbox API now expect string in the external ID's

### DIFF
--- a/walrus/methods/connectors/labelbox_connector.py
+++ b/walrus/methods/connectors/labelbox_connector.py
@@ -704,7 +704,7 @@ class LabelBoxSyncManager:
             'query': query,
             'data': data
         })
-        print('AAAAAAAA', result)
+
         created_datarows = result['result']['datasets'][0]['dataRows']
 
         for datarow in created_datarows:

--- a/walrus/methods/connectors/labelbox_connector.py
+++ b/walrus/methods/connectors/labelbox_connector.py
@@ -665,7 +665,7 @@ class LabelBoxSyncManager:
                     }
                     # Cache in memory the file for updating labelbox ID's later
                     diffgram_files_by_id[diffgram_file.id] = diffgram_file
-                    external_ids.append(diffgram_file.id)
+                    external_ids.append(str(diffgram_file.id))
                     file_urls.append(data_row)
             if diffgram_file.type == "video":
                 if diffgram_file.video:
@@ -676,7 +676,7 @@ class LabelBoxSyncManager:
                         'external_id': diffgram_file.id
                     }
                     # Cache in memory the file for updating labelbox ID's later
-                    external_ids.append(diffgram_file.id)
+                    external_ids.append(str(diffgram_file.id))
                     diffgram_files_by_id[diffgram_file.id] = diffgram_file
                     file_urls.append(data_row)
         task = labelbox_dataset.create_data_rows(file_urls)
@@ -704,8 +704,9 @@ class LabelBoxSyncManager:
             'query': query,
             'data': data
         })
-
+        print('AAAAAAAA', result)
         created_datarows = result['result']['datasets'][0]['dataRows']
+
         for datarow in created_datarows:
             file = diffgram_files_by_id[int(datarow['externalId'])]
             file.default_external_map = ExternalMap.new(


### PR DESCRIPTION
Error context:

```
KeyError: 'result'
at add_files_to_labelbox_dataset (/app/methods/connectors/labelbox_connector.py:707)
at wrapped (/app/methods/connectors/labelbox_connector.py:249)
at send_all_files_in_task_template (/app/methods/connectors/labelbox_connector.py:792)
at wrapped (/app/methods/connectors/labelbox_connector.py:258)
at wrapped (/app/methods/connectors/labelbox_connector.py:249)
at execute_after_launch_strategy (/pp/methods/task/task_template/task_template_after_launch_strategies/labelbox_task_template_after_launch_strategy.py:242)
```

Issue is fixed on this PR, just needed to convert to string the external ID.




