### PR TITLE
Fix job card title styles for long text

### DIFF
--- a/frontend/src/components/task/job/job_list_card_display.vue
+++ b/frontend/src/components/task/job/job_list_card_display.vue
@@ -46,9 +46,10 @@
 
         <v-card-title
               @click="job_detail_page_route_by_status(job)"
-              style="cursor: pointer;">
+              style="cursor: pointer; overflow-wrap: anywhere; padding-right: 3rem">
           <span>
-          {{job.name | truncate(40)}}</span>
+          {{job.name | truncate(40)}}
+          </span>
         </v-card-title>
 
         <v-card-subtitle>


### PR DESCRIPTION

Added some custom css to better handle text wrapping


![Screenshot from 2021-05-31 14-57-00](https://user-images.githubusercontent.com/6606958/120241734-a650fe80-c220-11eb-8ddc-8794546b2823.png)