### PR TITLE
Make use of alembic inside test context too.

### DIFF
--- a/default/tests/conftest.py
+++ b/default/tests/conftest.py
@@ -2,8 +2,14 @@ from shared.settings import settings
 from sqlalchemy_utils import database_exists, create_database
 from sqlalchemy_utils.functions import drop_database
 from sqlalchemy import create_engine
-from shared.database_setup_supporting import *
+import alembic.config
+import pathlib
+import os
 
+parent_path = pathlib.Path(__file__).parent.parent.parent.absolute()
+init_config_path = '{}/shared'.format(parent_path)
+
+os.chdir(init_config_path)
 if settings.DIFFGRAM_SYSTEM_MODE != 'testing':
     raise Exception('DIFFGRAM_SYSTEM_MODE must be in "testing" mode to perform any kind of test')
 
@@ -19,9 +25,13 @@ def pytest_configure(config):
     print('Checking DB: {}'.format(settings.DATABASE_URL))
     if not database_exists(engine.url):
         print('Creating DB: {}'.format(settings.DATABASE_URL))
-        from shared.database.core import Base
         create_database(engine.url)
-        Base.metadata.create_all(engine)
+        alembic_args = [
+            '--raiseerr',
+            'upgrade',
+            'head',
+        ]
+        alembic.config.main(argv = alembic_args)
         print('Database created successfully.')
     engine.dispose()
 

--- a/default/tests/shared/database/model/test_model_run.py
+++ b/default/tests/shared/database/model/test_model_run.py
@@ -56,7 +56,7 @@ class TestModelRun(testing_setup.DiffgramBaseTestCase):
     def test_get_by_id(self):
         model = Model.new(
             session = self.session,
-            reference_id = 'test_model',
+            reference_id = 'test_model_2',
             project_id = self.project.id,
             member_created_id = self.member.id,
             add_to_session = True,
@@ -64,7 +64,7 @@ class TestModelRun(testing_setup.DiffgramBaseTestCase):
         )
         model_run = ModelRun.new(
             session = self.session,
-            reference_id = 'test_model_run',
+            reference_id = 'test_model_run_2',
             project_id = self.project.id,
             member_created_id = self.member.id,
             add_to_session = True,
@@ -79,7 +79,7 @@ class TestModelRun(testing_setup.DiffgramBaseTestCase):
     def test_get_by_reference(self):
         model = Model.new(
             session = self.session,
-            reference_id = 'test_model',
+            reference_id = 'test_model_3',
             project_id = self.project.id,
             member_created_id = self.member.id,
             add_to_session = True,
@@ -87,7 +87,7 @@ class TestModelRun(testing_setup.DiffgramBaseTestCase):
         )
         model_run = ModelRun.new(
             session = self.session,
-            reference_id = 'test_model_run',
+            reference_id = 'test_model_run_3',
             project_id = self.project.id,
             member_created_id = self.member.id,
             add_to_session = True,
@@ -102,7 +102,7 @@ class TestModelRun(testing_setup.DiffgramBaseTestCase):
     def test_list(self):
         model = Model.new(
             session = self.session,
-            reference_id = 'test_model',
+            reference_id = 'test_model_4',
             project_id = self.project.id,
             member_created_id = self.member.id,
             add_to_session = True,
@@ -110,7 +110,7 @@ class TestModelRun(testing_setup.DiffgramBaseTestCase):
         )
         model_run1 = ModelRun.new(
             session = self.session,
-            reference_id = 'test_model_run',
+            reference_id = 'test_model_run_4',
             project_id = self.project.id,
             member_created_id = self.member.id,
             add_to_session = True,
@@ -119,7 +119,7 @@ class TestModelRun(testing_setup.DiffgramBaseTestCase):
         )
         model_run2 = ModelRun.new(
             session = self.session,
-            reference_id = 'test_model_run',
+            reference_id = 'test_model_run_5',
             project_id = self.project.id,
             member_created_id = self.member.id,
             add_to_session = True,
@@ -129,7 +129,7 @@ class TestModelRun(testing_setup.DiffgramBaseTestCase):
 
         model_run3 = ModelRun.new(
             session = self.session,
-            reference_id = 'test_model_run',
+            reference_id = 'test_model_run_6',
             project_id = self.project.id,
             member_created_id = self.member.id,
             add_to_session = True,

--- a/walrus/tests/conftest.py
+++ b/walrus/tests/conftest.py
@@ -2,7 +2,15 @@ from shared.settings import settings
 from sqlalchemy_utils import database_exists, create_database
 from sqlalchemy_utils.functions import drop_database
 from sqlalchemy import create_engine
+import alembic.config
+import pathlib
+import os
 from shared.database_setup_supporting import *
+
+parent_path = pathlib.Path(__file__).parent.parent.parent.absolute()
+init_config_path = '{}/shared'.format(parent_path)
+
+os.chdir(init_config_path)
 
 if settings.DIFFGRAM_SYSTEM_MODE != 'testing':
     raise Exception('DIFFGRAM_SYSTEM_MODE must be in "testing" mode to perform any kind of test')
@@ -19,9 +27,13 @@ def pytest_configure(config):
     print('Checking DB: {}'.format(settings.DATABASE_URL))
     if not database_exists(engine.url):
         print('Creating DB: {}'.format(settings.DATABASE_URL))
-        from shared.database.core import Base
         create_database(engine.url)
-        Base.metadata.create_all(engine)
+        alembic_args = [
+            '--raiseerr',
+            'upgrade',
+            'head',
+        ]
+        alembic.config.main(argv = alembic_args)
         print('Database created successfully.')
     engine.dispose()
 


### PR DESCRIPTION
This allows us to indirectly test that the migrations have been done correctly setup and that we can guarantee creating the DB from scratch with the current migrations that exist in the codebase.