### PR TITLE
Add support for nested keys in JSON

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "debounce": "^1.2.0",
     "filesize": "^6.3.0",
     "highlight.js": "^10.6.0",
+    "lodash": "^4.17.21",
     "lodash.debounce": "^4.0.8",
     "mailslurp-client": "^10.2.1",
     "mathjs": "^7.5.1",

--- a/frontend/src/components/input/file_schema_mapper.vue
+++ b/frontend/src/components/input/file_schema_mapper.vue
@@ -282,7 +282,7 @@
   import Vue from "vue";
   import {v4 as uuidv4} from 'uuid';
   import filesize from 'filesize';
-
+  import { _get } from "lodash";
   export default Vue.extend({
       name: 'file_schema_mapper',
       components: {},
@@ -367,7 +367,7 @@
         validate_file_names: function () {
           const file_name_list = [];
           for (const instance of this.$props.pre_labeled_data) {
-            const file_name = instance[this.$props.diffgram_schema_mapping.file_name];
+            const file_name = _get(instance, this.$props.diffgram_schema_mapping.file_name);
             if (typeof file_name === 'number') {
               this.errors_file_schema = {};
               this.errors_file_schema[this.$props.diffgram_schema_mapping.file_name] = `File name should be a string not a number.`;
@@ -492,15 +492,16 @@
               const labels = response.data.labels_out;
               const label_names = labels.map(elm => elm.label.name)
               for (const instance of this.$props.pre_labeled_data) {
-                if (!label_names.includes(instance[this.diffgram_schema_mapping.name])) {
+                let label_name = _get(instance, this.diffgram_schema_mapping.name)
+                if (!label_names.includes(label_name)) {
                   this.errors_file_schema = {}
-                  this.errors_file_schema['label_names'] = `The label name "${instance[this.diffgram_schema_mapping.name]}" does not exist in the project. Please create it.`
+                  this.errors_file_schema['label_names'] = `The label name "${label_name}" does not exist in the project. Please create it.`
                   this.show_labels_link = false;
                   this.valid_labels = false;
                   this.load_label_names = false;
                   return false
                 } else {
-                  const label = labels.find(l => l.label.name === instance[this.diffgram_schema_mapping.name]);
+                  const label = labels.find(l => l.label.name === label_name);
                   instance.label_file_id = label.id;
                 }
               }
@@ -521,14 +522,16 @@
             return true
           }
           for (const instance of this.$props.pre_labeled_data) {
-            const related_file = this.file_list_to_upload.find(f => f.name === instance[this.diffgram_schema_mapping.file_name]);
+            const file_name = _get(instance, this.diffgram_schema_mapping.file_name);
+            const related_file = this.file_list_to_upload.find(f => f.name === file_name);
             if (!related_file) {
-              this.errors_file_schema['file_name'] = `No file named: ${instance[this.diffgram_schema_mapping.file_name]}`;
+              this.errors_file_schema['file_name'] = `No file named: ${file_name}`;
               this.errors_file_schema['wrong_data'] = JSON.stringify(instance);
               return false
             }
             if (this.supported_video_files.includes(related_file.type)) {
-              if (instance[this.diffgram_schema_mapping.frame_number] == undefined) {
+              let frame_number = _get(instance, this.diffgram_schema_mapping.frame_number)
+              if (frame_number == undefined) {
                 this.errors_file_schema = {}
                 this.errors_file_schema['frame_number'] = `Provide frame numbers.`
                 this.errors_file_schema['wrong_data'] = JSON.stringify(instance)
@@ -543,14 +546,16 @@
             return true
           }
           for (const instance of this.$props.pre_labeled_data) {
-            const related_file = this.file_list_to_upload.find(f => f.name === instance[this.diffgram_schema_mapping.file_name]);
+            const file_name = _get(instance, this.diffgram_schema_mapping.file_name);
+            const related_file = this.file_list_to_upload.find(f => f.name === file_name);
             if (!related_file) {
-              this.errors_file_schema['file_name'] = `No file named: ${instance[this.diffgram_schema_mapping.file_name]}`;
+              this.errors_file_schema['file_name'] = `No file named: ${file_name}`;
               this.errors_file_schema['wrong_data'] = JSON.stringify(instance);
               return false
             }
             if (this.supported_video_files.includes(related_file.type)) {
-              if (instance[this.diffgram_schema_mapping.number] == undefined) {
+              const seq_number = _get(instance, this.diffgram_schema_mapping.number);
+              if (seq_number == undefined) {
                 this.errors_file_schema = {}
                 this.errors_file_schema['sequence_numbers'] = `Provide Sequence numbers.`
                 this.errors_file_schema['wrong_data'] = JSON.stringify(instance)
@@ -565,7 +570,7 @@
             if (this.upload_mode !== 'update') {
               return true
             }
-            const file_id_list = this.$props.pre_labeled_data.map(inst => inst[this.diffgram_schema_mapping.file_id]);
+            const file_id_list = this.$props.pre_labeled_data.map(inst => _get(inst, this.diffgram_schema_mapping.file_id));
             for (const id of file_id_list) {
               if (isNaN(id)) {
                 this.errors_file_schema['file_ids'] = 'File IDs must be numbers.'
@@ -597,9 +602,8 @@
             this.$props.included_instance_types[key] = false;
           }
           for (const elm of this.$props.pre_labeled_data) {
-            if (elm[this.diffgram_schema_mapping.instance_type]) {
-
-              const instance_type = elm[this.diffgram_schema_mapping.instance_type];
+            const instance_type = _get(elm, this.diffgram_schema_mapping.instance_type)
+            if (instance_type) {
               if (this.allowed_instance_types.includes(instance_type)) {
                 this.included_instance_types[instance_type] = true;
               } else {

--- a/frontend/src/components/input/file_schema_mapper.vue
+++ b/frontend/src/components/input/file_schema_mapper.vue
@@ -282,7 +282,7 @@
   import Vue from "vue";
   import {v4 as uuidv4} from 'uuid';
   import filesize from 'filesize';
-  import { _get } from "lodash";
+  import _ from "lodash";
   export default Vue.extend({
       name: 'file_schema_mapper',
       components: {},
@@ -367,7 +367,7 @@
         validate_file_names: function () {
           const file_name_list = [];
           for (const instance of this.$props.pre_labeled_data) {
-            const file_name = _get(instance, this.$props.diffgram_schema_mapping.file_name);
+            const file_name = _.get(instance, this.$props.diffgram_schema_mapping.file_name);
             if (typeof file_name === 'number') {
               this.errors_file_schema = {};
               this.errors_file_schema[this.$props.diffgram_schema_mapping.file_name] = `File name should be a string not a number.`;
@@ -492,7 +492,7 @@
               const labels = response.data.labels_out;
               const label_names = labels.map(elm => elm.label.name)
               for (const instance of this.$props.pre_labeled_data) {
-                let label_name = _get(instance, this.diffgram_schema_mapping.name)
+                let label_name = _.get(instance, this.diffgram_schema_mapping.name)
                 if (!label_names.includes(label_name)) {
                   this.errors_file_schema = {}
                   this.errors_file_schema['label_names'] = `The label name "${label_name}" does not exist in the project. Please create it.`
@@ -522,7 +522,7 @@
             return true
           }
           for (const instance of this.$props.pre_labeled_data) {
-            const file_name = _get(instance, this.diffgram_schema_mapping.file_name);
+            const file_name = _.get(instance, this.diffgram_schema_mapping.file_name);
             const related_file = this.file_list_to_upload.find(f => f.name === file_name);
             if (!related_file) {
               this.errors_file_schema['file_name'] = `No file named: ${file_name}`;
@@ -530,7 +530,7 @@
               return false
             }
             if (this.supported_video_files.includes(related_file.type)) {
-              let frame_number = _get(instance, this.diffgram_schema_mapping.frame_number)
+              let frame_number = _.get(instance, this.diffgram_schema_mapping.frame_number)
               if (frame_number == undefined) {
                 this.errors_file_schema = {}
                 this.errors_file_schema['frame_number'] = `Provide frame numbers.`
@@ -546,7 +546,7 @@
             return true
           }
           for (const instance of this.$props.pre_labeled_data) {
-            const file_name = _get(instance, this.diffgram_schema_mapping.file_name);
+            const file_name = _.get(instance, this.diffgram_schema_mapping.file_name);
             const related_file = this.file_list_to_upload.find(f => f.name === file_name);
             if (!related_file) {
               this.errors_file_schema['file_name'] = `No file named: ${file_name}`;
@@ -554,7 +554,7 @@
               return false
             }
             if (this.supported_video_files.includes(related_file.type)) {
-              const seq_number = _get(instance, this.diffgram_schema_mapping.number);
+              const seq_number = _.get(instance, this.diffgram_schema_mapping.number);
               if (seq_number == undefined) {
                 this.errors_file_schema = {}
                 this.errors_file_schema['sequence_numbers'] = `Provide Sequence numbers.`
@@ -570,7 +570,7 @@
             if (this.upload_mode !== 'update') {
               return true
             }
-            const file_id_list = this.$props.pre_labeled_data.map(inst => _get(inst, this.diffgram_schema_mapping.file_id));
+            const file_id_list = this.$props.pre_labeled_data.map(inst => _.get(inst, this.diffgram_schema_mapping.file_id));
             for (const id of file_id_list) {
               if (isNaN(id)) {
                 this.errors_file_schema['file_ids'] = 'File IDs must be numbers.'
@@ -602,7 +602,7 @@
             this.$props.included_instance_types[key] = false;
           }
           for (const elm of this.$props.pre_labeled_data) {
-            const instance_type = _get(elm, this.diffgram_schema_mapping.instance_type)
+            const instance_type = _.get(elm, this.diffgram_schema_mapping.instance_type)
             if (instance_type) {
               if (this.allowed_instance_types.includes(instance_type)) {
                 this.included_instance_types[instance_type] = true;

--- a/frontend/src/components/input/instance_schema_mapper.vue
+++ b/frontend/src/components/input/instance_schema_mapper.vue
@@ -459,7 +459,7 @@
   import Vue from "vue";
   import {v4 as uuidv4} from 'uuid';
   import filesize from 'filesize';
-
+  import { _get } from "lodash";
   export default Vue.extend({
       name: 'instance_schema_mapper',
       components: {},
@@ -667,9 +667,10 @@
             const key_name_local = this.diffgram_schema_mapping.box[key_name];
             const box_labels = this.pre_labeled_data.filter(inst => inst.type === 'box');
             for (const box_instance of box_labels) {
-              if (isNaN(box_instance[key_name_local])) {
+              const box_coord = _get(box_instance, key_name_local);
+              if ( isNaN( box_coord ) ) {
                 this.error_box_instance[key_name][key_name_local] = 'Value should be a number';
-                this.error_box_instance[key_name]['wrong_data'] = JSON.stringify(box_instance[key_name_local]);
+                this.error_box_instance[key_name]['wrong_data'] = JSON.stringify(box_coord);
                 return
               }
             }
@@ -698,9 +699,10 @@
             const key_name_local = this.diffgram_schema_mapping.ellipse[key_name];
             const ellipse_labels = this.pre_labeled_data.filter(inst => inst.type === 'ellipse');
             for (const ellipse_instance of ellipse_labels) {
-              if (isNaN(ellipse_instance[key_name_local])) {
+              let ellipse_coord = _get(ellipse_instance, key_name_local)
+              if (isNaN(ellipse_coord)) {
                 this.error_ellipse_instance[key_name][key_name_local] = 'Value should be a number';
-                this.error_ellipse_instance[key_name]['wrong_data'] = JSON.stringify(ellipse_instance[key_name_local]);
+                this.error_ellipse_instance[key_name]['wrong_data'] = JSON.stringify(ellipse_coord);
                 return
               }
             }
@@ -755,9 +757,10 @@
             const key_name_local = this.diffgram_schema_mapping.cuboid[key_name];
             const cuboid_labels = this.pre_labeled_data.filter(inst => inst.type === 'cuboid');
             for (const cuboid_instance of cuboid_labels) {
-              if (isNaN(cuboid_instance[key_name_local])) {
+              let cuboid_coord = _get(cuboid_instance, key_name_local);
+              if (isNaN(cuboid_coord)) {
                 this.error_cuboid_instance[key_name][key_name_local] = 'Value should be a number';
-                this.error_cuboid_instance[key_name]['wrong_data'] = JSON.stringify(cuboid_instance[key_name_local]);
+                this.error_cuboid_instance[key_name]['wrong_data'] = JSON.stringify(cuboid_coord);
                 return
               }
             }
@@ -774,9 +777,10 @@
             const key_name_local = this.diffgram_schema_mapping.line[key_name];
             const line_labels = this.pre_labeled_data.filter(inst => inst.type === 'line');
             for (const line_instance of line_labels) {
-              if (isNaN(line_instance[key_name_local])) {
+              let line_coord = _get(line_instance, key_name_local);
+              if (isNaN(line_coord)) {
                 this.error_line_instance[key_name][key_name_local] = 'Value should be a number';
-                this.error_line_instance[key_name]['wrong_data'] = JSON.stringify(line_instance[key_name_local]);
+                this.error_line_instance[key_name]['wrong_data'] = JSON.stringify(line_coord);
                 return
               }
             }
@@ -793,9 +797,10 @@
             const key_name_local = this.diffgram_schema_mapping.point[key_name];
             const point_labels = this.pre_labeled_data.filter(inst => inst.type === 'point');
             for (const point_instance of point_labels) {
-              if (isNaN(point_instance[key_name_local])) {
+              let point_coord = _get(point_instance, key_name_local)
+              if (isNaN(point_coord)) {
                 this.error_point_instance[key_name][key_name_local] = 'Value should be a number';
-                this.error_point_instance[key_name]['wrong_data'] = JSON.stringify(point_instance[key_name_local]);
+                this.error_point_instance[key_name]['wrong_data'] = JSON.stringify(point_coord);
                 return
               }
             }
@@ -812,7 +817,7 @@
             const polygon_labels = this.pre_labeled_data.filter(inst => inst.type === 'polygon');
             let i = 0;
             for (const polygon_instance of polygon_labels) {
-              const value = polygon_instance[key_name];
+              const value = _get(polygon_instance, key_name);
               if (!Array.isArray(value)) {
                 this.error_polygon_instance['points'] = 'Points should have an array of X,Y values objects({x: number, y: number})';
                 return
@@ -821,7 +826,7 @@
                 if ((!point.x || isNaN(point.x)) || (!point.y || isNaN(point.y))) {
                   this.error_polygon_instance['points'] = 'Points should have an array of X,Y values objects({x: number, y: number})'
                   this.error_polygon_instance['row_number'] = i
-                  this.error_polygon_instance['data'] = JSON.stringify(polygon_instance[key_name_local]);
+                  this.error_polygon_instance['data'] = JSON.stringify(value);
                   return
                 }
               }
@@ -853,9 +858,9 @@
           }
           let result = '';
           for (const instance of this.pre_labeled_data.slice(0, 10)) {
-            let value = instance[this.diffgram_schema_mapping[instance_type][key]];
+            let value = _get(instance, this.diffgram_schema_mapping[instance_type][key]);
             if(typeof value === "object"){
-              value = JSON.stringify(instance[this.diffgram_schema_mapping[instance_type][key]]);
+              value = JSON.stringify(value);
             }
             if (value) {
               result += `${value}, \n`
@@ -871,9 +876,9 @@
             return false
           }
           for (const instance of this.pre_labeled_data) {
-            let x_points = instance[this.diffgram_schema_mapping.polygon.points_x];
-            x_points = x_points.split(';').map(x => parseInt(x, 10))
-            let y_points = instance[this.diffgram_schema_mapping.polygon.points_y];
+            let x_points = _get(instance, this.diffgram_schema_mapping.polygon.points_x);
+            x_points = x_points.split(';').map(x => parseInt(x, 10));
+            let y_points = _get(instance, this.diffgram_schema_mapping.polygon.points_y);
             y_points = y_points.split(';').map(y => parseInt(y, 10))
             if (!x_points || !y_points) {
               this.errors_instance_schema = {};

--- a/frontend/src/components/input/instance_schema_mapper.vue
+++ b/frontend/src/components/input/instance_schema_mapper.vue
@@ -459,7 +459,7 @@
   import Vue from "vue";
   import {v4 as uuidv4} from 'uuid';
   import filesize from 'filesize';
-  import { _get } from "lodash";
+  import _ from "lodash";
   export default Vue.extend({
       name: 'instance_schema_mapper',
       components: {},
@@ -667,7 +667,7 @@
             const key_name_local = this.diffgram_schema_mapping.box[key_name];
             const box_labels = this.pre_labeled_data.filter(inst => inst.type === 'box');
             for (const box_instance of box_labels) {
-              const box_coord = _get(box_instance, key_name_local);
+              const box_coord = _.get(box_instance, key_name_local);
               if ( isNaN( box_coord ) ) {
                 this.error_box_instance[key_name][key_name_local] = 'Value should be a number';
                 this.error_box_instance[key_name]['wrong_data'] = JSON.stringify(box_coord);
@@ -699,7 +699,7 @@
             const key_name_local = this.diffgram_schema_mapping.ellipse[key_name];
             const ellipse_labels = this.pre_labeled_data.filter(inst => inst.type === 'ellipse');
             for (const ellipse_instance of ellipse_labels) {
-              let ellipse_coord = _get(ellipse_instance, key_name_local)
+              let ellipse_coord = _.get(ellipse_instance, key_name_local)
               if (isNaN(ellipse_coord)) {
                 this.error_ellipse_instance[key_name][key_name_local] = 'Value should be a number';
                 this.error_ellipse_instance[key_name]['wrong_data'] = JSON.stringify(ellipse_coord);
@@ -757,7 +757,7 @@
             const key_name_local = this.diffgram_schema_mapping.cuboid[key_name];
             const cuboid_labels = this.pre_labeled_data.filter(inst => inst.type === 'cuboid');
             for (const cuboid_instance of cuboid_labels) {
-              let cuboid_coord = _get(cuboid_instance, key_name_local);
+              let cuboid_coord = _.get(cuboid_instance, key_name_local);
               if (isNaN(cuboid_coord)) {
                 this.error_cuboid_instance[key_name][key_name_local] = 'Value should be a number';
                 this.error_cuboid_instance[key_name]['wrong_data'] = JSON.stringify(cuboid_coord);
@@ -777,7 +777,7 @@
             const key_name_local = this.diffgram_schema_mapping.line[key_name];
             const line_labels = this.pre_labeled_data.filter(inst => inst.type === 'line');
             for (const line_instance of line_labels) {
-              let line_coord = _get(line_instance, key_name_local);
+              let line_coord = _.get(line_instance, key_name_local);
               if (isNaN(line_coord)) {
                 this.error_line_instance[key_name][key_name_local] = 'Value should be a number';
                 this.error_line_instance[key_name]['wrong_data'] = JSON.stringify(line_coord);
@@ -797,7 +797,7 @@
             const key_name_local = this.diffgram_schema_mapping.point[key_name];
             const point_labels = this.pre_labeled_data.filter(inst => inst.type === 'point');
             for (const point_instance of point_labels) {
-              let point_coord = _get(point_instance, key_name_local)
+              let point_coord = _.get(point_instance, key_name_local)
               if (isNaN(point_coord)) {
                 this.error_point_instance[key_name][key_name_local] = 'Value should be a number';
                 this.error_point_instance[key_name]['wrong_data'] = JSON.stringify(point_coord);
@@ -817,7 +817,7 @@
             const polygon_labels = this.pre_labeled_data.filter(inst => inst.type === 'polygon');
             let i = 0;
             for (const polygon_instance of polygon_labels) {
-              const value = _get(polygon_instance, key_name);
+              const value = _.get(polygon_instance, key_name);
               if (!Array.isArray(value)) {
                 this.error_polygon_instance['points'] = 'Points should have an array of X,Y values objects({x: number, y: number})';
                 return
@@ -858,7 +858,7 @@
           }
           let result = '';
           for (const instance of this.pre_labeled_data.slice(0, 10)) {
-            let value = _get(instance, this.diffgram_schema_mapping[instance_type][key]);
+            let value = _.get(instance, this.diffgram_schema_mapping[instance_type][key]);
             if(typeof value === "object"){
               value = JSON.stringify(value);
             }
@@ -876,9 +876,9 @@
             return false
           }
           for (const instance of this.pre_labeled_data) {
-            let x_points = _get(instance, this.diffgram_schema_mapping.polygon.points_x);
+            let x_points = _.get(instance, this.diffgram_schema_mapping.polygon.points_x);
             x_points = x_points.split(';').map(x => parseInt(x, 10));
-            let y_points = _get(instance, this.diffgram_schema_mapping.polygon.points_y);
+            let y_points = _.get(instance, this.diffgram_schema_mapping.polygon.points_y);
             y_points = y_points.split(';').map(y => parseInt(y, 10))
             if (!x_points || !y_points) {
               this.errors_instance_schema = {};

--- a/frontend/src/components/input/new_or_update_upload_screen.vue
+++ b/frontend/src/components/input/new_or_update_upload_screen.vue
@@ -332,6 +332,7 @@
           return {
             init: function () {
               this.on("addedfile", function (file) {
+                console.log('added file', file)
                 if (file.type === 'application/json' || file.type === 'text/csv') {
                   file.data_type = 'Annotations';
                 } else {

--- a/frontend/src/components/input/upload_wizard_sheet.vue
+++ b/frontend/src/components/input/upload_wizard_sheet.vue
@@ -657,12 +657,35 @@
           this.loading_sync_jobs = false;
           this.$emit('current_directory', this.current_directory)
         },
+        extract_object_keys(obj, prepend = undefined){
+          let result = [];
+          for (const key in obj) {
+
+            if(typeof obj[key] != 'object'){
+              if (!result.includes(key)) {
+                if(prepend){
+                  result.push(prepend + key)
+                }
+                else{
+                  result.push(key)
+                }
+
+              }
+            }
+            else{
+              const nested_result = this.extract_object_keys(obj[key], `${ prepend ? `${prepend}${key}` : key}.`);
+              result = result.concat(nested_result)
+            }
+          }
+          return result
+        },
 
         extract_pre_label_key_list: function (pre_labels_object) {
-          const result = []
+          const result = [];
           for (const elm of pre_labels_object) {
-            for (const key in elm) {
-              if (!result.includes(key)) {
+            const current_result = this.extract_object_keys(elm, undefined);
+            for(const key of current_result){
+              if(!result.includes(key)){
                 result.push(key)
               }
             }


### PR DESCRIPTION
I realized this is going to be a necessary step if we want to support more standard data formats like tensorflow or pytorch json format since they all use nested values on the ouput jsons. This way people can just download the standard coco dataset for example and reupload it to diffgram with the wizard or via the connections system.