### PR TITLE
fix: stop execution when having an exception on instance_list processing

### DIFF
--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -399,7 +399,7 @@ class Annotation_Update():
 
         self.left_over_instance_deletion()
 
-        self.instance_list_cache_update()
+        self.   instance_list_cache_update()
 
         if len(self.log["error"].keys()) == 0:
             self.log['success'] = True


### PR DESCRIPTION
Otherwise annotation_update is not available and raises an unhandled exception.