### PR TITLE
Public project support

### DIFF
--- a/default/methods/annotation/instance_template_list.py
+++ b/default/methods/annotation/instance_template_list.py
@@ -8,7 +8,7 @@ from shared.annotation import Annotation_Update
 
 
 @routes.route('/api/v1/project/<string:project_string_id>/instance-template/list', methods = ['POST'])
-@Project_permissions.user_has_project(Roles = ["admin", "Editor"], apis_user_list = ["api_enabled_builder"])
+@Project_permissions.user_has_project(Roles = ["admin", "Editor", "allow_if_project_is_public"], apis_user_list = ["api_enabled_builder"])
 def list_instance_template_api(project_string_id):
     """
         Fetch the list of instance templates in the project.

--- a/default/methods/annotation/labels/labels.py
+++ b/default/methods/annotation/labels/labels.py
@@ -103,7 +103,7 @@ def new_label_file_object_core(session, input, project_string_id, log):
 @routes.route('/api/project/<string:project_string_id>' +
               '/labels/refresh',
               methods = ['GET'])
-@Project_permissions.user_has_project(["admin", "Editor", "Viewer"])
+@Project_permissions.user_has_project(["admin", "Editor", "Viewer", "allow_if_project_is_public"])
 def labelRefresh(project_string_id):
     """
     Get labels from project

--- a/default/methods/discussions/discussion_list.py
+++ b/default/methods/discussions/discussion_list.py
@@ -7,7 +7,7 @@ from shared.database.discussion.discussion import Discussion
 
 
 @routes.route('/api/v1/project/<string:project_string_id>/discussions/list', methods = ['POST'])
-@Project_permissions.user_has_project(Roles = ["admin", "Editor"], apis_user_list = ["api_enabled_builder"])
+@Project_permissions.user_has_project(Roles = ["admin", "Editor", "allow_if_project_is_public"], apis_user_list = ["api_enabled_builder"])
 def discussion_list_web(project_string_id):
     """
         List all the discussion based on the given filters.
@@ -63,9 +63,10 @@ def discussion_list_web(project_string_id):
         if user:
             member = user.member
         else:
-            client_id = request.authorization.get('username', None)
-            auth = Auth_api.get(session, client_id)
-            member = auth.member
+            if request.authorization:
+                client_id = request.authorization.get('username', None)
+                auth = Auth_api.get(session, client_id)
+                member = auth.member
 
         issues_data, log = issue_list_core(
             session = session,

--- a/default/methods/model/model_run_list.py
+++ b/default/methods/model/model_run_list.py
@@ -6,7 +6,7 @@ except:
 from shared.database.model.model_run import ModelRun
 
 @routes.route('/api/v1/project/<string:project_string_id>/model-runs/list', methods = ['POST'])
-@Project_permissions.user_has_project(Roles = ["admin", "Editor"], apis_user_list = ["api_enabled_builder"])
+@Project_permissions.user_has_project(Roles = ["admin", "Editor", "allow_if_project_is_public"], apis_user_list = ["api_enabled_builder"])
 def model_run_list_web(project_string_id):
     """
         List all the discussion based on the given filters.

--- a/default/methods/source_control/file/file_browser.py
+++ b/default/methods/source_control/file/file_browser.py
@@ -377,13 +377,16 @@ def view_file_list_web_route(project_string_id, username):
             return jsonify("Error with directory"), 400
 
         user = User.get(session)
+        member = None
         if user:
             member = user.member
         else:
-            client_id = request.authorization.get('username', None)
-            auth = Auth_api.get(session, client_id)
-            member = auth.member
-
+            # In some cases there can be no authorization (since project can be public)
+            # So we check if authorization exists in request.
+            if request.authorization:
+                client_id = request.authorization.get('username', None)
+                auth = Auth_api.get(session, client_id)
+                member = auth.member
         file_browser_instance = File_Browser(
             session = session,
             project = project,

--- a/default/methods/source_control/file/file_browser.py
+++ b/default/methods/source_control/file/file_browser.py
@@ -56,7 +56,7 @@ def view_file_by_id():  # Assumes permissions handled later with Project_permiss
 
         Project_permissions.by_project_core(
             project_string_id = input['project_string_id'],
-            Roles = ["admin", "Editor", "Viewer"])
+            Roles = ["admin", "Editor", "Viewer", "allow_if_project_is_public"])
 
         project = Project.get(
             session = session,

--- a/default/methods/userscript/userscript.py
+++ b/default/methods/userscript/userscript.py
@@ -223,8 +223,8 @@ def __userscript_update(
               '/userscript/list',
               methods=['POST'])
 @Project_permissions.user_has_project(
-    Roles=["admin", "Editor", "Viewer"],
-    apis_user_list=['api_enabled_builder', 'security_email_verified', 'allow_if_project_is_public'])
+    Roles=["admin", "Editor", "Viewer", "allow_if_project_is_public"],
+    apis_user_list=['api_enabled_builder', 'security_email_verified'])
 def list_userscript_api(project_string_id):
     """
 

--- a/default/methods/userscript/userscript.py
+++ b/default/methods/userscript/userscript.py
@@ -224,7 +224,7 @@ def __userscript_update(
               methods=['POST'])
 @Project_permissions.user_has_project(
     Roles=["admin", "Editor", "Viewer"],
-    apis_user_list=['api_enabled_builder', 'security_email_verified'])
+    apis_user_list=['api_enabled_builder', 'security_email_verified', 'allow_if_project_is_public'])
 def list_userscript_api(project_string_id):
     """
 

--- a/default/methods/video/sequence.py
+++ b/default/methods/video/sequence.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import joinedload
 			  '/video/single/<int:video_file_id>' +
 			  '/sequence/list', 
 			  methods=['GET'])
-@Project_permissions.user_has_project(["admin", "Editor", "Viewer"])
+@Project_permissions.user_has_project(["admin", "Editor", "Viewer", "allow_if_project_is_public"])
 def get_sequence(project_string_id, video_file_id):
 
 	start_time = time.time()
@@ -71,7 +71,7 @@ def get_sequence_from_label_using_task(task_id, label_file_id):
 			  '/label/<int:label_file_id>'
 			  '/sequence/list', 
 			  methods=['GET'])
-@Project_permissions.user_has_project(["admin", "Editor", "Viewer"])
+@Project_permissions.user_has_project(["admin", "Editor", "Viewer", "allow_if_project_is_public"])
 def get_sequence_from_label(project_string_id, video_file_id, label_file_id):
 
 	with sessionMaker.session_scope() as session:

--- a/default/methods/video/video_view.py
+++ b/default/methods/video/video_view.py
@@ -36,7 +36,7 @@ def get_video_single_image(project_string_id, video_parent_file_id, frame_number
 			  methods=['POST'],  defaults={'task_id': -1})
 @PermissionTaskOrProject.by_task_or_project_wrapper(
     apis_user_list = ["builder_or_trainer"],
-    roles = ["admin", "Editor", "Viewer"])
+    roles = ["admin", "Editor", "Viewer", "allow_if_project_is_public"])
 def get_video_image_list(project_string_id, task_id, video_parent_file_id):
 
 	spec_list = [{"frame_list" : {

--- a/frontend/cypress/integration/diffgram/user/user_login_spec.js
+++ b/frontend/cypress/integration/diffgram/user/user_login_spec.js
@@ -14,6 +14,7 @@ describe('Login Flow tests', function () {
       'action',
       'ai',
       'alert',
+      'public_project',
       'annotation_assignment',
       'annotation_project',
       'annotation_state',

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -5461,17 +5461,29 @@ export default Vue.extend( {
 
     },
     get_instance_list_for_image: async function(){
-      if (this.$store.state.builder_or_trainer.mode == "builder") {
-        let file = this.$props.file;
+      let url = undefined;
+      let file = this.$props.file;
+      if(this.$store.getters.is_on_public_project){
+        url = `/api/project/${this.$props.project_string_id}/file/${String(this.$props.file.id)}/annotation/list`;
+
+        const response = await axios.post(url, {
+          directory_id : this.$store.state.project.current_directory.directory_id,
+          job_id : this.job_id,
+          attached_to_job: file.attached_to_job
+        })
+        this.get_instances_core(response)
+        this.annotations_loading = false
+
+      }
+      else if (this.$store.state.builder_or_trainer.mode == "builder") {
         if (this.task && this.task.id) {
           // If a task is present, prefer this route to handle permissions
-          var url = '/api/v1/task/' + this.task.id + '/annotation/list';
+          url = '/api/v1/task/' + this.task.id + '/annotation/list';
           file = this.$props.task.file;
 
         } else {
 
-          var url = '/api/project/' + this.$props.project_string_id +
-            '/file/' + String(this.$props.file.id) + '/annotation/list'
+          url = `/api/project/${this.$props.project_string_id}/file/${String(this.$props.file.id)}/annotation/list`
         }
         try{
           const response = await axios.post(url, {
@@ -5489,21 +5501,20 @@ export default Vue.extend( {
         }
         return
       }
-
-
-      if (this.$store.state.builder_or_trainer.mode == "trainer") {
-        var url = '/api/v1/task/' + this.task.id +
+      else if (this.$store.state.builder_or_trainer.mode == "trainer") {
+        url = '/api/v1/task/' + this.task.id +
           '/annotation/list'
+        try{
+          const response = await axios.get(url, {})
+          this.get_instances_core(response)
+          this.annotations_loading = false
+        }
+        catch(error){
+          console.debug(error);
+          this.loading = false
+        }
       }
-      try{
-        const response = await axios.get(url, {})
-        this.get_instances_core(response)
-        this.annotations_loading = false
-      }
-      catch(error){
-        console.debug(error);
-        this.loading = false
-      }
+
     },
     add_override_colors_for_model_runs: function(){
       if(!this.model_run_list){
@@ -5601,6 +5612,7 @@ export default Vue.extend( {
       this.show_annotations = false
       this.loading = true
       this.annotations_loading = true
+
       this.instance_buffer_error = {}
 
       this.instance_frame_start = this.current_frame

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -2,7 +2,7 @@
   <div id="annotation_core">
 
 
-    <div>
+    <div style="position: relative">
 
 
       <main_menu :height="`${show_default_navigation ? '100px' : '50px'}`"
@@ -52,16 +52,10 @@
                    >
           </toolbar>
 
-        <v-alert v-if="view_only_mode == true"
-                    type="info"
-                    icon="mdi-eye"
-                    width="250px"
-                    height="30px"
-                    class="ma-auto align-self-center d-flex justify-center align-center mr-5" >
-            View only
-        </v-alert>
+
 
         </template>
+
       </main_menu>
 
       <!-- Errors / info -->

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -76,6 +76,7 @@
 
     </div>
     <v-snackbar
+      v-if="snackbar_issues"
       v-model="snackbar_issues"
       :multi-line="true"
       :timeout="-1"
@@ -95,6 +96,7 @@
     </v-snackbar>
 
     <v-snackbar
+      v-if="show_custom_snackbar"
       v-model="show_custom_snackbar"
       :multi-line="true"
       :timeout="-1"
@@ -115,6 +117,7 @@
 
 
     <v-snackbar
+      v-if="show_snackbar_auto_border"
       v-model="show_snackbar_auto_border"
       :multi-line="true"
       :timeout="-1"
@@ -133,6 +136,7 @@
       </template>
     </v-snackbar>
     <v-snackbar
+      v-if="show_snackbar_paste"
       v-model="show_snackbar_paste"
       :multi-line="true"
       :timeout="5000"

--- a/frontend/src/components/annotation/annotation_ui_factory.vue
+++ b/frontend/src/components/annotation/annotation_ui_factory.vue
@@ -127,12 +127,14 @@
         if (this.$route.query.view_only) {
           this.view_only = true;
         }
-        if (this.$props.task_id_prop) {
-          this.add_visit_history_event('task');
-        } else if (this.$props.file_id_prop) {
-          this.add_visit_history_event('file');
-        } else {
-          this.add_visit_history_event('page')
+        if(!this.$store.getters.is_on_public_project){
+          if (this.$props.task_id_prop) {
+            this.add_visit_history_event('task');
+          } else if (this.$props.file_id_prop) {
+            this.add_visit_history_event('file');
+          } else {
+            this.add_visit_history_event('page')
+          }
         }
 
       },
@@ -154,7 +156,6 @@
         }
       },
       computed: {
-
         file_id: function () {
           let file_id = this.$props.file_id_prop;
           if (this.$route.query.file) {

--- a/frontend/src/components/annotation/annotation_ui_factory.vue
+++ b/frontend/src/components/annotation/annotation_ui_factory.vue
@@ -128,6 +128,7 @@
           this.view_only = true;
         }
         if(!this.$store.getters.is_on_public_project){
+
           if (this.$props.task_id_prop) {
             this.add_visit_history_event('task');
           } else if (this.$props.file_id_prop) {
@@ -135,6 +136,9 @@
           } else {
             this.add_visit_history_event('page')
           }
+        }
+        else{
+          this.view_only = true;
         }
 
       },

--- a/frontend/src/components/annotation/annotation_ui_factory.vue
+++ b/frontend/src/components/annotation/annotation_ui_factory.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="overflow-x:auto;">
+  <div>
 
     <div id="annotation_ui_factory" tabindex="0">
       <div v-if="show_annotation_core == true">

--- a/frontend/src/components/annotation/instance_detail_list_view.vue
+++ b/frontend/src/components/annotation/instance_detail_list_view.vue
@@ -313,7 +313,7 @@
                         </td>
 
                         <!-- Actions -->
-                        <td>
+                        <td v-if="!view_only_mode && !anonymous_user_in_public_project">
                           <v-layout>
 
                             <!-- Edit label
@@ -620,6 +620,14 @@ import Vue from "vue";
     },
 
     computed: {
+      anonymous_user_in_public_project: function(){
+        if(this.$store.getters.is_on_public_project && !this.$store.state.user.logged_in){
+          return true
+        }
+        else{
+          return false;
+        }
+      },
       filtered_instance_set: function(){
         const instance_list = this.instance_list.map((inst, i) => ({
           ...inst,
@@ -688,13 +696,20 @@ import Vue from "vue";
           return this.base_header
 
         }
-
-        else {
-
-          if (this.task && this.task.task_type == 'review' && this.render_mode != "gold_standard") {
-            // This is really brittle but works for now
-            this.base_header[3].width = "600px"
+        if (this.task && this.task.task_type == 'review' && this.render_mode != "gold_standard") {
+          // This is really brittle but works for now
+          this.base_header[3].width = "600px"
+        }
+        if(this.view_only_mode && this.anonymous_user_in_public_project){
+          for(let i = 0; i < this.base_header.length; i++){
+            const header = this.base_header[i];
+            if(header.text === 'Actions'){
+              this.base_header.splice(i, 1);
+            }
           }
+          return this.base_header
+        }
+        else {
 
           return this.base_header
         }

--- a/frontend/src/components/annotation/media_core.vue
+++ b/frontend/src/components/annotation/media_core.vue
@@ -26,7 +26,7 @@
 
     <v-alert v-if="!loading && !media_loading && file_list.length == 0"
              type="info">
-      <v-layout> 
+      <v-layout>
 
         <p class="pr-4">
           No files match criteria. Change criteria and refresh. Or import new data.
@@ -97,7 +97,7 @@
                     >{{metadata_previous.file_count}}</v-chip>
 
               </div>
-              
+
               <!-- Note show conditions are different for next / previous
                 and show conditions are inverted as opposed to disable-->
               <!-- Only show next/previous page if it exists, saves real estate vs disabling-->
@@ -249,7 +249,7 @@
 
               <button_with_menu
                 tooltip_message="Transfer Selected Files"
-                v-if="!view_only_mode"
+                v-if="!view_only_mode && !anonymous_user_in_public_project"
                 icon="mdi-file-move"
                 color="primary"
                 :loading="api_file_update_loading"
@@ -279,7 +279,7 @@
                 color="primary"
                 :loading="api_file_update_loading"
                 :disabled="api_file_update_loading || selected.length == 0"
-                v-if="['annotation'].includes(file_view_mode)"
+                v-if="!view_only_mode && !anonymous_user_in_public_project && ['annotation'].includes(file_view_mode)"
                 :icon_style="true"
                 :bottom="true"
               >
@@ -1102,7 +1102,14 @@ import Vue from "vue";
     }
   },
   computed: {
-
+    anonymous_user_in_public_project: function(){
+      if(this.$store.getters.is_on_public_project && !this.$store.state.user.logged_in){
+        return true
+      }
+      else{
+        return false;
+      }
+    },
     select_all_data_table: function () {
       if (this.file_view_mode == "home") {
         return false

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -197,21 +197,24 @@
 
     <v-divider
       vertical
+      v-if="!view_only_mode"
     ></v-divider>
 
 
-    <tooltip_button
-      @click="$emit('save')"
-      datacy="save_button"
-      :loading="save_loading"
-      :disabled="!has_changed || save_loading || view_only_mode || (file == undefined && task == undefined)"
-      color="primary"
-      icon="save"
-      tooltip_message="Save Image / Frame"
-      :icon_style="true"
-      :bottom="true">
-    </tooltip_button>
+    <div>
+      <tooltip_button
+          @click="$emit('save')"
+          datacy="save_button"
+          :loading="save_loading"
+          :disabled="!has_changed || save_loading || view_only_mode || (file == undefined && task == undefined)"
+          color="primary"
+          icon="save"
+          tooltip_message="Save Image / Frame"
+          :icon_style="true"
+          :bottom="true">
+      </tooltip_button>
 
+    </div>
     <div class="has-changed">
       <div style="width: 100px">
         <span v-if="save_loading"> Saving. </span>
@@ -223,6 +226,7 @@
     </div>
 
     <v-divider
+      v-if="!view_only_mode"
       vertical
     ></v-divider>
 
@@ -260,32 +264,34 @@
   <!--  without this div the order of the two buttons randomly swaps
     -->
   <div>
-    <tooltip_button
-      tooltip_message="Previous File"
-      v-if="!task && file && file.id"
-      @click="$emit('change_file', 'previous')"
-      :disabled="loading || annotations_loading || full_file_loading || !file"
-      color="primary"
-      icon="mdi-chevron-left-circle"
-      :icon_style="true"
-      :bottom="true"
-                    >
-    </tooltip_button>
-
+      <tooltip_button
+          tooltip_message="Previous File"
+          v-if="!task && file && file.id"
+          @click="$emit('change_file', 'previous')"
+          :disabled="loading || annotations_loading || full_file_loading || !file"
+          color="primary"
+          icon="mdi-chevron-left-circle"
+          :icon_style="true"
+          :bottom="true"
+      >
+      </tooltip_button>
       <!-- TODO Move some of disabled logic into functions don't like having
             so much of it here as it gets more complext -->
-    <tooltip_button
-      tooltip_message="Next File"
-      v-if="!task && file && file.id"
-      @click="$emit('change_file', 'next')"
-      :disabled="loading || annotations_loading ||  full_file_loading || !file"
-      color="primary"
-      icon="mdi-chevron-right-circle"
-      :icon_style="true"
-      :bottom="true"
-                    >
-    </tooltip_button>
+
   </div>
+    <div>
+      <tooltip_button
+          tooltip_message="Next File"
+          v-if="!task && file && file.id"
+          @click="$emit('change_file', 'next')"
+          :disabled="loading || annotations_loading ||  full_file_loading || !file"
+          color="primary"
+          icon="mdi-chevron-right-circle"
+          :icon_style="true"
+          :bottom="true"
+      >
+      </tooltip_button>
+    </div>
     <div>
       <tooltip_button
         tooltip_message="Previous Task"
@@ -748,6 +754,13 @@
 
 
       </v-toolbar-items>
+  <v-chip
+      v-if="view_only_mode == true"
+      small
+      color="primary"
+      class="d-flex pa-2 justify-center align-center" >
+    <span style="font-size: 12px" class="mr-2"><strong> <v-icon class="mr-2">mdi-eye</v-icon>View only</strong></span>
+  </v-chip>
     </v-toolbar>
 
 </template>

--- a/frontend/src/components/input/new_or_update_upload_screen.vue
+++ b/frontend/src/components/input/new_or_update_upload_screen.vue
@@ -121,7 +121,7 @@
                 <v-col cols="12" class="pa-0" >
 
                   <connector_import_renderer
-                     max_height="375px"
+                    max_height="375px"
                     :project_string_id="project_string_id"
                     :connection="incoming_connection"
                     :video_split_duration="video_split_duration"
@@ -341,7 +341,6 @@
                 }
                 file.source = 'local';
                 $vm.file_list_to_upload.push(file);
-                console.log('FILEEEE', file)
 
                 $vm.$emit('file_list_updated', $vm.file_list_to_upload)
               });
@@ -639,13 +638,14 @@
 
 
           this.is_actively_sending = true
+          this.$emit('update_is_actively_sending', this.is_actively_sending)
         },
 
 
         drop_zone_complete() {
 
           this.is_actively_sending = false
-
+          this.$emit('update_is_actively_sending', this.is_actively_sending)
           // Not super happy with this but something to think on
           // how deeply we want to integrate this with upload
           // or if we even want to show this here at all

--- a/frontend/src/components/input/new_or_update_upload_screen.vue
+++ b/frontend/src/components/input/new_or_update_upload_screen.vue
@@ -333,7 +333,6 @@
           return {
             init: function () {
               this.on("addedfile", function (file) {
-                console.log('added file', file)
                 if (file.type === 'application/json' || file.type === 'text/csv') {
                   file.data_type = 'Annotations';
                 } else {
@@ -437,7 +436,6 @@
           for (const item of file_list) {
             let data_type = 'Raw Media';
             const extension = item.name.split('.').pop();
-            console.log('es', extension)
             if (extension && this.accepted_annotation_file_types.includes(extension)) {
               data_type = 'Annotations'
             }

--- a/frontend/src/components/input/upload_progress.vue
+++ b/frontend/src/components/input/upload_progress.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container v-if="(!progress_percentage && percentage < 100) || (progress_percentage && progress_percentage < 100)">
+  <v-container v-if="(!progress_percentage && percentage < 100) || (progress_percentage && progress_percentage < 100) || is_actively_sending">
     <h1>Uploading Files...</h1>
     <h3 v-if="formatted_total && formatted_uploaded && !progress_percentage">
       {{formatted_uploaded}} of {{formatted_total}}
@@ -42,6 +42,9 @@
         },
         'progress_percentage': {
           default: null,
+        },
+        'is_actively_sending': {
+          default: true,
         }
       },
       data() {
@@ -50,7 +53,7 @@
       computed: {
         percentage: function(){
           if(this.$props.total_bytes === 0){ return 0}
-          return Math.round((this.$props.uploaded_bytes + this.$props.currently_uploading) / this.$props.total_bytes * 100);
+          return Math.round((this.$props.uploaded_bytes) / this.$props.total_bytes * 100);
         },
         formatted_total: function(){
           if(this.$props.total_bytes == undefined){ return undefined}

--- a/frontend/src/components/input/upload_wizard_sheet.vue
+++ b/frontend/src/components/input/upload_wizard_sheet.vue
@@ -158,6 +158,7 @@
             @change_step_no_annotations="el = 6"
             @change_step_annotations="load_annotations_file"
             @progress_updated="update_progress_values"
+            @update_is_actively_sending="update_is_actively_sending"
             @reset_total_files_size="reset_total_files_size"
             @current_directory="set_current_directory"
             @file_added="file_added"
@@ -226,6 +227,7 @@
             v-if="upload_in_progress"
             :total_bytes="dropzone_total_file_size"
             :uploaded_bytes="dropzone_uploaded_file_size"
+            :is_actively_sending="is_actively_sending"
             :currently_uploading="currently_uploading_bytes"
             :progress_percentage="progress_percentage"
             @close_wizard="close"
@@ -261,6 +263,7 @@
       total_questions: 18,
       progress_percentage: null,
       with_pre_labels: null,
+      is_actively_sending: true,
 
       error_update_files: undefined,
       batch: null,
@@ -282,6 +285,7 @@
         number: null,
         model_id: null,
         model_run_id: null,
+        file_metadata: null,
         box: {
           x_min: null,
           x_max: null,
@@ -470,6 +474,9 @@
       },
 
       methods: {
+        update_is_actively_sending: function(is_actively_sending){
+          this.is_actively_sending = is_actively_sending
+        },
         on_change_step: function (step) {
           const stepnum = parseInt(step, 10);
           if (stepnum === 3) {
@@ -667,7 +674,6 @@
         extract_object_keys(obj, prepend = undefined){
           let result = [];
           for (const key in obj) {
-
             if(typeof obj[key] != 'object'){
               if (!result.includes(key)) {
                 if(prepend){
@@ -680,6 +686,12 @@
               }
             }
             else{
+              if(prepend){
+                result.push(prepend + key)
+              }
+              else{
+                result.push(key)
+              }
               const nested_result = this.extract_object_keys(obj[key], `${ prepend ? `${prepend}${key}` : key}.`);
               result = result.concat(nested_result)
             }

--- a/frontend/src/components/instance_templates/instance_template_creation_dialog.vue
+++ b/frontend/src/components/instance_templates/instance_template_creation_dialog.vue
@@ -250,7 +250,6 @@
         try {
           this.error = {};
           const has_empty_instances = this.validate_empty_instance_list();
-          console.log('has_empty_instances',has_empty_instances)
           if(!has_empty_instances){
             return
           }
@@ -285,7 +284,6 @@
         try {
           this.error = {};
           const has_empty_instances = this.validate_empty_instance_list();
-          console.log('has_empty_instances',has_empty_instances)
           if(!has_empty_instances){
             return
           }

--- a/frontend/src/components/main_menu/menu.vue
+++ b/frontend/src/components/main_menu/menu.vue
@@ -480,7 +480,8 @@ import Vue from "vue";
     route_home_new_tab: function () {
       if (this.$store.state.user.logged_in == true) {
         window.open('/home/dashboard')
-      } else {
+      }
+      else {
         window.open('/')
       }
     }

--- a/frontend/src/components/source_control/dataset_explorer.vue
+++ b/frontend/src/components/source_control/dataset_explorer.vue
@@ -2,9 +2,19 @@
   <v-layout class="d-flex flex-column">
     <v-toolbar extended elevation="0" class="ma-8 mb-0">
       <v-toolbar-title class="d-flex align-center mb-0">
+        <tooltip_button
+          tooltip_message="Refresh"
+          datacy="refresh_button"
+          @click="fetch_file_list"
+          icon="refresh"
+          :icon_style="true"
+          color="primary"
+        >
+        </tooltip_button>
         <v-icon x-large>mdi-folder-home</v-icon>Projects/{{project_string_id}}/Datasets/
       </v-toolbar-title>
       <div class="d-flex align-center mr-5">
+
         <v_directory_list :project_string_id="project_string_id"
                           @change_directory="on_change_ground_truth_dir"
                           ref="ground_truth_dir_list"
@@ -179,6 +189,12 @@
               this.file_list = response.data.file_list;
             }
             else{
+
+              for(const file in response.data.file_list){
+                if(!this.file_list.find(f => f.id === file.id)){
+                  this.file_list.push(file);
+                }
+              }
               this.file_list = this.file_list.concat(response.data.file_list);
             }
 

--- a/frontend/src/components/source_control/directory_list.vue
+++ b/frontend/src/components/source_control/directory_list.vue
@@ -249,7 +249,6 @@
       if (this.set_from_id && this.$store.state.project.current.directory_list_filtered) {
         this.current_directory = this.directory_list_filtered.find(
           x => {return x.directory_id == this.set_from_id});
-        console.log('emite', this.change_on_mount, this.current_directory)
         if(this.change_on_mount){
 
           this.$emit('change_directory', this.current_directory)

--- a/frontend/src/components/source_control/file_manager_sheet.vue
+++ b/frontend/src/components/source_control/file_manager_sheet.vue
@@ -111,7 +111,7 @@
       Open File Explorer
       <template v-slot:activator="{ on }">
         <v-btn
-          style="position: absolute; bottom: 25px; right: 25px"
+          style="position: fixed; bottom: 25px; right: 25px"
           color="primary"
           data-cy="file_explorer_button"
           @click="media_sheet = !media_sheet"

--- a/frontend/src/components/source_control/file_manager_sheet.vue
+++ b/frontend/src/components/source_control/file_manager_sheet.vue
@@ -5,6 +5,7 @@
                     hide-overlay
                     class="media-core-container"
                     no-click-animation
+                    style="position: fixed"
                     :fullscreen="full_screen"
                     v-if="!error_permissions.data"
                     :persistent="persistent_bottom_sheet"

--- a/frontend/src/components/source_control/file_preview.vue
+++ b/frontend/src/components/source_control/file_preview.vue
@@ -164,7 +164,6 @@
             let filtered_instances = this.global_instance_list.filter(inst => {
               return inst.model_run_id === model_run.id;
             })
-            console.log('model urn', model_run)
             filtered_instances = filtered_instances.map(inst => {
               return {
                 ...inst,

--- a/frontend/src/components/source_control/file_preview.vue
+++ b/frontend/src/components/source_control/file_preview.vue
@@ -2,6 +2,7 @@
   <v-card class="ma-2" :elevation="0" style="background: #f6f7f8" :height="file_preview_height">
     <v-card-text class="pa-0 ma-0 drawable-wrapper" v-if="image_bg" @click="view_file_details(undefined)" >
       <drawable_canvas
+        v-if="image_bg"
         :allow_zoom="false"
         :image_bg="image_bg"
         :canvas_height="file_preview_height"
@@ -182,7 +183,6 @@
 
         if(this.$props.show_ground_truth){
           const ground_truth_instances = this.global_instance_list.filter(inst => !inst.model_run_id);
-          console.log('ground_truth_instances', ground_truth_instances)
           for(const inst of ground_truth_instances){
 
             this.filtered_instance_list.push(inst)
@@ -208,7 +208,6 @@
       },
 
       view_file_details: function(current_frame){
-        console.log('VIEW DETAILS')
         let model_runs = [];
         let color_list = [];
         if(this.base_model_run){
@@ -244,6 +243,7 @@
         if(this.$props.file.video){
           return this.video_instance_list;
         }
+        return []
       }
     },
   });

--- a/frontend/src/components/video/sequence_list.vue
+++ b/frontend/src/components/video/sequence_list.vue
@@ -164,7 +164,7 @@
 
       <v-data-table
                     style="overflow-y:auto; max-height: 400px;"
-                    :headers="headers"
+                    :headers="header_with_perms"
                     :items="sequence_list"
                     item-key="id"
                     :options.sync="options">
@@ -270,7 +270,7 @@
             </td>
 
 
-            <td>
+            <td v-if="!view_only_mode">
               <!-- Actions -->
 
               <!-- Change label
@@ -494,7 +494,18 @@ export default Vue.extend( {
     }
   },
   computed: {
-
+    header_with_perms: function(){
+      const result = [];
+      for(const header of this.headers){
+        if(header.text === 'Actions' && this.view_only_mode){
+          continue
+        }
+        else{
+          result.push(header)
+        }
+      }
+      return result
+    }
   },
   watch: {
 

--- a/frontend/src/components/video/video.vue
+++ b/frontend/src/components/video/video.vue
@@ -638,7 +638,6 @@ export default Vue.extend( {
        */
       let rect = this.box_client;
       var x = this.mouse_x - rect.left;
-      console.log('AAAA', this.mouse_x, rect.left)
       let padding = 16
       if(x < 0){
         return
@@ -654,9 +653,6 @@ export default Vue.extend( {
       let slider_width = rect.width - (padding * 2)
 
       let percent_on_slider = (x - offset) / slider_width
-      console.log('percent on slider', percent_on_slider)
-      console.log('x', x)
-      console.log('offset x', offset)
       if (isNaN(percent_on_slider)){
         return
       }
@@ -840,7 +836,6 @@ export default Vue.extend( {
     },
 
     slide_change: function (event) {
-      console.log('SLIDER CHANGE', event)
       this.update_slide_start() // saveing hook
       this.slider_end(event)
     },
@@ -971,7 +966,6 @@ export default Vue.extend( {
 
             this.$emit('playing')
             this.primary_video.playbackRate = this.playback_rate
-            console.log('video animation start');
             this.video_animation_start()
 
           })

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -198,7 +198,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     this.is_dragging_instance = true;
   }
   public add_node_to_instance() {
-    console.log('add node instance')
     if (this.is_hovered) {
       if (this.current_node_connection.length === 1) {
         //console.log('aaaa ad edgeee', this.node_hover_index, this.current_node_connection)

--- a/frontend/src/router/router.js
+++ b/frontend/src/router/router.js
@@ -544,10 +544,11 @@ const routes = routerOptions.map(route => {
           // Test if the route can be accessed on a public project
           if(to.matched.some(record => record.meta.available_on_public_project)){
             const project_string_id = to.params.project_string_id;
-            const project = await this.fetch_public_project();
+            const project = await fetch_public_project(project_string_id);
+            console.log('public project', project)
             if(project){
               // If project exists, this is a public project and we can see it
-              
+              store.commit('set_current_public_project', project);
             }
             else{
               // Otherwise redirect to login
@@ -556,7 +557,6 @@ const routes = routerOptions.map(route => {
                 query: {redirect: to.fullPath}
               })
             }
-            console.log('PUBLIC PROJECTT', to)
           }
           else{
             next({

--- a/frontend/src/router/router.js
+++ b/frontend/src/router/router.js
@@ -549,6 +549,7 @@ const routes = routerOptions.map(route => {
             if(project){
               // If project exists, this is a public project and we can see it
               store.commit('set_current_public_project', project);
+              next();
             }
             else{
               // Otherwise redirect to login

--- a/frontend/src/router/router.js
+++ b/frontend/src/router/router.js
@@ -545,7 +545,6 @@ const routes = routerOptions.map(route => {
           if(to.matched.some(record => record.meta.available_on_public_project)){
             const project_string_id = to.params.project_string_id;
             const project = await fetch_public_project(project_string_id);
-            console.log('public project', project)
             if(project){
               // If project exists, this is a public project and we can see it
               store.commit('set_current_public_project', project);

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -2,6 +2,8 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import createPersistedState from 'vuex-persistedstate'
 
+
+
 Vue.use(Vuex)
 
 
@@ -117,7 +119,18 @@ export const user_module = {
   }
 }
 
+export const public_project = {
+  state: {
+    current:{
 
+    }
+  },
+  mutations:{
+    set_current_public_project(state, project) {
+      state.project = project
+    },
+  }
+}
 export const project = {
 
   // TODO merge name and string methods in project
@@ -580,7 +593,7 @@ const video = {
   }
 }
 
-
+const modulesToOmit = ['public_project']
 const my_store = new Vuex.Store({
   modules: {
     attribute: attribute,
@@ -601,9 +614,23 @@ const my_store = new Vuex.Store({
     video: video,
     job: job,
     connection: connection,
-    input: input
+    input: input,
+    public_project: public_project
   },
-  plugins: [createPersistedState()]
+  plugins: [createPersistedState({
+
+    reducer: (state) => {
+      let reducer = Object.assign({}, state)
+      for(const key in Object.keys(reducer)){
+        if(modulesToOmit.includes('key')){
+          delete reducer.key;
+        }
+      }
+
+
+      return (reducer)
+    }
+  })]
 })
 if (window.Cypress) {
   window.__store__ = my_store

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -121,14 +121,24 @@ export const user_module = {
 
 export const public_project = {
   state: {
-    current:{
+    project:{
 
     }
   },
   mutations:{
     set_current_public_project(state, project) {
       state.project = project
-    },
+    }
+  },
+  getters:{
+    is_on_public_project(state){
+      if(state.project.project_string_id){
+        return true
+      }
+      else{
+        return false
+      }
+    }
   }
 }
 export const project = {

--- a/shared/database/source_control/file.py
+++ b/shared/database/source_control/file.py
@@ -315,7 +315,8 @@ class File(Base, Caching):
                 file['video'] = self.video.serialize_list_view(session, self.project)
 
         if self.type == "text":
-            file['text'] = self.text_file.serialize()
+            if self.text_file:
+                file['text'] = self.text_file.serialize()
 
         # Could also get parent file information here too...
 

--- a/shared/database/source_control/file.py
+++ b/shared/database/source_control/file.py
@@ -315,8 +315,7 @@ class File(Base, Caching):
                 file['video'] = self.video.serialize_list_view(session, self.project)
 
         if self.type == "text":
-            if self.video:
-                file['text'] = self.text_file.serialize()
+            file['text'] = self.text_file.serialize()
 
         # Could also get parent file information here too...
 

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -91,7 +91,8 @@ def process_media_unit_of_work(item):
                 process_media.main_entry()
             except Exception as e:
                 traceback.format_exc(e)
-                print("[Process Media] Main failed on", str(item.input_id))
+                logger.error("[Process Media] Main failed on {}".format(item.input_id))
+                logger.error(str(e))
         else:
             process_media.main_entry()
 

--- a/walrus/methods/input/upload.py
+++ b/walrus/methods/input/upload.py
@@ -54,6 +54,7 @@ def api_project_upload_large(project_string_id):
         more_chunks_expected: bool = int(upload.dzchunkindex) + 1 != int(upload.dztotalchunkcount)
 
         if more_chunks_expected is False:
+            session.commit()
             upload.start_media_processing(input=upload.input)
 
         return jsonify(success=True), 200

--- a/walrus/methods/input/upload.py
+++ b/walrus/methods/input/upload.py
@@ -53,7 +53,7 @@ def api_project_upload_large(project_string_id):
 
         more_chunks_expected: bool = int(upload.dzchunkindex) + 1 != int(upload.dztotalchunkcount)
 
-        if more_chunks_expected is False:
+        if more_chunks_expected is False and upload.input is not None:
             session.commit()
             upload.start_media_processing(input=upload.input)
 


### PR DESCRIPTION
This new feature allows projects to be public and seen by users with no diffgram account.

The approach to accomplish this is to extend a bit the logic in router.js and add an additions metadata key to the routes called `available_on_public_project`. All routes with `available_on_public_project === true` should be allowed to be rendered if the project provided in the URL is public.

Please let me know if you find any issues with this mechanism for permissions or if you have any additional comments on it.