### PR TITLE
Add error condition when frame packet map is empty in update case

### DIFF
--- a/frontend/src/components/input/input_payload_dialog.vue
+++ b/frontend/src/components/input/input_payload_dialog.vue
@@ -11,6 +11,9 @@
         <v-layout v-if="input && input.instance_list">
           {{input.instance_list}}
         </v-layout>
+        <v-layout v-if="input && !input.instance_list && !input.frame_packet_map" class="d-flex justify-center ma-12">
+          <h2><v-icon x-large>mdi-dolly</v-icon>Empty Payload</h2>
+        </v-layout>
       </v-card-text>
     </v-card>
   </v-dialog>

--- a/frontend/src/components/input/input_view.vue
+++ b/frontend/src/components/input/input_view.vue
@@ -440,7 +440,7 @@
 
 
                   <tooltip_button
-                    v-if="props.item.has_instance_list || props.item.has_frame_packet_map"
+                    v-if="props.item.mode == 'update' || props.item.mode == 'update_with_existing'"
                     tooltip_message="Raw Instance List & Frame Map"
                     icon="mdi-dump-truck"
                     :icon_style="true"

--- a/shared/database/input.py
+++ b/shared/database/input.py
@@ -290,6 +290,12 @@ class Input(Base):
             'newly_copied_file_id': self.newly_copied_file_id
         }
 
+    def serialize_with_frame_packet(self):
+        result = self.serialize()
+        result['frame_packet_map'] = self.frame_packet_map
+        result['instance_list'] = self.instance_list
+        return result
+
     @staticmethod
     def directory_not_equal_to_status(
             session,

--- a/walrus/methods/input/input_view_detail.py
+++ b/walrus/methods/input/input_view_detail.py
@@ -22,9 +22,7 @@ def input_view_detail_api(project_string_id, input_id):
 
     log = regular_log.default()
 
-
     with sessionMaker.session_scope() as session:
-
         project = Project.get(session, project_string_id)
 
         # MAIN
@@ -32,7 +30,7 @@ def input_view_detail_api(project_string_id, input_id):
             session = session,
             project = project,
             input_id = input_id,
-            log=log,
+            log = log,
         )
         if len(log["error"].keys()) >= 1:
             return jsonify(log = log), 400
@@ -43,10 +41,10 @@ def input_view_detail_api(project_string_id, input_id):
 
 
 def input_detail_core(
-        session,
-        project: Project,
-        input_id: int,
-        log: dict):
+    session,
+    project: Project,
+    input_id: int,
+    log: dict):
     """
         TODO put as part of Input class
     """

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -777,6 +777,13 @@ class Process_Media():
         global New_video  # important
         from methods.video.video import New_video
 
+        if not self.input.frame_packet_map:
+            self.input.update_log['error']['frame_packet_map'] = 'Please provide a frame packet map. It cannot be empty.'
+            self.input.status = 'error'
+            self.input.status_text = "Please provide a frame packet map. It cannot be empty.'"
+            return
+
+
         # TODO "new video" name makes less sense in new context
         new_video = New_video(
             session=self.session,

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -779,8 +779,10 @@ class Process_Media():
 
         if not self.input.frame_packet_map:
             self.input.update_log['error']['frame_packet_map'] = 'Please provide a frame packet map. It cannot be empty.'
-            self.input.status = 'error'
+            self.input.status = 'failed'
             self.input.status_text = "Please provide a frame packet map. It cannot be empty.'"
+            self.session.add(self.input)
+            self.try_to_commit()
             return
 
 


### PR DESCRIPTION
When processing an update and receiving an empty frame packet map in the video case, the input status was stuck at "processing" and never failed.