### PR TITLE
bugfix: small fix on building url to append a slash when non-existent.

### DIFF
--- a/default/methods/user/account/account_verify.py
+++ b/default/methods/user/account/account_verify.py
@@ -115,7 +115,7 @@ def start_verify_via_email( session,
 		if not url_base.endswith('/'):
 			url_base += '/'
 
-		link_verify = settings.URL_BASE + "user/account/verify_email/"+ \
+		link_verify = url_base + "user/account/verify_email/"+ \
 						 auth.email_sent_to + \
 						 "/" + \
 						 auth.code


### PR DESCRIPTION
Context is that in some cases the base domain does not end with a slash and in some cases it does. So handling both cases here.