### PR TITLE
Improve pagination on file list

### DIFF
--- a/default/methods/source_control/file/file_browser.py
+++ b/default/methods/source_control/file/file_browser.py
@@ -503,6 +503,7 @@ class File_Browser():
         executor = SqlAlchemyQueryExecutor(session = self.session, diffgram_query = diffgram_query_obj)
         sql_alchemy_query, execution_log = executor.execute_query()
         if sql_alchemy_query:
+            count = sql_alchemy_query.count()
             if limit is not None:
                 sql_alchemy_query = sql_alchemy_query.limit(limit)
 
@@ -510,8 +511,9 @@ class File_Browser():
                 sql_alchemy_query = sql_alchemy_query.offset(offset)
             file_list = sql_alchemy_query.all()
         else:
-            return False, execution_log
-        return file_list, query_creator.log
+            count = None
+            return False, execution_log, count
+        return file_list, query_creator.log, count
 
     def file_view_core(
         self,
@@ -614,13 +616,13 @@ class File_Browser():
                 order_by_class_and_attribute = File.time_last_updated
 
         if self.metadata.get('query') and self.metadata.get('query') != '':
-            working_dir_file_list, log = self.build_and_execute_query(
+            working_dir_file_list, log, count = self.build_and_execute_query(
                 limit = self.metadata["limit"],
                 offset = self.metadata["start_index"],
             )
             if not working_dir_file_list or len(log['error'].keys()) > 1:
                 return False
-            # TODO ADD FILE COUNT TO QUERY EXECUTOR
+            file_count += count
         else:
             query, count = WorkingDirFileLink.file_list(
                 session = self.session,

--- a/default/methods/source_control/file/file_browser.py
+++ b/default/methods/source_control/file/file_browser.py
@@ -10,7 +10,7 @@ from sqlalchemy import asc
 from sqlalchemy import desc
 from shared.query_engine.query_creator import QueryCreator
 from shared.query_engine.sqlalchemy_query_exectutor import SqlAlchemyQueryExecutor
-
+import math
 
 @routes.route('/api/v1/file/view',
               methods = ['POST'])
@@ -443,7 +443,14 @@ class File_Browser():
 
         self.metadata['file'] = {}
         self.metadata['query'] =  self.metadata_proposed.get("query", None)
+
         self.metadata['limit'] = 25
+        self.metadata['page'] = self.metadata_proposed.get("page", 1)
+        if self.metadata['page'] == 0:
+            self.metadata['page'] = 1
+        self.metadata['next_page'] = self.metadata_proposed.get("page", 1) + 1
+        self.metadata['total_pages'] = 1
+        self.metadata['prev_page'] = self.metadata_proposed.get("page", 1) - 1 if self.metadata_proposed.get("page", 1) > 1 else None
 
         self.metadata['directory_id'] = self.metadata_proposed.get("directory_id", None)
         self.metadata['date_from'] = self.metadata_proposed.get("date_from", None)
@@ -475,29 +482,9 @@ class File_Browser():
             else:
                 self.metadata["limit"] = server_side_limit
 
-        request_next_page = self.metadata_proposed.get('request_next_page', None)
-
-        # TODO this makes a lot of assumptions about which fires first,
-        # ie would rather have a "request_next_page_kind" or something...
-
-        # Why need meta data previous here?
-        # mainly based off 'end_index'
-        if request_next_page is True and self.metadata_proposed.get('previous', None):
-            self.metadata["start_index"] = int(
-                self.metadata_proposed['previous'].get('end_index', 0))
-
-        # self.metadata['label']["start_index"] = int(self.metadata_proposed['previous']['label'].get('end_index', 0))
-
-        request_previous_page = self.metadata_proposed.get('request_previous_page', None)
-        if request_previous_page is True:
-            # this seems kinda hacky to use the limit...
-            if self.metadata_proposed['previous'].get('start_index'):
-                self.metadata["start_index"] = int(
-                    self.metadata_proposed['previous'].get('start_index')) - int(self.metadata["limit"])
-            if self.metadata["start_index"] < 0:
-                self.metadata["start_index"] = 0
-
-        self.metadata['pagination'] = self.metadata_proposed.get('pagination', {})
+        # Index calculation is now done based on page and limit
+        self.metadata["start_index"] = (self.metadata["page"] - 1) * self.metadata["limit"]
+        print('start', self.metadata['start_index'], self.metadata['page'])
 
     def build_and_execute_query(self, limit = 25, offset = None):
         """
@@ -611,14 +598,13 @@ class File_Browser():
                 job_id = self.metadata['job_id']
 
         order_by_direction = desc
-        requested_direction = self.metadata['pagination'].get('descending')
-        if requested_direction == False:  # defaults to true...
+        if self.metadata.get('order', 'desc') == 'asc':  # defaults to true...
             order_by_direction = asc
 
         # Default
         order_by_class_and_attribute = File.time_last_updated
 
-        requested_order_by = self.metadata['pagination'].get('sortBy')
+        requested_order_by = self.metadata.get('sortBy')
         if requested_order_by:
             if requested_order_by == "filename":
                 order_by_class_and_attribute = File.original_filename
@@ -634,6 +620,7 @@ class File_Browser():
             )
             if not working_dir_file_list or len(log['error'].keys()) > 1:
                 return False
+            # TODO ADD FILE COUNT TO QUERY EXECUTOR
         else:
             query, count = WorkingDirFileLink.file_list(
                 session = self.session,
@@ -660,6 +647,17 @@ class File_Browser():
             file_count += count
 
             working_dir_file_list = query.all()
+
+        self.metadata['total_pages'] = math.ceil(float(file_count) / float(self.metadata['limit']))
+        if self.metadata['page'] >= self.metadata['total_pages']:
+            self.metadata['next_page'] = None
+            self.metadata['prev_page'] = self.metadata['page'] - 1
+        else:
+            self.metadata['next_page'] = self.metadata['page'] + 1
+            if self.metadata['next_page'] > 1:
+                self.metadata['prev_page'] = self.metadata['page'] - 1
+            else:
+                self.metadata['prev_page'] = None
 
         if mode == "serialize":
             for index_file, file in enumerate(working_dir_file_list):

--- a/frontend/src/components/annotation/media_core.vue
+++ b/frontend/src/components/annotation/media_core.vue
@@ -117,7 +117,7 @@
                 <tooltip_button
                   v-show="!loading &&
                       (metadata_previous.end_index != metadata_previous.file_count
-                      || request_next_page_available)"
+                      || metadata_previous.next_page != undefined)"
                   tooltip_message="Next Page"
                   @click="next_page"
                   :loading="loading"
@@ -927,7 +927,7 @@ import Vue from "vue";
       file_list: [],
 
       height: 0,
-      page_number: 0,
+      page_number: 1,
       selected_dirs: [],
       job_attached_dirs: [],
       select_from_metadata: false,
@@ -979,10 +979,7 @@ import Vue from "vue";
       annotation_status: "All",
 
       metadata_limit_options: [10, 25, 100, 250, 950],
-      metadata_limit: 25, // TODO attach to vue store.
-
-      request_next_page_flag: false,
-      request_next_page_available: true,
+      metadata_limit: 10, // TODO attach to vue store.
 
       job_list: [],
       date: undefined,
@@ -1176,9 +1173,7 @@ import Vue from "vue";
         'issues_filter': this.issues_filter,
         'limit': this.metadata_limit,
         'media_type': this.filter_media_type_setting,
-        'page_number': this.page_number,
-        'request_next_page': this.request_next_page_flag,
-        'request_previous_page' : this.request_previous_page_flag,
+        'page': this.page_number,
         'file_view_mode': this.file_view_mode,
         'previous': this.metadata_previous,
         'options': this.options,
@@ -1463,9 +1458,8 @@ import Vue from "vue";
       this.current_dataset = event
 
       this.$addQueriesToLocation({'dataset' : event.directory_id})
-      this.page_number = 0;
-      this.request_previous_page_flag = false;
-      this.request_next_page_flag = false;
+      this.page_number = 1;
+
       this.get_media(false);
 
 
@@ -1525,11 +1519,11 @@ import Vue from "vue";
         } else { i -= 1 }
 
         // limits
-        if (i < 0 && this.page_number > 0) {
+        if (i < 0 && this.page_number > 1) {
           await this.previous_page();
           i = this.file_list.length - 1
         }
-        else if(i < 0 && this.page_number == 0){
+        else if(i < 0 && this.page_number == 1){
           i = 0
         }
         // End of list, go to next page
@@ -1562,21 +1556,15 @@ import Vue from "vue";
     },
 
     item_changed() {
-      this.request_next_page_available = false
+
     },
     request_media() {
-      this.request_next_page_flag = false
-      this.request_previous_page_flag = false
-      this.request_next_page_available = true
-
       this.select_from_metadata = false
       this.selected = []
 
       this.get_media();
     },
     async next_page() {
-      this.request_next_page_flag = true
-      this.request_previous_page_flag = false
       this.page_number += 1
       await this.get_media();
     },
@@ -1585,8 +1573,6 @@ import Vue from "vue";
        * prefer to share this function...
        *
        */
-      this.request_next_page_flag = false
-      this.request_previous_page_flag = true
       this.page_number -= 1
       await this.get_media();
 

--- a/frontend/src/components/annotation/media_core.vue
+++ b/frontend/src/components/annotation/media_core.vue
@@ -979,7 +979,7 @@ import Vue from "vue";
       annotation_status: "All",
 
       metadata_limit_options: [10, 25, 100, 250, 950],
-      metadata_limit: 10, // TODO attach to vue store.
+      metadata_limit: 25, // TODO attach to vue store.
 
       job_list: [],
       date: undefined,

--- a/frontend/src/components/source_control/dataset_explorer.vue
+++ b/frontend/src/components/source_control/dataset_explorer.vue
@@ -187,8 +187,6 @@
           'limit': 28,
           'media_type': this.filter_media_type_setting,
           'page_number': 1,
-          'request_next_page': false,
-          'request_previous_page' : false,
           'query_menu_open' : false,
           'file_view_mode': 'explorer',
           'previous': undefined,
@@ -225,7 +223,6 @@
       },
       load_more_files: async function(){
         this.metadata.page_number += 1;
-        this.metadata.request_next_page = true
         await this.fetch_file_list(false)
       },
       update_compare_to_model_runs: function(value){
@@ -237,7 +234,6 @@
       fetch_file_list: async function(reload_all = true){
         if(reload_all){
           this.metadata.page_number = 1;
-          this.metadata.request_next_page = false;
           this.loading = true
         }
         else{


### PR DESCRIPTION
The idea is to remove the boolean request_next page and just build the pagination mechanism based on the page number and the limit.

This is because now the pagination is going to be supported in the SDK and we need this working before we can implement the new SDK features.