### PR TITLE
fix: when no label templates available there was an unhandled exception.

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -393,7 +393,7 @@
                               :height="canvas_height"
                               :width="canvas_width"
                               :show="show_target_reticle"
-                              :target_colour="current_label_file.colour"
+                              :target_colour="current_label_file ? current_label_file.colour : undefined"
                               :text_color="this.$get_sequence_color(this.current_instance.sequence_id)"
                               :target_text="this.current_instance.number"
                               :target_type="target_reticle_type"

--- a/frontend/src/components/label/label_select_annotation.vue
+++ b/frontend/src/components/label/label_select_annotation.vue
@@ -99,7 +99,10 @@
 
         </template>
 
-
+        <template v-slot:no-data>
+          No Labels Templates Created.
+          <v-btn color="primary" small @click="$router.push(`/project/${project_string_id}/labels`)">Create Label Templates</v-btn>
+        </template>
       </v-select>
 
     </v-layout>


### PR DESCRIPTION
current labels is undefined if not label templates have been created on the project. I also added a link to the label creation section when clicking the empty label list selector.