### PR TITLE
Improve UI styles of toolbar

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6,6 +6,7 @@
 
 
       <main_menu :height="`${show_default_navigation ? '100px' : '50px'}`"
+
                  :show_default_navigation="show_default_navigation">
 
         <template slot="second_row" >
@@ -318,8 +319,7 @@
         </v-container>
       </v-container>
       <div id="annotation" tabindex="0"
-           v-if="!error_no_permissions.data"
-           class="pl-1 pt-1">
+           v-if="!error_no_permissions.data">
 
         <!-- Must wrap canvas to detect events in this context
       Careful, the slider needs to be in this context too
@@ -2899,7 +2899,7 @@ export default Vue.extend( {
        * frame: [list of sequence ids]
        * 351: [3619]
          355: [3620, 3621]
-       * 
+       *
        */
       let keyframes_to_sequences = {}
 
@@ -4065,7 +4065,7 @@ export default Vue.extend( {
   },
 
   ghost_clear_hover_index: function () {
-    this.ghost_instance_hover_index = null   
+    this.ghost_instance_hover_index = null
     this.ghost_instance_hover_type = null
   },
 
@@ -4074,7 +4074,7 @@ export default Vue.extend( {
   },
 
   ghost_promote_instance_to_actual: function (ghost_index) {
-      this.has_changed = true  // otherwise user click event won't trigger change detection 
+      this.has_changed = true  // otherwise user click event won't trigger change detection
 
       let instance = this.ghost_instance_list[ghost_index]
       this.add_instance_to_frame_buffer(instance, this.current_frame)    // this handles the creation_ref_id stuff too

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -157,9 +157,9 @@
       </template>
     </v-snackbar>
 
-  <v-sheet >
+  <v-sheet style="outline: none" >
 
-   <v-layout >
+   <v-layout style="outline: none">
 
 
 
@@ -6400,3 +6400,10 @@ export default Vue.extend( {
     }
   }
   ) </script>
+
+<style>
+  #canvas_wrapper, #annotation_core{
+    outline: none;
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0); /* mobile webkit */
+  }
+</style>

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -1,13 +1,12 @@
 <template>
-<div v-cloak>
-
 <v-toolbar
       v-if="show_toolbar"
       dense
-      elevation="1"
+      width="100%"
+      elevation="0"
       fixed
       :height="height"
-      style="overflow: hidden; padding:0"
+      style="overflow: hidden; padding:0; border-bottom: 1px solid #e0e0e0"
       >
   <v-toolbar-items>
 
@@ -744,14 +743,13 @@
 
       </template>
      </button_with_menu>
+    <v-spacer class="flex-grow-1"></v-spacer>
 
 
 
       </v-toolbar-items>
     </v-toolbar>
 
-
-</div>
 </template>
 
 <script lang="ts">

--- a/frontend/src/components/label/label_select_annotation.vue
+++ b/frontend/src/components/label/label_select_annotation.vue
@@ -82,18 +82,20 @@
 
         <template v-slot:selection="data">
 
-          <v-icon
-            left
-            :style="style_color(data.item.colour.hex)">
-            flag
-          </v-icon>
+          <div class="mb-4">
+            <v-icon
+              left
+              :style="style_color(data.item.colour.hex)">
+              flag
+            </v-icon>
 
-          <v-icon v-if="data.item.label.default_sequences_to_single_frame"
-                  color="black">
-            mdi-flag-checkered
-          </v-icon>
+            <v-icon v-if="data.item.label.default_sequences_to_single_frame"
+                    color="black">
+              mdi-flag-checkered
+            </v-icon>
 
-          {{ label_name_truncated(data.item.label.name) }}
+            {{ label_name_truncated(data.item.label.name) }}
+          </div>
 
         </template>
 

--- a/frontend/src/components/main_menu/menu.vue
+++ b/frontend/src/components/main_menu/menu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div style="padding: 0">
     <!-- v toolbar has drawer access button which interfaces
      with v navigation drawer. they are technically seperate components
      but are logically connected given this button so keeping together here
@@ -111,12 +111,13 @@
 
 
     <v-app-bar app
+               style="padding: 0; background: white;"
                elevation="0"
                :height="height">
 
     <v-layout column>
 
-      <v-layout>
+      <v-layout >
 
       <!-- TODO would like to add  style="overflow: hidden"
            to toolbar but on marketing menu it causes
@@ -125,6 +126,7 @@
 
       <v-toolbar height="50px"
                  padding="0"
+                 class="pl-4 pr-4"
                  v-if="show_default_navigation == true"
                  >
       <ahref_seo_optimal :href="route_home">
@@ -169,7 +171,7 @@
           <!-- Only show menu if a builder mode is enabled
       (new users have no mode enabled-->
 
- 
+
 
           <!-- END action menu -->
 
@@ -486,3 +488,8 @@ import Vue from "vue";
   }
 }
 ) </script>
+<style>
+  .v-toolbar__content{
+    padding: 0;
+  }
+</style>

--- a/frontend/src/components/regular/diffgram_select.vue
+++ b/frontend/src/components/regular/diffgram_select.vue
@@ -79,7 +79,7 @@
     <!-- Menu CLOSED -->
       <template v-slot:selection="data">
 
-        <v-layout>
+        <v-layout class="mb-4">
 
           <v-icon v-if="data.item.icon"
                   :color="data.item.color"


### PR DESCRIPTION
- Now toolbar has a full screen width and the entire app has white bg to make it more consistent. 
- Also fixed some spacing issue with the label select and instance type select which made the borders look a bit weird.
- Removed black border of the canvas on the "focus-visible" state.


Before
![Screenshot from 2021-05-28 12-46-16](https://user-images.githubusercontent.com/6606958/120029122-e8750880-bfb2-11eb-8813-dfd13ec29498.png)


After:

![Screenshot from 2021-05-28 12-19-23](https://user-images.githubusercontent.com/6606958/120029155-f0cd4380-bfb2-11eb-9b93-6fc60afb0c59.png)
