### PR TITLE
👻 Ghost Objects - Video Now 10x easier for new annotators 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-# Diffgram - Supervised Learning Data Platform
+# Diffgram - Open AI Data Platform
 
 ![](./github_assets/overview_diffgram_high_level.PNG)
 
@@ -49,7 +49,8 @@ python install.py
 # After install:  View the Web UI at: http://localhost:8085
 ```
 ### Other Useful Links For Starting Out
-- [Install Guide Compute Engine](https://medium.com/diffgram/tutorial-install-diffgram-in-google-compute-engine-134aae7d8a9b)
+- [Google GCP Install Guide Compute Engine](https://medium.com/diffgram/tutorial-install-diffgram-in-google-compute-engine-134aae7d8a9b)
+- [Azure AKS Kubernetes Install Guide](https://medium.com/diffgram/tutorial-installing-diffgram-on-azure-aks-b9447685e271)
 - [Updating Existing Installation](https://diffgram.readme.io/docs/updating-an-existing-installation)
 - [Development Install Docs](https://diffgram.readme.io/docs/quickstart-installation-of-diffgram-open-core)
 - [Production Install Docs](https://diffgram.readme.io/docs/open-installation-production)
@@ -94,7 +95,7 @@ Security issues: Do not create a public issue. Email security@diffgram.com with 
 * [Streaming](https://diffgram.com/streaming)
 * [Security and Privacy](https://diffgram.com/secure)
 * [Speed Up with AI Userscripts](https://diffgram.readme.io/docs/userscript-examples)
-* Open Core (This Repo!)
+* Open Source (This Repo!)
 * [Integrations](#integrations)
 
 # Speed Ups & AI
@@ -110,7 +111,7 @@ Latest AI + More
 * [Diffgram API](https://diffgram.readme.io/reference) Any language
 * [AWS - Amazon Storage](https://diffgram.readme.io/docs/amazon-web-services-connection-requirements)
 * [GCP Google Storage](https://diffgram.readme.io/docs/google-connection-requirements)
-* Azure - (Select during install - not available as separate connection yet)
+* Azure - Now available
 * [Scale AI](https://diffgram.readme.io/docs/scale-ai)
 * [Datasaur](https://diffgram.readme.io/docs/datasaur-integration)
 * [Labelbox](https://diffgram.readme.io/docs/labelbox-integration)

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -2857,13 +2857,11 @@ export default Vue.extend( {
       if (!this.sequence_list_local_copy) { return }
 
       let keyframes_to_sequences = this.build_keyframes_to_sequences_dict()
-      console.log(keyframes_to_sequences)
+      //console.log(keyframes_to_sequences)
 
       this.populate_ghost_list_with_most_recent_instances_from_keyframes(keyframes_to_sequences)
 
       this.may_fire_user_ghost_canvas_available_alert()
-
-      console.log(this.ghost_instance_list)
 
     },
 
@@ -2924,7 +2922,7 @@ export default Vue.extend( {
       for (const [keyframe, sequence_numbers] of Object.entries(keyframes_to_sequences)){
 
         let instance_list = this.instance_buffer_dict[keyframe];
-        console.log(keyframe, instance_list)
+        //console.log(keyframe, instance_list)
         if (!instance_list) { continue }
 
         for (let instance of instance_list) {

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -4007,7 +4007,7 @@ export default Vue.extend( {
     },
 
   ghost_may_promote_instance_to_actual: function () {
-    if (this.ghost_instance_hover_index) {
+    if (this.ghost_instance_hover_index != undefined) { // may be 0!
       this.instance_hover_index = this.ghost_instance_hover_index
       this.instance_hover_type = this.ghost_instance_hover_type
       this.ghost_promote_instance_to_actual(this.ghost_instance_hover_index)

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -350,6 +350,15 @@
           >
 
           </autoborder_avaiable_alert>
+
+          <ghost_canvas_available_alert
+            :x_position="canvas_alert_x"
+            :y_position="canvas_alert_y"
+            ref="ghost_canvas_available_alert"
+          >
+
+          </ghost_canvas_available_alert>
+
           <canvas
             data-cy="canvas"
             ref="canvas"
@@ -719,6 +728,7 @@ import axios from 'axios';
 import Vue from 'vue';
 import instance_detail_list_view from './instance_detail_list_view'
 import autoborder_avaiable_alert from './autoborder_avaiable_alert'
+import ghost_canvas_available_alert from './ghost_canvas_available_alert'
 import canvas_current_instance from '../vue_canvas/current_instance'
 import canvas_instance_list from '../vue_canvas/instance_list'
 import ghost_instance_list_canvas from '../vue_canvas/ghost_instance_list'
@@ -784,7 +794,8 @@ export default Vue.extend( {
       task_status_icons,
       context_menu,
       userscript,
-      toolbar
+      toolbar,
+      ghost_canvas_available_alert
     },
     props: {
       'project_string_id': {
@@ -2850,8 +2861,21 @@ export default Vue.extend( {
 
       this.populate_ghost_list_with_most_recent_instances_from_keyframes(keyframes_to_sequences)
 
+      this.may_fire_user_ghost_canvas_available_alert()
+
       console.log(this.ghost_instance_list)
 
+    },
+
+    may_fire_user_ghost_canvas_available_alert: function () {
+      if (this.$store.state.user.settings.hide_ghost_canvas_available_alert == true) {
+        return
+      }
+      if (this.ghost_instance_list.length >= 1) {
+        this.canvas_alert_x = this.mouse_position.x
+        this.canvas_alert_y = this.mouse_position.y
+        this.$refs.ghost_canvas_available_alert.show_alert();
+      }
     },
     build_keyframes_to_sequences_dict: function () {
       /*

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -2942,6 +2942,7 @@ export default Vue.extend( {
     },
 
     duplicate_instance_into_ghost_list: function (instance){
+      if (!instance) { return }
       let instance_clipboard = this.duplicate_instance(instance);
       instance_clipboard.id = null
       instance_clipboard.created_time = null  //

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -4061,6 +4061,7 @@ export default Vue.extend( {
   },
 
   ghost_promote_instance_to_actual: function (ghost_index) {
+      this.has_changed = true  // otherwise user click event won't trigger change detection 
 
       let instance = this.ghost_instance_list[ghost_index]
       this.add_instance_to_frame_buffer(instance, this.current_frame)    // this handles the creation_ref_id stuff too

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -2834,14 +2834,6 @@ export default Vue.extend( {
       this.seeking = seeking
     },
 
-    ghost_promote_instance_to_actual: function (instance) {
-
-      this.add_instance_to_frame_buffer(instance, this.current_frame_number)    // this handles the creation_ref_id stuff too
-
-      // TODO remove from ghost list
-      // this.ghost_instance_list
-    },
-
     ghost_refresh_instances: function () {
       this.ghost_instance_list = []
       if (!this.sequence_list_local_copy) { return }
@@ -3027,7 +3019,6 @@ export default Vue.extend( {
 
     ghost_instance_hover_update: function (index: Number, type : String) {
       //if (this.lock_point_hover_change == true) {return}
-      console.log(index, type)
       if (index != null) {
         this.ghost_instance_hover_index = parseInt(index)
         this.ghost_instance_hover_type = type   // ie polygon, box, etc.
@@ -4002,6 +3993,28 @@ export default Vue.extend( {
     this.instance_list.splice(this.instance_hover_index, 1, instance);
     return true
   },
+
+  ghost_clear_hover_index: function () {
+    this.ghost_instance_hover_index = null   
+    this.ghost_instance_hover_type = null
+  },
+
+  ghost_promote_instance_to_actual: function (ghost_index) {
+
+      let instance = this.ghost_instance_list[ghost_index]
+      this.add_instance_to_frame_buffer(instance, this.current_frame)    // this handles the creation_ref_id stuff too
+      this.ghost_instance_list.splice(ghost_index, 1)   // remove from ghost list
+    },
+
+  ghost_may_promote_instance_to_actual: function () {
+    if (this.ghost_instance_hover_index) {
+      this.instance_hover_index = this.ghost_instance_hover_index
+      this.instance_hover_type = this.ghost_instance_hover_type
+      this.ghost_promote_instance_to_actual(this.ghost_instance_hover_index)
+      this.ghost_clear_hover_index()
+    }
+  },
+
   move_something: function (event) {
 
       /*
@@ -5186,6 +5199,9 @@ export default Vue.extend( {
       if (this.mouse_down_limits(event) == false) {
         return
       }
+
+      this.ghost_may_promote_instance_to_actual()
+
       // For new refactored instance types (eventually all should be here)
       const mouse_down_interaction = this.generate_event_interactions(event);
       if(mouse_down_interaction){

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -4046,9 +4046,18 @@ export default Vue.extend( {
     return true
   },
 
+  ghost_clear_for_file_change_context: function()  {
+    this.ghost_clear_hover_index()
+    this.ghost_clear_list()
+  },
+
   ghost_clear_hover_index: function () {
     this.ghost_instance_hover_index = null   
     this.ghost_instance_hover_type = null
+  },
+
+  ghost_clear_list: function () {
+    this.ghost_instance_list = []
   },
 
   ghost_promote_instance_to_actual: function (ghost_index) {
@@ -4060,7 +4069,6 @@ export default Vue.extend( {
 
   ghost_may_promote_instance_to_actual: function () {
     if (this.label_settings.show_ghost_instances == false) { return }
-
     if (this.ghost_instance_hover_index != undefined) { // may be 0!
       this.instance_hover_index = this.ghost_instance_hover_index
       this.instance_hover_type = this.ghost_instance_hover_type
@@ -5661,6 +5669,7 @@ export default Vue.extend( {
       await this.prepare_canvas_for_new_file();
 
       this.full_file_loading = false;
+      this.ghost_clear_for_file_change_context()
 
     },
     on_change_current_file: async function () {
@@ -5689,6 +5698,7 @@ export default Vue.extend( {
       await this.prepare_canvas_for_new_file();
 
       this.full_file_loading = false;
+      this.ghost_clear_for_file_change_context()
     },
 
     refresh_attributes_from_current_file: async function (file) {

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -604,6 +604,7 @@
           :force_new_sequence_request="force_new_sequence_request"
           :label_file_list="label_list"
           :request_clear_sequence_list_cache="request_clear_sequence_list_cache"
+          :label_settings="label_settings"
           ref="sequence_list"
           >
         </v_sequence_list>
@@ -1050,6 +1051,7 @@ export default Vue.extend( {
         filter_contrast: 100, // Percentage. A value of 0% will create a drawing that is completely black. A value of 100% leaves the drawing unchanged.
         filter_grayscale: 0, //  A value of 100% is completely gray-scale. A value of 0% leaves the drawing unchanged.
         instance_buffer_size: 60,
+        on_instance_creation_advance_sequence: true
       },
 
       annotations_loading: false,

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -5794,6 +5794,10 @@ export default Vue.extend( {
         this.force_new_sequence_request = Date.now()
       }
 
+      if (event.key === "g") {
+        this.label_settings.show_ghost_instances = !this.label_settings.show_ghost_instances
+      }
+
       if (event.keyCode === 83) { // save
         this.save();
       }

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -426,6 +426,7 @@
 
             <ghost_instance_list_canvas
                 :ord="4"
+                :show="label_settings.show_ghost_instances"
                 :instance_list="ghost_instance_list"
                 :vertex_size="label_settings.vertex_size"
                 :video_mode="video_mode"
@@ -1008,6 +1009,7 @@ export default Vue.extend( {
       loading: false,
 
       label_settings: {
+        show_ghost_instances: true,
         show_text: true,
         show_label_text: true,
         show_attribute_text: true,
@@ -4007,6 +4009,8 @@ export default Vue.extend( {
     },
 
   ghost_may_promote_instance_to_actual: function () {
+    if (this.label_settings.show_ghost_instances == false) { return }
+
     if (this.ghost_instance_hover_index != undefined) { // may be 0!
       this.instance_hover_index = this.ghost_instance_hover_index
       this.instance_hover_type = this.ghost_instance_hover_type

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -221,7 +221,7 @@
 
       </instance_history_sidepanel>
       <create_issue_panel :project_string_id="project_string_id ? project_string_id : this.$store.state.project.current.project_string_id"
-                          v-show="show_issue_panel && !current_issue"
+                          v-show="show_issue_panel == true && !current_issue"
                           :instance_list="instance_list"
                           :task="task"
                           :file="file"
@@ -233,7 +233,7 @@
       ></create_issue_panel>
       <view_edit_issue_panel
           v-if="!loading"
-          v-show="show_issue_panel && current_issue"
+          v-show="show_issue_panel == true && current_issue"
           :project_string_id="project_string_id ? project_string_id : this.$store.state.project.current.project_string_id"
           :task="task"
           :instance_list="instance_list"
@@ -883,6 +883,17 @@ export default Vue.extend( {
 
         this.clear_selected()
 
+      },
+      show_issue_panel: function () {
+        if (this.show_issue_panel == true) {
+          this.label_settings.show_ghost_instances = false
+          this.label_settings.ghost_instances_closed_by_open_view_edit_panel = true
+        } else {
+          if (this.label_settings.ghost_instances_closed_by_open_view_edit_panel == true) {
+            this.label_settings.show_ghost_instances = true
+            this.label_settings.ghost_instances_closed_by_open_view_edit_panel = false
+          }
+        }
       }
    },
 
@@ -1038,7 +1049,8 @@ export default Vue.extend( {
         canvas_scale_global_is_automatic: true,
         canvas_scale_global_setting: 0.5,
         left_nav_width: 450,
-        on_instance_creation_advance_sequence: true
+        on_instance_creation_advance_sequence: true,
+        ghost_instances_closed_by_open_view_edit_panel: false
       },
 
       annotations_loading: false,

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -2408,6 +2408,11 @@ export default Vue.extend( {
          return
       }
 
+      if (update.mode == 'pause_object'){
+        instance.pause_object = true
+        console.log(instance.pause_object)
+      }
+
       // instance update
       if (update.mode == "update_label") {
         // not 100% sure if we need both here
@@ -2877,6 +2882,19 @@ export default Vue.extend( {
       return keyframes_to_sequences
     },
 
+    ghost_determine_if_no_conflicts_with_existing: function (ghost_instance) {
+      for (let existing_instance of this.instance_list){
+        if (existing_instance.sequence_id == ghost_instance.sequence_id) {
+          return false
+        }
+        if (existing_instance.label_file_id == ghost_instance.label_file_id &&
+            existing_instance.number == ghost_instance.number) {
+          return false
+        }
+      }
+      return true
+    },
+
     populate_ghost_list_with_most_recent_instances_from_keyframes: function(keyframes_to_sequences){
 
       for (const [keyframe, sequence_numbers] of Object.entries(keyframes_to_sequences)){
@@ -2887,10 +2905,16 @@ export default Vue.extend( {
 
         for (let instance of instance_list) {
           if (sequence_numbers.includes(instance.number)) {
-            console.log(instance.sequence_numbers)
+
+            // if it's the last object then we don't show ghost
+            if (instance.pause_object == true) { continue }
+
+            if (this.ghost_determine_if_no_conflicts_with_existing(instance) == false) {
+              continue
+            }
+
             this.duplicate_instance_into_ghost_list(instance)
           }
-
         }
       }
     },

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -1035,6 +1035,9 @@ export default Vue.extend( {
         filter_contrast: 100, // Percentage. A value of 0% will create a drawing that is completely black. A value of 100% leaves the drawing unchanged.
         filter_grayscale: 0, //  A value of 100% is completely gray-scale. A value of 0% leaves the drawing unchanged.
         instance_buffer_size: 60,
+        canvas_scale_global_is_automatic: true,
+        canvas_scale_global_setting: 0.5,
+        left_nav_width: 450,
         on_instance_creation_advance_sequence: true
       },
 

--- a/frontend/src/components/annotation/ghost_canvas_available_alert.vue
+++ b/frontend/src/components/annotation/ghost_canvas_available_alert.vue
@@ -22,21 +22,21 @@
         Instances that may be useful but are not yet confirmed by you.
         <br> <br>
 
-        <h3> Identify a Ghost by the Dashed Lines.</h3>
+        <h3> Identify a Ghost by the Dashed Lines</h3>
         All ghost objects are showing as dashed lines instead of the normal solid lines.
 
         <br><br>
-        <h3> Give a Ghost a New Life:</h3>
+        <h3> Give a Ghost a New Life</h3>
         Click or drag the ghost object to promote it to a normal annotation.
         After, Right click "Pause Object" to prevent future ghost frames for that object from showing.
         <br> <br>
 
-        <h3> Safely Ignore Irrelevant Ghosts </h3>
+        <h3> Safely Ignore Irrelevant Ghosts</h3>
         If a ghost object is not relevant, you can safely ignore it. Ghost objects
         are never saved unless you expressly click them or drag them.
         <br> <br>
-        <h3> Banish All Ghosts: </h3>
-        To hide all ghosts press "G" or go to More / Settings / Show Ghost Instances
+        <h3> Banish All Ghosts</h3>
+        To hide/show all ghosts press <kbd>G</kbd> or go to More / Settings / Show Ghost Instances
 
       </v-card-text>
       <v-card-actions>

--- a/frontend/src/components/annotation/ghost_canvas_available_alert.vue
+++ b/frontend/src/components/annotation/ghost_canvas_available_alert.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-menu
+    top
+    v-model="show_menu"
+    max-width="500"
+    :position-x="x_position"
+    :position-y="y_position"
+    absolute
+    offset-y
+    :close-on-click="false"
+    :close-on-content-click="false"
+  >
+    <v-card class="pa-0">
+      <v-card-title>
+        What are Ghost Objects? 👻
+      </v-card-title>
+      <v-card-text>
+        <!--
+        <img src="" width="200px"
+             height="220px"> -->
+        <h3> Ghost Objects are "Proposals" </h3>
+        Instances that may be useful but are not yet confirmed by you.
+        <br> <br>
+
+        <h3> Identify a Ghost by the Dashed Lines.</h3>
+        All ghost objects are showing as dashed lines instead of the normal solid lines.
+
+        <br><br>
+        <h3> Give a Ghost a New Life:</h3>
+        Click or drag the ghost object to promote it to a normal annotation.
+        After, Right click "Pause Object" to prevent future ghost frames for that object from showing.
+        <br> <br>
+
+        <h3> Safely Ignore Irrelevant Ghosts </h3>
+        If a ghost object is not relevant, you can safely ignore it. Ghost objects
+        are never saved unless you expressly click them or drag them.
+        <br> <br>
+        <h3> Banish All Ghosts: </h3>
+        To hide all ghosts press "G" or go to More / Settings / Show Ghost Instances
+
+      </v-card-text>
+      <v-card-actions>
+        <v-btn @click="show_menu = false" small color="primary">Ok</v-btn>
+        <v-btn @click="show_menu = false,
+               $store.commit('set_user_setting', ['hide_ghost_canvas_available_alert', true])
+               "
+               small
+               color="secondary">Don't Show Again</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+</template>
+
+<script lang="ts">
+
+  import axios from 'axios';
+
+  import Vue from "vue";
+
+  export default Vue.extend({
+      name: 'ghost_canvas_available_alert',
+      props: {
+        'x_position': {
+          default: undefined
+        },
+        'y_position': {
+          default: undefined
+        }
+      },
+      data() {
+        return {
+          show_menu: false
+        }
+      },
+      methods: {
+        show_alert: function () {
+          this.show_menu = true;
+        }
+      }
+    }
+  )
+
+</script>

--- a/frontend/src/components/annotation/hotkeys.vue
+++ b/frontend/src/components/annotation/hotkeys.vue
@@ -11,6 +11,7 @@
   <p> <kbd>Esc</kbd> (Twice) Cancel current drawing and return to draw mode </p>
 
   <p> <kbd>W</kbd> Toggle Label Menu </p>
+  <p> <kbd>G</kbd> Toggle Ghost Instances </p>
   <p> <kbd>1 - 9</kbd> Change label </p>
 
   <p> <kbd>Shift</kbd> + <kbd>←</kbd>,<kbd>→</kbd> Previous or Next File </p>

--- a/frontend/src/components/annotation/hotkeys.vue
+++ b/frontend/src/components/annotation/hotkeys.vue
@@ -1,0 +1,83 @@
+<template>
+<div v-cloak>
+<v-layout column>
+
+  <h2> General </h2>
+
+  Right click an instance to bring up context menu.
+
+  <p> <kbd>Esc</kbd> Toggle draw and edit mode </p>
+
+  <p> <kbd>Esc</kbd> (Twice) Cancel current drawing and return to draw mode </p>
+
+  <p> <kbd>W</kbd> Toggle Label Menu </p>
+  <p> <kbd>1 - 9</kbd> Change label </p>
+
+  <p> <kbd>Shift</kbd> + <kbd>←</kbd>,<kbd>→</kbd> Previous or Next File </p>
+  <p> <kbd>Ctrl</kbd> + <kbd>c</kbd> Copy Selected Instance </p>
+  <p> <kbd>Ctrl</kbd> + <kbd>v</kbd> Paste Selected Instance </p>
+
+  <p> <kbd>C</kbd> Complete. Save, Mark as Complete, Go to Next.</p>
+
+  <h2> Video </h2>
+
+  <p> <kbd>Spacebar</kbd> Play/Pause Video </p>
+
+  <p> <kbd>←</kbd>,<kbd>→</kbd> or <kbd>A</kbd>, <kbd>D</kbd> Previous or Next Frame</p>
+
+  <p> <kbd>F</kbd> New Sequence </p>
+  <p> <kbd>Shift</kbd> + <kbd>n</kbd> Jump to Next Instance </p>
+  <h2> Image / Frame </h2>
+  <p> <kbd>S</kbd> Save </p>
+
+  <p> <kbd>Delete</kbd> Deletes selected instances </p>
+
+  <p> <kbd>Mouse wheel</kbd> Zoom / pan </p>
+
+  <p> <kbd>Ctrl</kbd> Pan Only </p>
+
+  <h2> Polygons </h2>
+  <p> <kbd>Enter</kbd> Complete polygon (Or click first point again)  </p>
+
+  <p> <b>Hold </b> <kbd>Shift</kbd>
+    🔥 Turbo mode, auto places point as you move mouse.
+    <br />
+    Can switch between this mode and normal as needed by
+    releasing shift.</p>
+
+</v-layout>
+
+</div>
+</template>
+
+<script lang="ts">
+
+import Vue from "vue";
+
+export default Vue.extend( {
+
+  name: 'hotkeys',
+  components: {
+  },
+  props: {
+   
+  },
+  data() {
+    return {
+
+    }
+  },
+  watch: {
+
+  },
+  mounted() {
+  },
+  computed: {
+
+  },
+  methods: {
+
+  }
+}
+
+) </script>

--- a/frontend/src/components/annotation/media_core.vue
+++ b/frontend/src/components/annotation/media_core.vue
@@ -310,7 +310,30 @@
                 </template>
               </button_with_menu>
 
+              <!-- Pending removal -->
+              <!--
+              <div v-if="$store.state.user.current.api
+               && $store.state.user.current.api.api_actions">
 
+                <tooltip_button
+                  @click="inference_selected()"
+                  icon="mdi-rocket"
+                  tooltip_message="Inference"
+                  color="red"
+                  v-if="['annotation'].includes(file_view_mode)"
+                  :disabled="inference_selected_loading
+                   || selected.length == 0
+                   || select_from_metadata"
+                  :icon_style="true"
+                  :bottom="true"
+                >
+                </tooltip_button>
+
+                <v_error_multiple :error="error_inference">
+                </v_error_multiple>
+
+              </div>
+              -->
 
             <v-divider
               vertical
@@ -427,29 +450,6 @@
 
 
 
-
-
-            <div v-if="$store.state.user.current.api
-             && $store.state.user.current.api.api_actions">
-
-              <tooltip_button
-                @click="inference_selected()"
-                icon="mdi-rocket"
-                tooltip_message="Inference"
-                color="red"
-                v-if="['annotation'].includes(file_view_mode)"
-                :disabled="inference_selected_loading
-                 || selected.length == 0
-                 || select_from_metadata"
-                :icon_style="true"
-                :bottom="true"
-              >
-              </tooltip_button>
-
-              <v_error_multiple :error="error_inference">
-              </v_error_multiple>
-
-            </div>
 
             <!-- Deprecated ? -->
             <!--

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -693,6 +693,16 @@
                         v-model="label_settings_local.instance_buffer_size">
               </v-slider>
 
+              <tooltip_button
+                tooltip_message="Restore All User Settings & Prompts"
+                @click="$store.commit('restore_default_user_settings')"
+                color="primary"
+                icon="mdi-refresh"
+                :icon_style="true"
+                :bottom="true"
+              >
+              </tooltip_button>
+
             </v-layout>
           </template>
 

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -704,6 +704,11 @@
               </v-slider>
 
 
+              <v-checkbox label="On Instance Creation: Advance Sequence Number"
+                          data-cy="on_instance_creation_advance_sequence"
+                          v-model="label_settings_local.on_instance_creation_advance_sequence">
+              </v-checkbox>
+
               <!-- Note backend enforces hard
                 limit on this (ie max 1000) , so need to update
                 there too if required-->

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -382,7 +382,7 @@
 
   </button_with_menu>
 
-    <button_with_menu
+  <button_with_menu
     tooltip_message="Hotkeys"
     v-if="view_only_mode != true"
     color="primary"
@@ -391,52 +391,7 @@
         >
 
     <template slot="content">
-      <v-layout column>
-
-        <h2> General </h2>
-
-        Right click an instance to bring up context menu.
-
-        <p> <kbd>Esc</kbd> Toggle draw and edit mode </p>
-
-        <p> <kbd>Esc</kbd> (Twice) Cancel current drawing and return to draw mode </p>
-
-        <p> <kbd>W</kbd> Toggle Label Menu </p>
-        <p> <kbd>1 - 9</kbd> Change label </p>
-
-        <p> <kbd>Shift</kbd> + <kbd>←</kbd>,<kbd>→</kbd> Previous or Next File </p>
-        <p> <kbd>Ctrl</kbd> + <kbd>c</kbd> Copy Selected Instance </p>
-        <p> <kbd>Ctrl</kbd> + <kbd>v</kbd> Paste Selected Instance </p>
-
-        <p> <kbd>C</kbd> Complete. Save, Mark as Complete, Go to Next.</p>
-
-        <h2> Video </h2>
-
-        <p> <kbd>Spacebar</kbd> Play/Pause Video </p>
-
-        <p> <kbd>←</kbd>,<kbd>→</kbd> or <kbd>A</kbd>, <kbd>D</kbd> Previous or Next Frame</p>
-
-        <p> <kbd>F</kbd> New Sequence </p>
-        <p> <kbd>Shift</kbd> + <kbd>n</kbd> Jump to Next Instance </p>
-        <h2> Image / Frame </h2>
-        <p> <kbd>S</kbd> Save </p>
-
-        <p> <kbd>Delete</kbd> Deletes selected instances </p>
-
-        <p> <kbd>Mouse wheel</kbd> Zoom / pan </p>
-
-        <p> <kbd>Ctrl</kbd> Pan Only </p>
-
-        <h2> Polygons </h2>
-        <p> <kbd>Enter</kbd> Complete polygon (Or click first point again)  </p>
-
-        <p> <b>Hold </b> <kbd>Shift</kbd>
-          🔥 Turbo mode, auto places point as you move mouse.
-          <br />
-          Can switch between this mode and normal as needed by
-          releasing shift.</p>
-
-      </v-layout>
+      <hotkeys></hotkeys>
     </template>
 
   </button_with_menu>
@@ -797,6 +752,7 @@ import file_meta_data_card from './file_meta_data_card'
 import task_relations_card from './task_relations_card'
 import file_relations_card from './file_relations_card'
 import task_meta_data_card from './task_meta_data_card'
+import hotkeys from './hotkeys'
 
 export default Vue.extend( {
 
@@ -807,6 +763,7 @@ export default Vue.extend( {
     file_relations_card,
     task_meta_data_card,
     task_relations_card,
+    hotkeys
   },
   props: {
     'project_string_id': {

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -717,6 +717,10 @@
                         v-model="label_settings_local.spatial_line_size">
               </v-slider>
 
+              <v-checkbox label="Show Ghost Instances"
+                          data-cy="show_ghost_instances"
+                          v-model="label_settings_local.show_ghost_instances">
+              </v-checkbox>
 
               <v-checkbox label="On Instance Creation: Advance Sequence Number"
                           data-cy="on_instance_creation_advance_sequence"

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -103,7 +103,7 @@
       vertical
     ></v-divider>
 
-    <div class="pt-3 pl-1 pr-2">
+    <div class="pt-3 pl-2 pr-2">
 
       <v-tooltip bottom
                   color="info"
@@ -130,8 +130,8 @@
       vertical
     ></v-divider>
 
-    <v-flex xs2>
-      <div class="pl-3 pr-3 pt-4">
+    <div style="width: 310px">
+      <div class="pl-2 pr-3 pt-4">
         <label_select_annotation
             :project_string_id="project_string_id"
             :label_file_list="label_list"
@@ -144,7 +144,7 @@
         >
         </label_select_annotation>
       </div>
-    </v-flex>
+    </div>
 
     <!-- TODO @get_next_instance="request_next_instance" -->
 

--- a/frontend/src/components/context_menu/context_menu.vue
+++ b/frontend/src/components/context_menu/context_menu.vue
@@ -204,6 +204,14 @@
         this.locked_mouse_position = {...this.mouse_position};
       },
 
+      pause_object(event) {
+        let instance_update = {
+          index: this.instance_hover_index_locked,
+          mode: "pause_object"
+        }
+        this.emit_update_and_hide_instance(instance_update)
+      },
+
       change_sequence(event) {
         let instance_update = {
           index: this.instance_hover_index_locked,
@@ -309,6 +317,7 @@
       <div v-if="video_mode == true">
         <sequence_select
           v-if="instance_hover_index_locked != undefined"
+          label="Change Sequence"
           class="pt-2 pl-4 pr-4"
           :sequence_list="sequence_list"
           :select_this_id="selected_instance.sequence_id"
@@ -318,11 +327,34 @@
             won't be part of the event detection for clicking,
             and the hover index will become None-->
         </sequence_select>
+
+        <v-divider></v-divider>
       </div>
 
       <v-list-item
         dense
-        v-if="!draw_mode && video_mode && (instance_hover_index_locked != null || instance_clipboard)"
+        v-if="video_mode
+              && instance_hover_index_locked != null"
+        @click="pause_object()"
+      >
+
+        <v-list-item-icon>
+          <tooltip_icon
+            tooltip_message="Pause Object"
+            icon="mdi-pause-octagon"
+            color="primary"
+          />
+        </v-list-item-icon>
+        <v-list-item-content>
+          <v-list-item-title class="pr-4">
+            Pause Object
+          </v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
+
+      <v-list-item
+        dense
+        v-if="video_mode && (instance_hover_index_locked != null || instance_clipboard)"
         @click="display_paste_menu"
       >
 
@@ -370,6 +402,8 @@
           </v-card-actions>
         </v-card>
       </v-menu>
+
+      <v-divider></v-divider>
 
       <v-list-item
         link

--- a/frontend/src/components/discussions/create_issue_panel.vue
+++ b/frontend/src/components/discussions/create_issue_panel.vue
@@ -336,8 +336,8 @@
             marker_frame_number: this.$props.frame_number,
             marker_type: 'point',
             marker_data: {
-              x: this.$props.mouse_position.x,
-              y: this.$props.mouse_position.y,
+              x: this.$props.mouse_position ? this.$props.mouse_position.x : undefined,
+              y: this.$props.mouse_position ? this.$props.mouse_position.y : undefined,
             },
             description: this.editor.getHTML(),
             attached_elements: this.attached_elements

--- a/frontend/src/components/label/label_select_annotation.vue
+++ b/frontend/src/components/label/label_select_annotation.vue
@@ -216,13 +216,13 @@
       methods: {
 
         label_name_truncated: function(name) {
-          let max_size = 11
-          let default_selector_size = 180
+          let max_size = 23
+          let default_selector_size = 290 // feels pretty brittle
           if (document.getElementById('label_select_annotation').offsetWidth
                 < default_selector_size) {
             max_size = 5
           }
-          if (name.length >= max_size) {
+          if (name.length > max_size) {
             return name.slice(0, max_size) + '...'
           } else {
             return name

--- a/frontend/src/components/label/label_select_annotation.vue
+++ b/frontend/src/components/label/label_select_annotation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-cloak >
+  <div v-cloak  id="label_select_annotation">
     <v-layout >
 
 
@@ -82,19 +82,18 @@
 
         <template v-slot:selection="data">
 
-          <v-chip color="white">
-            <v-icon
-              :style="style_color(data.item.colour.hex)">
-              flag
-            </v-icon>
+          <v-icon
+            left
+            :style="style_color(data.item.colour.hex)">
+            flag
+          </v-icon>
 
-            <v-icon v-if="data.item.label.default_sequences_to_single_frame"
-                    color="black">
-              mdi-flag-checkered
-            </v-icon>
+          <v-icon v-if="data.item.label.default_sequences_to_single_frame"
+                  color="black">
+            mdi-flag-checkered
+          </v-icon>
 
-            {{ data.item.label.name}}
-          </v-chip>
+          {{ label_name_truncated(data.item.label.name) }}
 
         </template>
 
@@ -215,6 +214,20 @@
       },
 
       methods: {
+
+        label_name_truncated: function(name) {
+          let max_size = 11
+          let default_selector_size = 180
+          if (document.getElementById('label_select_annotation').offsetWidth
+                < default_selector_size) {
+            max_size = 5
+          }
+          if (name.length >= max_size) {
+            return name.slice(0, max_size) + '...'
+          } else {
+            return name
+          }
+        },
 
         toggle_label_visible(label) {
           if (typeof label.is_visible == "undefined") {

--- a/frontend/src/components/video/sequence_list.vue
+++ b/frontend/src/components/video/sequence_list.vue
@@ -422,7 +422,8 @@ export default Vue.extend( {
     },
     'request_clear_sequence_list_cache': {
       default: null
-    }
+    },
+    'label_settings': {}
 
   },
   data() {
@@ -547,6 +548,7 @@ export default Vue.extend( {
         return  // see comment above.
       }
 
+
       // set from parent
       this.current_sequence = new_sequence
 
@@ -558,11 +560,15 @@ export default Vue.extend( {
       if (index !== -1) {
        this.sequence_list.splice(index, 1, new_sequence)
       } else {
+        //creation context
+
         this.sequence_list.push(new_sequence)
 
         // prior we expected to this from the response
         // same concept.
         this.highest_sequence_number = new_sequence.number
+
+        this.may_auto_advance_sequence()
       }
 
       this.emit_current_sequence()
@@ -954,6 +960,12 @@ export default Vue.extend( {
 
       this.change_current_sequence(this.sequence_list[0])
 
+    },
+
+    may_auto_advance_sequence: function () {
+      if(this.$props.label_settings.on_instance_creation_advance_sequence == true){
+        this.force_new_sequence()
+      }
     },
 
     update_sequence(sequence_id, payload, mode) {

--- a/frontend/src/components/vue_canvas/ghost_instance_list.vue
+++ b/frontend/src/components/vue_canvas/ghost_instance_list.vue
@@ -15,6 +15,10 @@
 
  export default Vue.extend({
       props: {
+        "show": {
+          default: true,
+          type: Boolean
+        },
         "ord": {},
         "mode": {
           default: 'default'
@@ -230,7 +234,7 @@
 
         // MAIN function
         draw: function (ctx, done) {
-          if (this.show_annotations != true) {
+          if (this.show != true) {
             done()
             return
           }

--- a/frontend/src/components/vue_canvas/ghost_instance_list.vue
+++ b/frontend/src/components/vue_canvas/ghost_instance_list.vue
@@ -1,0 +1,1358 @@
+<template>
+</template>
+<script lang="ts">
+
+  /*
+  Draw existing instances
+  */
+
+  import Vue from 'vue'
+  import { cuboid } from './cuboid.js'
+  import { ellipse } from './ellipse.js'
+  Vue.prototype.$cuboid = new cuboid()
+  Vue.prototype.$ellipse = new ellipse()
+
+
+ export default Vue.extend({
+      props: {
+        "ord": {},
+        "mode": {
+          default: 'default'
+        },
+        "instance_list": {},
+        "is_actively_resizing": {
+          "default": false,
+          type: Boolean
+        },
+        "current_frame": undefined,
+        "is_actively_drawing": undefined,
+        "video_mode": undefined,
+        "current_instance": {},
+        "vertex_size": {
+          default: 0,
+          type: Number
+        },
+        "refresh": {},
+        "mouse_position" : {},
+        "draw_mode": {
+          default: true
+        },
+        "canvas_transform" : {},
+        "show_annotations": {},
+        "annotations_loading": {},
+        "render_mode": {},
+        "label_file_colour_map": {},
+        "label_settings": {
+          default: null
+        },
+        "instance_focused_index": {
+          default: null
+        },
+        // CAUTION  there is some type of performance issue with monitoring cuboid_hover_index
+        // when we are also emiting an event
+        "hidden_label_id_list": {},
+        "emit_instance_hover": {
+          type: Boolean,
+          default: true
+          // if True will run checks for hover, otherwise false to save computation
+        }
+      },
+
+      /* ord, order of drawing on canvas
+       * instance_list, list of instance objects (dictionaries),
+       * current_box, dictionary,
+       * refresh, integer / hack for forcing reactive property change
+       * mouse_position, dictionary, x, y
+       * draw_mode, boolean
+       * canvas_transform, dictionary,
+       * show_annotations, boolean
+       * */
+      data() {
+        return {
+          colour: null,
+          circle_size: null,
+
+          count_instance_in_ctx_paths: 0,
+          cuboid_hovered_face: undefined,
+          prev_cuboid_hovered_face: undefined,
+          count_issues_in_ctx_paths: 0,
+
+          instance_hover_index: -1,
+          issue_hover_index: -1,
+          previous_instance_hover_index: -2,
+          previous_issue_hover_index: -2,
+
+          instance_hover_type: null,
+
+        }
+      },
+
+      methods: {
+
+        toInt: function (n) {
+          return Math.round(Number(n));   // TODO review if can use built in instead
+        },
+        get_instance_corner: function (instance){
+          if(instance.type === 'polygon'){
+            return {x: instance.points[0].x +10, y: instance.points[0].y + 10}
+          }
+          else if(instance.type === 'box'){
+            return {x: instance.x_max +10, y: instance.y_min + 20};
+          }
+          else if(instance.type === 'point'){
+            return {x: instance.points[0].x +10 , y: instance.points[0].y + 10}
+          }
+          else if(instance.type === 'line'){
+            return {x: instance.points[0].x +10, y: instance.points[0].y + 10}
+          }
+          else if(instance.type === 'ellipse'){
+            this.$ellipse.generate_ellipse_corners(instance, instance.width, instance.height)
+            return {x: instance.corners.top_right.x +10, y: instance.corners.top_right.y + 10}
+          }
+          else if(instance.type === 'curve'){
+            return {x: instance.cp.x +10, y: instance.cp.y + 10}
+          }
+          else if(instance.type === 'cuboid'){
+            return {x: instance.front_face.top_right.x +10, y: instance.front_face.top_right.y + 10}
+          }
+          else if(instance.type === 'keypoints'){
+            return {x: Math.max(...instance.nodes.map(n => n.x)), y: Math.min(...instance.nodes.map(n => n.y))}
+          }
+          else{
+            return undefined
+          }
+        },
+        isInText(ctx, region, x, y) {
+          // source:
+          //https://stackoverflow.com/questions/28706989/how-do-i-check-if-a-mouse-click-is-inside-a-rotated-text-on-the-html5-canvas-in
+
+          ctx.beginPath();
+          ctx.rect(region.x, region.y, region.w, region.h);
+
+          return ctx.isPointInPath(x, y);
+        },
+
+        is_mouse_in_path_issue: function (ctx, region, i, issue) {
+
+          // This is first because we always want user to know which one they are on
+          if (this.isInText(
+            ctx,
+            region,
+            this.mouse_position.raw.x,
+            this.mouse_position.raw.y)) {
+            if (this.issue_hover_index != i){
+              this.issue_hover_index = i
+
+            }
+            this.count_issues_in_ctx_paths += 1;
+          }
+
+        },
+        draw_alert_icon: function(ctx, x, y, i, issue){
+          if(!ctx.material_icons_loaded){
+            return
+          }
+          const old_color = ctx.fillStyle;
+          const old_font = ctx.font
+          ctx.font = '24px material-icons';
+          ctx.fillStyle = 'rgb(255,175,0)';
+          const text_icon = 'error';
+          const text = ctx.fillText(text_icon, this.toInt(x -20), this.toInt(y + 20));
+          ctx.fillStyle = old_color;
+          ctx.font = old_font;
+          const measures = ctx.measureText(text_icon);
+          // Create an invisible box for click events.
+          const region = {x: x - 24 , y: y - 24 , w: measures.width, h: 100};
+          this.is_mouse_in_path_issue(ctx, region, i, issue)
+        },
+        draw_issues_markers(ctx){
+          if(!this.$props.issues_list || this.$props.issues_list.length === 0){
+            return
+          }
+          this.$props.issues_list.forEach((issue, i) =>{
+            if(issue.status === 'closed'){return}
+            if(this.$props.video_mode && issue.marker_frame_number != this.$props.current_frame){
+              return
+            }
+
+            if(issue.marker_type === 'point' && issue.marker_data && issue.marker_data.x && issue.marker_data.y){
+              this.draw_alert_icon(ctx, issue.marker_data.x, issue.marker_data.y, i, issue);
+
+            }
+
+          })
+
+        },
+        draw_checkmark: function(instance, ctx){
+          if(!ctx.material_icons_loaded){
+            return
+          }
+          const old_color = ctx.fillStyle;
+          const old_font = ctx.font
+          ctx.font = '50px material-icons';
+          ctx.fillStyle = 'rgb(76,175,80)';
+          const point = this.get_instance_corner(instance)
+          ctx.fillText('check_mark', point.x, point.y);
+          ctx.fillStyle = old_color;
+          ctx.font = old_font;
+        },
+        draw_circle: function (x, y, ctx) {
+          /* March 31, 2020
+           *  In prior context we were calling this beside the regular line
+           * We are now trying to split that apart, and in this new context it
+           * may not be needed to do this reset with move to.
+           *
+           * Straight removing causes some artifacts so leaving it for now
+           */
+          ctx.arc(x, y, this.$props.vertex_size, 0, 2 * Math.PI);
+          ctx.moveTo(x, y) // reset
+        },
+
+        draw_circle_from_instance: function (instance, points, index, ctx) {
+
+          let x = points[index].x
+          let y = points[index].y
+
+          this.draw_circle(x, y, ctx)
+
+
+          if(points[index].hovered_while_drawing || instance.type === 'line'){
+            ctx.fill();
+            ctx.stroke();
+          }
+          else{
+            ctx.fill();
+            ctx.stroke();
+          }
+
+
+        },
+
+        // MAIN function
+        draw: function (ctx, done) {
+          if (this.show_annotations != true) {
+            done()
+            return
+          }
+
+          this.circle_size = 6 / this.canvas_transform['canvas_scale_combined']
+          let font_size = this.label_settings.font_size / this.canvas_transform['canvas_scale_combined']
+          ctx.font = font_size + "px Verdana";
+
+          this.count_issues_in_ctx_paths = 0   // reset
+          this.count_instance_in_ctx_paths = 0   // reset
+
+
+          // MAIN loop
+          for (var i in this.instance_list) {
+            this.draw_single_instance(ctx, i)
+          }
+
+          this.draw_issues_markers(ctx);
+
+          this.check_null_hover_case()    // careful, these should fire outside of main loop
+
+          this.emit_unified_hover_event()
+
+          done();
+
+        },
+
+
+        draw_single_instance_limits: function (instance, i) {
+
+
+          if (instance.type == 'tag') { // tag is whole image so nothing to draw.
+            return false
+          }
+
+          if (instance.soft_delete == true &&
+            this.label_settings.show_removed_instances != true) {
+            return false
+          }
+          // ie on first load from database .selected is undefined
+          if (instance.label_file == undefined) {
+            return false
+          }
+          if (this.instance_focused_index != undefined) {
+            if (this.instance_focused_index != i) {
+              return false
+            }
+          }
+          /* More work then storing the 'visible' state, but in the context
+           * of video this feels like stronger solution.
+           * Also argue that if it does find something it returns so it 'saves'
+           * the work of rendering, ie end result is probably less or equal work.
+           */
+          if (this.hidden_label_id_list.includes(instance.label_file_id) ) {
+            return false
+          }
+          // not quite right place, but need to handle returning if false
+          // This assumes we can get it from the 'master' list
+          // eg if the label template color is changed... etc.
+          if(this.label_file_colour_map){
+            this.colour = this.label_file_colour_map[instance.label_file_id]
+          }
+
+          if (this.colour == undefined) {
+            // Context is for Tasks, where we may have tasks that have instances that
+            // aren't present in Label Template (label_file_colour_map)
+            // at the moment this is less preferred because it's harder to update
+            // and requires storing more data per instance (vs just referencing a map)
+            if (instance.label_file &&
+                instance.label_file.colour) {
+              this.colour = instance.label_file.colour
+            } else {
+              // default fallback, just set it to black if
+              // defined color is not available
+              // otherwise risks not rendering it (which is prob worse)
+              this.colour = {}
+              this.colour.rgba = {
+                r: 255,
+                g: 255,
+                b: 255
+                }
+            }
+          }
+
+          return true
+        },
+
+        color_instance: function (instance, ctx) {
+          // TODO test this better, and also try to move other colors stuff here...
+          let strokeColor = undefined;
+          let fillColor = undefined;
+          let lineWidth = undefined;
+
+          // GHOST
+          ctx.setLineDash([3])
+
+          if(this.instance_select_for_issue){
+            // Case of selecting instance for issue creation
+            let r = 255
+            let g = 255
+            let b = 255
+            fillColor = "rgba(" + r + "," + g + "," + b + ", 1)";
+          }
+
+          // start Change type
+          if (instance.change_type != undefined) {
+            if (instance.change_type == "added") {
+              fillColor = "rgba(" + 0 + "," + 255 + "," + 0 + ", .25)";
+            }
+            else if (instance.change_type == "unchanged") {
+              fillColor = "rgba(" + 255 + "," + 255 + "," + 255 + ", .25)";
+            }
+            else if (instance.change_type == "deleted") {
+              fillColor = "rgba(" + 255 + "," + 0 + "," + 0 + ", .25)";
+            }
+          }
+          else {
+
+            let r = 255
+            let g = 255
+            let b = 255
+
+            // TODO can we move this somewhere else, ie as part of each component?
+            if (this.colour.rgba) {
+              r = this.colour.rgba.r
+              g = this.colour.rgba.g
+              b = this.colour.rgba.b
+            }
+
+            ctx.fillStyle = "rgba(" + r + "," + g + "," + b + ", 1)";
+          }
+
+          if (instance.change_type != undefined) {
+            if (instance.change_type == "added") {
+              strokeColor = "green";
+            }
+            else if (instance.change_type == "unchanged") {
+              strokeColor = "white";
+            }
+            else if (instance.change_type == "deleted") {
+              strokeColor = "red";
+            }
+          } else {
+
+            // good to have defaults here
+            // in case something wacky with if (exists) logic
+
+            if (this.mode == 'gold_standard') {
+              strokeColor = "#FFD700"
+            }
+            if (this.mode == 'default') {
+              strokeColor = this.colour.hex
+            }
+
+            lineWidth = '2'
+            if (instance.selected == true) {
+              strokeColor = "blue"
+            }
+            if(this.instance_select_for_issue && !this.view_issue_mode){
+              if(instance.selected){
+                strokeColor = "green"
+                lineWidth = '4';
+                this.draw_checkmark(instance, ctx);
+              }
+            }
+            else if(this.view_issue_mode){
+              if(instance.selected){
+                strokeColor = "green"
+                lineWidth = '4';
+                if(this.instance_select_for_issue){
+                  this.draw_checkmark(instance, ctx);
+                }
+              }
+            }
+          }
+          ctx.strokeStyle = strokeColor;
+          ctx.fillStyle = fillColor;
+          ctx.lineWidth = lineWidth;
+          return {
+            strokeColor: strokeColor,
+            fillColor: fillColor,
+            lineWidth: lineWidth
+          }
+        },
+
+        draw_single_instance: function (ctx, i) {
+          var instance = this.instance_list[i]
+
+          let result = this.draw_single_instance_limits(instance, i)
+          if (result == false)  {
+            return
+          }
+
+          // note this is a convience function for toher things that test falsyness
+          // may nto need it, but that's why it's here and not in limits
+          // (glancing at it looks like it's a return thing but it's not.)
+          if (instance.selected == undefined){
+            instance.selected = false
+          }
+
+          // TODO review this.colour isolation here
+
+
+          ctx.textAlign = "start";
+          // WIP , restrict movement to center point only
+          //draw_circle(instance, instance.x_min + instance.width/2, instance.y_min + instance.height/2, ctx)
+
+
+
+          const color_data = this.color_instance(instance, ctx)
+
+          // TODO abstract to function ie for use with other "screen
+          // rendered types" like polygon
+          if (instance.rating) {
+            for (let rating_index = 0; rating_index < instance.rating; rating_index++) {
+              let x = instance.x_min + (rating_index * 35)
+              this.drawStar(x, instance.y_max + 3, 5, 12, 6, ctx);
+            }
+          }
+          if (instance.type == "box") {
+            ctx.beginPath()
+            this.draw_box(instance, ctx, i)
+            ctx.lineWidth = this.get_spatial_line_size()
+            ctx.stroke()
+          }
+
+          else if (["polygon", "line"].includes(instance.type)) {
+            ctx.beginPath()
+            this.draw_polygon(instance, ctx, i)
+          }
+
+          else if (instance.type == "cuboid") {
+            ctx.beginPath()
+            ctx.lineWidth = this.get_spatial_line_size()
+            let cuboid_result = this.draw_cuboid(instance, ctx, i)
+            ctx.stroke()
+          }
+
+          else if (instance.type == "ellipse") {
+            ctx.beginPath()
+            let cuboid_result = this.draw_ellipse(instance, ctx, i)
+            ctx.lineWidth = this.get_spatial_line_size()
+            ctx.stroke()
+          }
+          else if(instance.type === 'curve'){
+            ctx.beginPath()
+            ctx.lineWidth = this.get_spatial_line_size()
+            this.draw_cuadratic_curve(instance, ctx, i);
+            ctx.stroke()
+          }
+          else if (instance.type == "point") {
+            ctx.beginPath()
+            this.draw_point(instance, ctx, i)
+            ctx.lineWidth = '2'
+            ctx.stroke()
+          }
+          else if (instance.type == "keypoints") {
+            instance.strokeColor = color_data.strokeColor;
+            instance.lineWidth = this.get_spatial_line_size();
+            instance.vertex_size = this.$props.vertex_size;
+            instance.draw(ctx);
+            if(instance.is_hovered){
+              this.instance_hover_index = i
+              this.count_instance_in_ctx_paths +=1;
+              this.instance_hover_type = instance.type;
+            }
+          }
+
+          // TODO we may want to add the edit circle things
+          // (right now the stroke goes over the fill and it looks funny)
+
+          // TODO maybe could be a fancier highlight method
+          // ie maybe rect plus shaded or something
+          // ie https://stackoverflow.com/questions/10487882/html5-change-opacity-of-a-draw-rectangle
+          ctx.stroke()
+          // Reset line width after drawing.
+          ctx.lineWidth = '2'
+            /*
+            if (this.instance_focused_index != undefined) {
+              if (instance.id === this.instance_focused_index) {
+                ctx.strokeStyle = "blue"
+              }
+            }
+            */
+
+        },
+
+        get_spatial_line_size: function (){
+          return this.$props.label_settings.spatial_line_size / this.canvas_transform['canvas_scale_combined']
+        },
+
+        // edit circles
+        draw_many_polygon_circles: function (instance, i, ctx) {
+
+          // note different stopping point from lines
+          const fillStyle = ctx.fillStyle;
+          const strokeStyle = ctx.strokeStyle
+
+          for (var j = 0; j < instance.points.length; j++) {
+            ctx.beginPath();
+            ctx.fillStyle = '#ffffff';
+            ctx.strokeStyle = '#bdbdbd';
+            if (instance.points[j].hovered_while_drawing){
+              ctx.fillStyle = 'white';
+              ctx.strokeStyle = 'white';
+            }
+            if(instance.points[j].point_set_as_auto_border){
+              ctx.fillStyle = '#4caf50';
+              ctx.strokeStyle = '#4caf50';
+            }
+            this.draw_circle_from_instance(instance, instance.points, j, ctx)
+            ctx.fillStyle = fillStyle;
+            ctx.strokeStyle = strokeStyle;
+            this.is_mouse_in_path(ctx, i, instance)
+          }
+          ctx.fillStyle = fillStyle;
+          ctx.strokeStyle = strokeStyle;
+        },
+
+        draw_polygon_lines: function (instance, ctx) {
+
+          // All lines after first
+          // excluding last line
+          // because the last line "loops" back to the first element
+
+          for (var j = 0; j < instance.points.length - 1; j++) {
+            // for example if points.length is 11, we do
+            // up to j = 9 so j + 1 = 10 which is last index
+            ctx.lineTo(instance.points[j + 1].x, instance.points[j + 1].y)
+          }
+
+        },
+
+        is_mouse_in_path: function (ctx, i, instance) {
+
+          // This is first because we always want user to know which one they are on
+          if (ctx.isPointInPath(
+            this.mouse_position.raw.x,
+            this.mouse_position.raw.y)) {
+
+            if (this.instance_hover_index != i){
+              this.instance_hover_index = i
+              this.instance_hover_type = instance.type
+            }
+            this.count_instance_in_ctx_paths += 1
+            return true;
+          }
+          return false
+
+        },
+
+        emit_unified_hover_event: function () {
+          /*
+           * we only want to emit 1 event in case timing issue with this stuff
+           * otherwise potential timing issues, ie bouncing back and forth
+           * and seems easier to just take "last" one it found in path.
+           *
+           * We had a check on both the path and null case to update,
+           * but now that we have this unified thing, also need to see if we emit the
+           * event at all. otherwise we are always emiting even if no changes
+           */
+
+          if (this.emit_instance_hover == true) {
+
+            if (this.instance_hover_index != this.previous_instance_hover_index) {
+
+              this.previous_instance_hover_index = this.instance_hover_index
+
+              this.$emit('instance_hover_update',
+                [this.instance_hover_index, this.instance_hover_type])
+            }
+            if(this.instance_hover_type === 'cuboid' && this.prev_cuboid_hovered_face != this.cuboid_hovered_face){
+              this.prev_cuboid_hovered_face = this.cuboid_hovered_face;
+              this.$emit('cuboid_face_hover_update', this.cuboid_hovered_face)
+            }
+
+
+            if (this.issue_hover_index != this.previous_issue_hover_index) {
+
+              this.previous_issue_hover_index = this.issue_hover_index
+
+              this.$emit('issue_hover_update', this.issue_hover_index)
+            }
+          }
+        },
+
+        check_null_hover_case: function () {
+
+          if (this.count_instance_in_ctx_paths == 0) {
+
+            if (this.instance_hover_index != null) { // only update on change
+              this.instance_hover_index = null   // careful need to reset this here too
+              this.instance_hover_type = null
+              this.cuboid_hovered_face = undefined   // reset
+            }
+          }
+          // Do the same for issues.
+          if (this.count_issues_in_ctx_paths === 0) {
+
+            if (this.issue_hover_index != null) {
+              this.issue_hover_index = null
+            }
+          }
+        },
+        generate_polygon_mid_points(instance, ctx, i){
+          const midpoints_polygon = []
+          for(let i = 1; i < instance.points.length; i++){
+            const prev = instance.points[i - 1];
+            const current = instance.points[i];
+            midpoints_polygon.push({
+              x: (prev.x + current.x) / 2,
+              y: (prev.y + current.y) / 2
+            })
+          }
+          midpoints_polygon.push({
+            x: (instance.points[0].x + instance.points[instance.points.length - 1].x) / 2,
+            y: (instance.points[0].y + instance.points[instance.points.length - 1].y) / 2
+          })
+          instance.midpoints_polygon = midpoints_polygon;
+        },
+        draw_polygon_midpoints(instance, ctx, i){
+          if(!instance.midpoint_hover == undefined){return}
+          // Only draw when hovered in
+          const point = instance.midpoints_polygon[instance.midpoint_hover];
+          if(point == undefined){return}
+          const radius = (this.$props.vertex_size) / this.canvas_transform['canvas_scale_combined']
+          this.draw_single_path_circle(point.x, point.y, radius, ctx);
+
+        },
+
+        draw_polygon: function (instance, ctx, i) {
+          let result = this.draw_polygon_main_section(instance, ctx, i)
+                       this.draw_polygon_control_points(instance, ctx, i)
+        },
+        draw_polygon_main_section: function (instance, ctx, i) {
+          const preStrokeStyle = ctx.strokeStyle;
+          if(instance.type === 'polygon' && instance.selected){
+            this.generate_polygon_mid_points(instance, ctx, i)
+            this.draw_polygon_midpoints(instance, ctx, i)
+          }
+          ctx.beginPath();
+          const instance_colour = this.get_instance_colour();
+          let r = instance_colour.rgba.r
+          let g = instance_colour.rgba.g
+          let b = instance_colour.rgba.b
+
+          let points = instance.points
+          ctx.strokeStyle = preStrokeStyle;
+          // 1) draw primary path
+          if (points.length >= 1) {
+
+            this.draw_label(ctx, points[0].x, points[0].y, instance)
+            ctx.fillStyle = "rgba(" + r + "," + g + "," + b + ",.20)";
+            ctx.moveTo(points[0].x, points[0].y)
+
+          }
+
+          if (points.length >= 2) {
+            this.draw_polygon_lines(instance, ctx)
+            ctx.lineTo(points[0].x, points[0].y)
+          }
+
+          this.is_mouse_in_path(ctx, i, instance) // must be seperate from when circles are drawn
+
+          let spatial_line_size = this.get_spatial_line_size()
+          if (spatial_line_size != 0) {
+            ctx.lineWidth = spatial_line_size
+            ctx.stroke()
+          }
+
+          // We may want these selection values to be user definable
+          // Context of wanting a lower value when selected is so the person can still see the raw image
+          // AND the overall coverage is still visible. Especially relevant if spatial_line is 0.
+          if (instance.selected != "undefined" && instance.selected == true) {
+            ctx.fillStyle = "rgba(" + r + "," + g + "," + b + ", .1)";
+          }
+
+          if (this.instance_hover_index == i) {
+            ctx.fillStyle = "rgba(" + r + "," + g + "," + b + ",.1)";
+          }
+
+          if (instance.type == "polygon") {
+            ctx.fill()
+          }
+          if (instance.type == "line") {
+            ctx.lineWidth *= 2
+          }
+          return true
+        },
+        draw_polygon_control_points: function (instance, ctx, i) {
+          ctx.beginPath();
+          let points = instance.points
+          if (instance.selected || instance.type == 'line' || this.$props.is_actively_drawing) {
+            // Draw edit circles
+            // isPointInPath() needs to be run twice then, once for
+            // line path (ie clicking in middle of polygon) and once
+            // for clicking on circles
+            // prior when trying to run together did not detect in middle
+            if (points.length >= 1) {
+              ctx.fillStyle = '#ffffff';
+              ctx.strokeStyle = '#bdbdbd';
+              if (instance.points[0].hovered_while_drawing){
+                ctx.fillStyle = 'white';
+                ctx.strokeStyle = 'white';
+              }
+              if(instance.points[0].point_set_as_auto_border){
+                ctx.fillStyle = '#4caf50';
+                ctx.strokeStyle = '#4caf50';
+              }
+              this.draw_circle_from_instance(instance, points, 0, ctx)
+            }
+            if (points.length >= 2) {
+              this.draw_many_polygon_circles(instance,i , ctx)
+            }
+
+            // Need to run this again otherwise edges of circles
+            // outside of polygon won't be detected for edit which makes
+            // edit break
+            this.is_mouse_in_path(ctx, i, instance)
+
+          }
+          let spatial_line_size = this.get_spatial_line_size()
+          if (this.$props.auto_border_polygon_p1) {
+            this.draw_single_path_circle(this.$props.auto_border_polygon_p1.x,
+              this.$props.auto_border_polygon_p1.y,
+              this.circle_size,
+              ctx,
+              '#4caf50',
+              '#4caf50',
+              `${spatial_line_size}px`);
+          }
+
+          if (this.$props.auto_border_polygon_p2) {
+
+            this.draw_single_path_circle(this.$props.auto_border_polygon_p2.x,
+              this.$props.auto_border_polygon_p2.y,
+              this.circle_size,
+              ctx,
+              '#4caf50',
+              '#4caf50',
+              `${spatial_line_size}px`)
+          }
+
+          ctx.stroke()
+        },
+
+        // point type  (not sub of polygon)
+
+        draw_point: function (instance, ctx, i) {
+
+          let point = instance.points[0]
+
+          if (point == null) { return }
+
+          let circle_size = 5 / this.canvas_transform['canvas_scale_combined']
+
+          if (typeof this.colour == "undefined") {  return  }
+          const instance_colour = this.get_instance_colour();
+          let r = instance_colour.rgba.r
+          let g = instance_colour.rgba.g
+          let b = instance_colour.rgba.b
+
+          this.draw_label(ctx, point.x, point.y, instance)
+
+          ctx.fillStyle = "rgba(" + r + "," + g + "," + b + ",.75)";
+
+          this.draw_circle(point.x, point.y, ctx)
+
+          this.is_mouse_in_path(ctx, i, instance)   // caution must be after drawing path (ie circle)
+
+          ctx.fill()
+
+          ctx.stroke()
+
+        },
+
+        draw_cuboid_corner_circles: function(instance, ctx, i){
+          let result = false;
+          if (this.draw_mode == false) {
+            if (this.render_mode != "file_diff" && this.mode == 'default') {
+              const radius = (this.$props.vertex_size) / this.canvas_transform['canvas_scale_combined']
+              this.draw_single_path_circle(instance.front_face.top_left.x  , instance.front_face.top_left.y , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              this.draw_single_path_circle(instance.front_face.top_right.x , instance.front_face.top_right.y ,radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              this.draw_single_path_circle(instance.front_face.bot_left.x , instance.front_face.bot_left.y ,radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              this.draw_single_path_circle(instance.front_face.bot_right.x , instance.front_face.bot_right.y ,radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              this.draw_single_path_circle(instance.rear_face.top_left.x , instance.rear_face.top_left.y , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              this.draw_single_path_circle(instance.rear_face.top_right.x , instance.rear_face.top_right.y , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              this.draw_single_path_circle(instance.rear_face.bot_left.x , instance.rear_face.bot_left.y  , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              this.draw_single_path_circle(instance.rear_face.bot_right.x , instance.rear_face.bot_right.y  , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              const prevFill = ctx.fillStyle;
+              ctx.fillStyle = 'white';
+              ctx.fill()
+              ctx.stroke()
+              ctx.fillStyle = prevFill;
+            }
+          }
+          return result
+        },
+        inside: function(point, vs, ctx){
+          ctx.beginPath();
+          for(var i = 0; i< vs.length ; i++){
+            let current = vs[i]
+            if(i == 0){
+              ctx.moveTo(current.x, current.y)
+              continue;
+            }
+            ctx.lineTo(current.x, current.y)
+          }
+          ctx.closePath();
+
+          return ctx.isPointInPath(point.x, point.y);
+        },
+        is_point_in_cuboid_face: function(side, front_face, rear_face, ctx){
+          const mouse_x = this.mouse_position.raw.x;
+          const mouse_y = this.mouse_position.raw.y;
+          if(side === 'top'){
+            const polygon = [
+              front_face.top_left,
+              front_face.top_right,
+              rear_face.top_right,
+              rear_face.top_left,
+            ]
+            return this.inside({x: mouse_x, y: mouse_y}, polygon, ctx)
+          }
+          else if(side === 'rear'){
+            const polygon = [
+              rear_face.top_right,
+              rear_face.bot_right,
+              rear_face.bot_left,
+              rear_face.top_left,
+            ]
+            return this.inside({x: mouse_x, y: mouse_y}, polygon, ctx)
+          }
+          else if(side === 'front'){
+            const polygon = [
+              front_face.top_right,
+              front_face.bot_right,
+              front_face.bot_left,
+              front_face.top_left,
+            ]
+            return this.inside({x: mouse_x, y: mouse_y}, polygon, ctx)
+          }
+          else if(side === 'right'){
+            const polygon = [
+              front_face.top_right,
+              front_face.bot_right,
+              rear_face.bot_right,
+              rear_face.top_right,
+            ]
+            return this.inside({x: mouse_x, y: mouse_y}, polygon, ctx)
+          }
+          else if(side === 'left'){
+            const polygon = [
+              front_face.top_left,
+              front_face.bot_left,
+              rear_face.bot_left,
+              rear_face.top_left,
+            ]
+            return this.inside({x: mouse_x, y: mouse_y}, polygon, ctx)
+          }
+          else if(side === 'bottom'){
+            const polygon = [
+              front_face.bot_left,
+              front_face.bot_right,
+              rear_face.bot_right,
+              rear_face.bot_left,
+            ]
+            return this.inside({x: mouse_x, y: mouse_y}, polygon, ctx)
+          }
+          return false
+        },
+        detect_hover_on_cuboid: function (instance, ctx, i, hover_corner) {
+          if(this.$props.is_actively_resizing){
+            this.instance_hover_index = this.previous_instance_hover_index;
+            this.count_instance_in_ctx_paths +=1;
+            this.cuboid_hovered_face = this.prev_cuboid_hovered_face;
+            return
+          }
+          const hover_front_face = this.is_point_in_cuboid_face('front', instance.front_face, instance.rear_face, ctx);
+          const hover_rear_face = this.is_point_in_cuboid_face('rear', instance.front_face, instance.rear_face, ctx);
+          const hover_top_face = this.is_point_in_cuboid_face('top', instance.front_face, instance.rear_face, ctx);
+          const hover_left_face = this.is_point_in_cuboid_face('left', instance.front_face, instance.rear_face, ctx);
+          const hover_right_face = this.is_point_in_cuboid_face('right', instance.front_face, instance.rear_face, ctx);
+          const hover_bottom_face = this.is_point_in_cuboid_face('bottom', instance.front_face, instance.rear_face, ctx);
+
+          // if(hover_top_face){
+          //   // Hover Top Face
+          //   this.$cuboid.draw_cuboid_top_face(instance.front_face, instance.rear_face, ctx, true);
+          // }
+
+          if(instance.selected){
+            ctx.beginPath();
+            if (hover_rear_face) {
+              const instance_colour = this.get_instance_colour();
+              let r = instance_colour.rgba.r
+              let g = instance_colour.rgba.g
+              let b = instance_colour.rgba.b
+              ctx.fillStyle = "rgba(" + r + "," + g + "," + b + ", 0.7)";
+              this.$cuboid.draw_cuboid_face(instance.rear_face, ctx, true)
+              this.cuboid_hovered_face = 'rear';
+            } else if (hover_left_face) {
+              // Hover Left Face
+              this.$cuboid.draw_cuboid_left_face(instance.front_face, instance.rear_face, ctx, true)
+              this.cuboid_hovered_face = 'left';
+            } else if (hover_right_face) {
+              // Hover Right Face
+              this.$cuboid.draw_cuboid_right_face(instance.front_face, instance.rear_face, ctx, true)
+              this.cuboid_hovered_face = 'right';
+            } else if (hover_bottom_face) {
+              // Hover Bottom Face
+              this.$cuboid.draw_cuboid_down_face(instance.front_face, instance.rear_face, ctx, true)
+              this.cuboid_hovered_face = 'bottom';
+            }
+            else if (hover_top_face) {
+              // Hover Bottom Face
+              this.$cuboid.draw_cuboid_top_face(instance.front_face, instance.rear_face, ctx, true)
+              this.cuboid_hovered_face = 'top';
+            }
+
+          }
+
+
+
+          if (hover_top_face || hover_left_face || hover_right_face
+            || hover_bottom_face || hover_rear_face || hover_front_face || hover_corner) {
+            if (this.instance_hover_index != i) {
+              this.instance_hover_index = i
+              this.instance_hover_type = instance.type
+            }
+            this.count_instance_in_ctx_paths += 1
+          }
+        },
+        detect_hover_on_ellipse: function(instance, ctx, i){
+          const point = this.mouse_position.raw;
+          if(ctx.isPointInPath(point.x, point.y)){
+            this.count_instance_in_ctx_paths += 1;
+            this.instance_hover_index = i;
+            this.instance_hover_type = instance.type;
+          }
+          // Detect Hover Circle
+
+        },
+        draw_single_path_circle: function(x, y, radius, ctx, strokeStyle = '#bdbdbd', fillStyle= 'white', lineWidth='2px'){
+          ctx.beginPath();
+          ctx.strokeStyle = strokeStyle;
+          ctx.fillStyle = fillStyle;
+          ctx.lineWidth = lineWidth;
+          ctx.arc(x, y, radius, 0, 2 * Math.PI);
+          ctx.fill()
+          ctx.stroke()
+        },
+        draw_control_points_and_detect_hover: function(instance, ctx, i){
+          let circle_size = ( this.$props.vertex_size) / this.canvas_transform['canvas_scale_combined']
+          if(circle_size <= 0){
+            return
+          }
+          const mouse = this.mouse_position.raw;
+          // do we want to cache and then restore lineWidth or something?
+          // or can it just be the same?
+          ctx.lineWidth = this.get_spatial_line_size()
+          this.draw_single_path_circle(instance.p1.x, instance.p1.y, circle_size, ctx)
+          const hover_cp1 = ctx.isPointInPath(mouse.x, mouse.y);
+
+          this.draw_single_path_circle(instance.cp.x, instance.cp.y, circle_size, ctx);
+          const hover_cpmid = ctx.isPointInPath(mouse.x, mouse.y);
+
+          this.draw_single_path_circle(instance.p2.x, instance.p2.y, circle_size, ctx)
+          const hover_cp2 = ctx.isPointInPath(mouse.x, mouse.y);
+          // Draw lines to control point
+          ctx.setLineDash([3]);
+          ctx.moveTo(instance.p1.x, instance.p1.y);
+          if(instance.selected){
+            ctx.strokeStyle = 'rgba(189,189,189,0.4)';
+            ctx.lineTo(instance.cp.x, instance.cp.y)
+            ctx.stroke();
+            ctx.setLineDash([3]);
+            ctx.moveTo(instance.p2.x, instance.p2.y);
+
+            ctx.lineTo(instance.cp.x, instance.cp.y)
+            ctx.stroke()
+          }
+
+          if (hover_cp1 || hover_cpmid || hover_cp2) {
+            if (this.instance_hover_index != i) {
+              this.instance_hover_index = i
+              this.instance_hover_type = instance.type
+            }
+            this.count_instance_in_ctx_paths += 1
+          }
+        },
+
+        draw_cuadratic_curve(instance, ctx, i){
+
+          const mouse = this.mouse_position.raw;
+          ctx.beginPath();
+          ctx.moveTo(instance.p1.x, instance.p1.y)
+          ctx.quadraticCurveTo(instance.cp.x, instance.cp.y, instance.p2.x, instance.p2.y);
+          ctx.stroke();
+          // Line hover detection
+          if(ctx.isPointInPath(mouse.x, mouse.y)){
+            if (this.instance_hover_index != i) {
+              this.instance_hover_index = i
+              this.instance_hover_type = instance.type
+            }
+            this.count_instance_in_ctx_paths += 1
+          }
+
+
+          this.draw_control_points_and_detect_hover(instance, ctx, i);
+        },
+        draw_ellipse_corner_circles: function(instance, ctx, i){
+          let result = false;
+          if (this.draw_mode == false) {
+            if (this.render_mode != "file_diff" && this.mode == 'default') {
+              if(!instance.angle){
+                instance.angle = 0
+              }
+              let a = instance.width;
+              let b = instance.height;
+              const radius = ( this.$props.vertex_size) / this.canvas_transform['canvas_scale_combined']
+              this.$ellipse.generate_ellipse_corners(instance, a, b)
+
+              //right
+              this.draw_single_path_circle(instance.corners.right.x, instance.corners.right.y, radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              // left
+              this.draw_single_path_circle(instance.corners.left.x, instance.corners.left.y, radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              // top
+              this.draw_single_path_circle(instance.corners.top.x, instance.corners.top.y , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              // bot
+              this.draw_single_path_circle(instance.corners.bot.x, instance.corners.bot.y , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              // rotate point
+
+              this.draw_single_path_circle(instance.corners.rotate.x, instance.corners.rotate.y , radius + 4, ctx, 'blue', '4px')
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              // top right
+              this.draw_single_path_circle(instance.corners.top_right.x, instance.corners.top_right.y , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              // bot_right
+              this.draw_single_path_circle(instance.corners.bot_right.x, instance.corners.bot_right.y , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              // top_left
+              this.draw_single_path_circle(instance.corners.top_left.x, instance.corners.top_left.y , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+              // bot_left
+              this.draw_single_path_circle(instance.corners.bot_left.x, instance.corners.bot_left.y , radius, ctx)
+              if(this.is_mouse_in_path(ctx, i, instance)){ result = true}
+            }
+          }
+          return result
+        },
+        draw_ellipse: function(instance, ctx, i){
+          const instance_colour = this.get_instance_colour();
+          let r = instance_colour.rgba.r
+          let g = instance_colour.rgba.g
+          let b = instance_colour.rgba.b
+          ctx.fillStyle = `rgba(${r},${g},${b}, 0.1)`;
+          this.$ellipse.draw_ellipse(
+            instance,
+            ctx
+          )
+
+          this.detect_hover_on_ellipse(instance, ctx, i);
+          if(instance.selected){
+            this.draw_ellipse_corner_circles(instance, ctx);
+          }
+        },
+        draw_cuboid: function (instance, ctx, i) {
+          /* instance, current instance object
+           * ctx
+           * draws the front and back cuboid faces,
+           * then draws the 4 side lines
+           */
+          const instance_colour = this.get_instance_colour();
+          let r = instance_colour.rgba.r
+          let g = instance_colour.rgba.g
+          let b = instance_colour.rgba.b
+
+
+          ctx.stokeStyle = "rgba(" + r + "," + g + "," + b + ", 1)";
+          ctx.fillStyle = "rgba(" + r + "," + g + "," + b + ", 0)";
+          this.$cuboid.draw_cuboid_face(instance.front_face, ctx, false)
+          // Rear face has fill
+          ctx.fillStyle = "rgba(" + r + "," + g + "," + b + ", .4)";
+          this.$cuboid.draw_cuboid_face(instance.rear_face, ctx, true)
+
+          // Lateral Faces
+          // Top Face
+          this.$cuboid.draw_cuboid_top_face(instance.front_face, instance.rear_face, ctx, false);
+          // Left Face
+          this.$cuboid.draw_cuboid_left_face(instance.front_face, instance.rear_face, ctx, false)
+          // Right Face
+          this.$cuboid.draw_cuboid_right_face(instance.front_face, instance.rear_face, ctx, false)
+          // Bottom Face
+          this.$cuboid.draw_cuboid_down_face(instance.front_face, instance.rear_face, ctx, false)
+          ctx.stroke();
+
+          let hover_corner = false
+          if(instance.selected){
+            hover_corner = this.draw_cuboid_corner_circles(instance, ctx, i);
+          }
+          this.detect_hover_on_cuboid(instance, ctx, i, hover_corner);
+
+          return true
+
+        },
+
+        draw_label: function (ctx, x, y, instance) {
+          /* There's a lot of random stuff we may want to
+           * draw about something. I wonder if we are better to just place it all
+           * into one string...
+           * I think for now let's simplify to a message
+           * and can get more fancy later if we want
+           */
+
+          if ( this.label_settings == null
+               || this.label_settings.show_text == false
+               || instance == undefined) {
+            return
+          }
+
+          let message = ""
+
+          if (this.label_settings.show_label_text == true) {
+            message += instance.label_file.label.name
+            if (instance.number != undefined) {
+              message += " " + instance.number
+            }
+          }
+
+          if (this.label_settings.show_attribute_text == true) {
+            if (instance.attribute_groups) {
+             for (const [id, attribute] of Object.entries(instance.attribute_groups)) {
+               if (attribute && attribute['display_name']) {
+                 message += " " + attribute['display_name']
+               }
+              }
+            }
+          }
+
+          if (instance.missing) {
+            if (instance.missing == true) {
+               message += " Missing"
+            }
+          }
+
+          if (  instance.soft_delete
+             && instance.soft_delete == true) {
+            message += " Removed"
+          }
+
+          if (  instance.interpolated
+             && instance.interpolated == true) {
+            message += " Interpolated"
+          }
+
+
+          ctx.fillStyle = this.$get_sequence_color(instance.sequence_id)
+
+          ctx.fillText(message, x, y);
+
+        },
+
+        get_instance_colour(){
+          let colour_result =  {
+            rgba: {
+              r: 255,
+              g: 255,
+              b: 255,
+            }
+          }
+          colour_result.rgba.r = this.colour.rgba.r
+          colour_result.rgba.g = this.colour.rgba.g
+          colour_result.rgba.b = this.colour.rgba.b
+          if(this.$store.state.annotation_state.instance_select_for_issue){
+            colour_result.rgba.r = 255;
+            colour_result.rgba.g = 255;
+            colour_result.rgba.b = 255;
+
+          }
+          return colour_result
+        },
+        draw_box_edit_corners: function (ctx, i, instance) {
+
+          if (this.draw_mode == false && (this.previous_instance_hover_index == i || instance.selected)) {
+            if (this.render_mode != "file_diff" && this.mode == 'default') {
+
+              this.draw_circle(instance.x_min, instance.y_min, ctx)
+              ctx.moveTo(instance.x_max, instance.y_min);
+              this.draw_circle(instance.x_max, instance.y_min, ctx)
+              ctx.moveTo(instance.x_max, instance.y_max);
+              this.draw_circle(instance.x_max, instance.y_max, ctx)
+              ctx.moveTo(instance.x_min, instance.y_max);
+              this.draw_circle(instance.x_min, instance.y_max, ctx)
+              ctx.fill()
+            }
+          }
+        },
+
+        draw_box: function (instance, ctx, i) {
+
+          // possible to refactor this into a "draw face" function?
+          const instance_colour = this.get_instance_colour();
+          let r = instance_colour.rgba.r
+          let g = instance_colour.rgba.g
+          let b = instance_colour.rgba.b
+
+
+          this.draw_label(ctx, instance.x_min, instance.y_min, instance)
+
+          // start Focus instance feature
+          var opacity = .1
+
+          /*
+          // TODO this is confusing if we are just focusing one instance a time
+          if (this.instance_focused_index) {
+            if (instance.id == this.instance_focused_index) {
+              opacity = .35
+            } else {
+              opacity = .1
+            }
+          }
+          */
+          // end Focus feature
+          if (this.mode == 'gold_standard') {
+            ctx.fillStyle = "rgba(255, 215, 0," + opacity + ")";
+          }
+          if (this.mode == 'default') {
+            ctx.fillStyle = "rgba(" + r + "," + g + "," + b + "," + opacity + ")";
+          }
+
+          ctx.rect(
+            this.toInt(instance.x_min),
+            this.toInt(instance.y_min),
+            this.toInt(instance.width),
+            this.toInt(instance.height))
+
+          ctx.stroke()
+
+          ctx.fill()
+
+          this.is_mouse_in_path(ctx, i, instance)
+
+          // after we know if it's in path
+          this.draw_box_edit_corners(ctx, i, instance)
+
+          // run again so we still capture the corners for editing
+          this.is_mouse_in_path(ctx, i, instance)
+
+
+        },
+
+         // inspired by http://jsfiddle.net/m1erickson/8j6kdf4o/
+        drawStar: function (cx, cy, spikes, outerRadius, innerRadius, ctx) {
+
+          var rot = Math.PI / 2 * 3;
+          var x = cx;
+          var y = cy;
+          var step = Math.PI / spikes;
+
+          ctx.moveTo(cx, cy - outerRadius)
+
+          for (let i = 0; i < spikes; i++) {
+
+            x = cx + Math.cos(rot) * outerRadius;
+            y = cy + Math.sin(rot) * outerRadius;
+            ctx.lineTo(x, y)
+            rot += step
+
+            x = cx + Math.cos(rot) * innerRadius;
+            y = cy + Math.sin(rot) * innerRadius;
+            ctx.lineTo(x, y)
+            rot += step
+          }
+
+          ctx.lineTo(cx, cy - outerRadius)
+
+          ctx.stroke()
+          ctx.closePath();
+
+          ctx.fill()
+
+        },
+
+        draw_gold_standard: function () {
+
+          // TODO move gold standard functions here if possible
+
+        },
+
+        point_is_intersecting_circle: function (mouse, point) {
+          // Careful this is effected by scale
+
+            // bool, true if point if intersecting circle
+            let radius = 8 / this.canvas_transform['canvas_scale_combined']
+
+            return Math.sqrt(
+                (point.x - mouse.x) ** 2
+              + (mouse.y - point.y) ** 2) < radius  // < number == circle.radius
+        },
+      },
+   computed:{
+     instance_select_for_issue: function(){
+       return this.$store.getters.get_instance_select_for_issue;
+     },
+     view_issue_mode: function(){
+       return this.$store.getters.get_view_issue_mode;
+     }
+   }
+
+    })
+
+
+ </script>

--- a/frontend/src/components/vue_canvas/instance_list.vue
+++ b/frontend/src/components/vue_canvas/instance_list.vue
@@ -185,6 +185,19 @@
           })
 
         },
+        draw_pause: function(instance, ctx){
+          if(!ctx.material_icons_loaded){
+            return
+          }
+          const old_color = ctx.fillStyle;
+          const old_font = ctx.font
+          ctx.font = '30px material-icons';
+          ctx.fillStyle = 'rgb(0,0,0)';
+          const point = this.get_instance_corner(instance)
+          ctx.fillText('pause', point.x, point.y);
+          ctx.fillStyle = old_color;
+          ctx.font = old_font;
+        },
         draw_checkmark: function(instance, ctx){
           if(!ctx.material_icons_loaded){
             return
@@ -393,6 +406,7 @@
             if (instance.selected == true) {
               strokeColor = "blue"
             }
+
             if(this.instance_select_for_issue && !this.view_issue_mode){
               if(instance.selected){
                 strokeColor = "green"
@@ -434,7 +448,6 @@
           if (instance.selected == undefined){
             instance.selected = false
           }
-
           // TODO review this.colour isolation here
 
 
@@ -520,6 +533,14 @@
             }
             */
 
+           this.draw_icons(instance, ctx)
+
+        },
+
+        draw_icons: function (instance, ctx) {
+          if(instance.pause_object == true){
+            this.draw_pause(instance, ctx);
+          }
         },
 
         get_spatial_line_size: function (){

--- a/frontend/src/components/vue_canvas/instances/Instance.ts
+++ b/frontend/src/components/vue_canvas/instances/Instance.ts
@@ -41,6 +41,7 @@ export class Instance{
   public on_instance_hovered: Function = undefined;
   public on_instance_unhovered: Function = undefined;
   public on_instance_deselected: Function = undefined;
+  public pause_object: false
 
 
   public get_instance_data(): object{
@@ -77,6 +78,7 @@ export class Instance{
       points: this.points,
       sequence_id: this.sequence_id,
       soft_delete: this.soft_delete,
+      pause_object: this.pause_object
     }
   }
 

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -45,6 +45,9 @@ export const user_module = {
       state.is_typing_or_menu_open = false
       state.settings = default_user_settings
     },
+    restore_default_user_settings(state) {
+      state.settings = default_user_settings
+    },
     set_user_name(state, user_name) {
       state.user_name = user_name
     },

--- a/shared/alembic/versions_opencore/alembic_2021_05_17_21_32_c3d95120b9ce_add_pause_object.py
+++ b/shared/alembic/versions_opencore/alembic_2021_05_17_21_32_c3d95120b9ce_add_pause_object.py
@@ -1,0 +1,24 @@
+"""add pause_object
+
+Revision ID: c3d95120b9ce
+Revises: 77907aedd319
+Create Date: 2021-05-17 21:32:46.140955
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c3d95120b9ce'
+down_revision = '77907aedd319'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('instance', sa.Column('pause_object', sa.Boolean()))
+
+
+def downgrade():
+    op.drop_column('instance', 'pause_object')

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -279,6 +279,11 @@ class Annotation_Update():
 		{'change_source': {
 			'kind': str,
 			'required': False
+		}
+        },
+        	{'pause_object': {
+			'kind': bool,
+			'required': False
 		}}
 	])
 
@@ -835,7 +840,8 @@ class Annotation_Update():
 					change_source = input['change_source'],
 					hash_instances=hash_instances,
 					validate_label_file=validate_label_file,
-					overwrite_existing_instances = overwrite_existing_instances
+					overwrite_existing_instances = overwrite_existing_instances,
+                    pause_object = input['pause_object']
 				)
 
 	def get_min_coordinates_instance(self, instance):
@@ -966,7 +972,8 @@ class Annotation_Update():
 			edges = [],
 			hash_instances = True,
 			overwrite_existing_instances = True,
-			validate_label_file = True):
+			validate_label_file = True,
+            pause_object = None):
 		"""
 		Assumes a "system" level context
 
@@ -1047,6 +1054,7 @@ class Annotation_Update():
 			'p2': p2,
 			'nodes': {'nodes': nodes},
 			'edges': {'edges': edges},
+            'pause_object': pause_object
 		}
 
 		if overwrite_existing_instances and id is not None:

--- a/shared/database/annotation/instance.py
+++ b/shared/database/annotation/instance.py
@@ -72,6 +72,8 @@ class Instance(Base):
 
     global_frame_number = Column(Integer)
 
+    pause_object = Column(Boolean)
+
     # TODO review interpolated
     # And other options in relation to say box
     machine_made = Column(Boolean)
@@ -330,7 +332,8 @@ class Instance(Base):
             self.soft_delete,
             self.attribute_groups,
             self.machine_made,
-            self.sequence_id
+            self.sequence_id,
+            self.pause_object
         ]
 
         self.hash = hashlib.sha256(json.dumps(
@@ -403,7 +406,8 @@ class Instance(Base):
             'root_id': self.root_id,
             'version': self.version,
             'nodes': nodes,
-            'edges': edges
+            'edges': edges,
+            'pause_object': self.pause_object
 
         }
 


### PR DESCRIPTION
New "Ghost" instance proposals make it 10x easy to annotate for both casual and pro users.
Now, a user doesn't really need to understand anything about sequences to use sequences.

## Overview
As a user I can draw the the objects.
The system presents context that I can choose to accept or ignore.
There is no need to expressly "decline" proposals, all proposals are declined by default.

## Features
New "Ghost" proposals. Ghost proposals are generated on frame change. Crucially
1) It's based on the last keyframe. A user can go at any pace, from frame by frame to jumping thousands of frames.
2) It's clearly different from normal instances. By using a seperate list and rendering mechanism, this is isolated from the normal instance list. This presents a better "middle ground" between our prior state of not showing _any_ context, and other implementations that just show the full instance and it's confusing what's generated and what's user made.

Feature flag: `label_settings.show_ghost_instances = true`

## Video
https://www.loom.com/share/bc71bd9cab4f4e729f4189ca60595c19

## Visual
![ghost objects explained](https://user-images.githubusercontent.com/18080164/118593977-7ce29e00-b75d-11eb-8ca8-c65cdf716c3c.PNG)

## Pause Feature
![image](https://user-images.githubusercontent.com/18080164/118594724-bff14100-b75e-11eb-8b54-8ed4615f8d8f.png)

## User prompt upon first time feature is available
![image](https://user-images.githubusercontent.com/18080164/118595112-558cd080-b75f-11eb-806f-9eb832afe732.png)

## Future
1) I'd like to extend this idea to user scripts and other things that generate proposals.
2) "Pause" has a lot of room for improvement, eg a "Resume" function
3)  ghost_instance_list.vue is meant to be refactored into a concrete implementation that uses abstractions currently duplicated from instance_list. For the sake of timing I'm ok to do that as a seperate branch if everyone is ok with that too.

## Known issues - None appear super critical for v1 usage

1) Ghost logic is in annotation core but should be a class outside of annotation core
2) Some occasional timing issues with saving, initial keyframe. Any bugs in keyframe list break ghost objects.
3) "Selection" needs to be reviewed in this new context - sometimes the "selected" instance is off
4) Undo/Redo/Resize sometimes behavior unexpectedly in this new context
5) An instance paused prior to being the last key frame in a series isn't well handled


@PJEstrada  please let me know your thoughts :)

