### PR TITLE
Better handle errors in updating from frame packet map.

### DIFF
--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -800,6 +800,7 @@ class Process_Media():
             self.input.update_log['error']['update_from_frame_packet_map'] = str(e)
             self.input.status = 'failed'
             self.session.add(self.input)
+            logger.error(e)
 
 
         if len(self.input.update_log["error"].keys()) >= 1:

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -793,7 +793,14 @@ class Process_Media():
             input=self.input
         )
 
-        new_video.update_from_frame_packet_map()
+        try:
+            new_video.update_from_frame_packet_map()
+        except Exception as e:
+            traceback.format_exc()
+            self.input.update_log['error']['update_from_frame_packet_map'] = str(e)
+            self.input.status = 'failed'
+            self.session.add(self.input)
+
 
         if len(self.input.update_log["error"].keys()) >= 1:
             self.input = self.update_video_status_when_update_has_errors(input = self.input)  # 'parent' here not frame


### PR DESCRIPTION
Error should be a dict and not a string value.