### PR TITLE
Create Missing Labels on Upload Wizard

### DIFF
--- a/default/methods/source_control/file/file_browser.py
+++ b/default/methods/source_control/file/file_browser.py
@@ -543,7 +543,7 @@ class File_Browser():
         # outside of limits...
 
         if self.metadata['file_view_mode'] is None or \
-            self.metadata['file_view_mode'] not in ["changes", "annotation", "home", "task", "explorer"]:
+            self.metadata['file_view_mode'] not in ["changes", "annotation", "home", "task", "explorer", "base"]:
             return "Invalid file_view_mode", False
 
         ignore_id_list = None
@@ -665,6 +665,8 @@ class File_Browser():
             for index_file, file in enumerate(working_dir_file_list):
                 if self.metadata['file_view_mode'] == 'explorer':
                     file_serialized = file.serialize_with_annotations(self.session)
+                elif self.metadata['file_view_mode'] == 'base':
+                    file_serialized = file.serialize_base_file()
                 else:
                     file_serialized = file.serialize_with_type(self.session)
                 output_file_list.append(file_serialized)

--- a/default/methods/source_control/file/file_exists.py
+++ b/default/methods/source_control/file/file_exists.py
@@ -65,14 +65,16 @@ def file_list_exists_core(session,
     """
     try:
         file_list_db = File.get_files_in_project_id_list(session, project.id, file_id_list)
-        db_id_list = [f.id for f in file_list_db]
+        db_id_dict = {}
+        for f in file_list_db:
+            db_id_dict[f.id] = True
         result = True
     except Exception as e:
         log['error']['file_list'] = str(e)
         return False, log
     
     for id in file_id_list:
-        if id not in db_id_list:
+        if not db_id_dict.get(id):
             result = False
             break
     return result, log

--- a/frontend/src/components/input/file_schema_mapper.vue
+++ b/frontend/src/components/input/file_schema_mapper.vue
@@ -631,17 +631,23 @@
               for (const instance of this.$props.pre_labeled_data) {
                 let label_name = _.get(instance, this.diffgram_schema_mapping.name)
                 if (!label_names.includes(label_name)) {
-                  this.missing_labels.push(label_name)
+
                   this.errors_file_schema = {}
                   this.errors_file_schema['label_names'] = `The label name "${label_name}" does not exist in the project. Please create it.`
                   this.show_labels_link = false;
                   this.valid_labels = false;
                   this.load_label_names = false;
-                  return false
+                  if(!this.missing_labels.includes(label_name)){
+                    this.missing_labels.push(label_name)
+                  }
+
                 } else {
                   const label = labels.find(l => l.label.name === label_name);
                   instance.label_file_id = label.id;
                 }
+              }
+              if(this.missing_labels.length > 0){
+                return false
               }
               this.valid_labels = true;
               return true

--- a/frontend/src/components/input/file_schema_mapper.vue
+++ b/frontend/src/components/input/file_schema_mapper.vue
@@ -4,11 +4,12 @@
     <div class="d-flex align-center">
       <v_error_multiple :error="errors_file_schema">
       </v_error_multiple>
-      <v-btn v-if="errors_file_schema && Object.keys(errors_file_schema).length > 0 && !valid_labels" color="secondary"
-             @click="open_labels">Go To Labels
+      <v-alert dismissible type="success" v-if="success_missing_labels">Labels created successfully.</v-alert>
+      <v-btn small v-if="errors_file_schema && Object.keys(errors_file_schema).length > 0 && !valid_labels" color="secondary"
+             @click="open_labels"><v-icon>mdi-brush</v-icon> Go To Labels
       </v-btn>
-      <v-btn v-if="errors_file_schema && Object.keys(errors_file_schema).length > 0 && !valid_labels" color="secondary"
-             @click="create_missing_labels">Create Missing
+      <v-btn :loading="loading" class="ml-6" v-if="errors_file_schema && Object.keys(errors_file_schema).length > 0 && !valid_labels" color="primary"
+            small @click="create_missing_labels"><v-icon>mdi-plus</v-icon>Create Missing
       </v-btn>
     </div>
     <v-layout class="d-flex flex-column justify-center align-center pa-10">
@@ -329,7 +330,7 @@
   import {v4 as uuidv4} from 'uuid';
   import filesize from 'filesize';
   import _ from "lodash";
-  import {HexToHSVA, HexToRGBA, HSVAtoHSLA} from 'vuetify/src/util/colorUtils'
+  import {HexToHSVA, HexToRGBA, HSVAtoHSLA} from '../../utils/colorUtils'
 
 
   export default Vue.extend({
@@ -377,6 +378,7 @@
           current_question: 0,
           missing_labels: [],
           errors_file_schema: undefined,
+          success_missing_labels: false,
           wizard_height: '800px',
           load_label_names: false,
           loading: false,
@@ -569,6 +571,7 @@
         },
         create_missing_labels: async function(){
           this.loading = true
+          this.success_missing_labels = false
           this.error = {}
           if(!this.missing_labels){
             return
@@ -589,7 +592,7 @@
               const response = await axios.post('/api/v1/project/' + this.$props.project_string_id +'/label/new',
                 {
                   colour: color_obj,
-                  name: this.new_label_name,
+                  name: label_name,
                   default_sequences_to_single_frame: false
                 });
               this.new_label_name = null
@@ -606,9 +609,11 @@
                   this.error = error.response.data.log.error
                 }
               }
+              return
 
             }
           }
+          this.success_missing_labels = true;
           this.loading = false
 
 

--- a/frontend/src/components/input/new_or_update_upload_screen.vue
+++ b/frontend/src/components/input/new_or_update_upload_screen.vue
@@ -524,7 +524,7 @@
         update_files: async function (file_data) {
           try {
             let processed_files = 0;
-            await Promise.all(Object.keys(file_data).map(async (file_key) => {
+            for(const file_key of Object.keys(file_data)){
               const file = file_data[file_key]
               const data = await axios.post(`/api/walrus/v1/project/${this.$props.project_string_id}/input/packet`, {
                 file_id: file.file_id,
@@ -539,10 +539,8 @@
                 this.$emit('error_update_files', undefined);
                 processed_files += 1;
                 this.update_progress_percentage((processed_files * 1.0 / Object.keys(file_data).length) * 100);
-                return data;
-
               }
-            }));
+            }
 
           } catch (error) {
             this.file_update_error = this.$route_api_errors(error);
@@ -553,6 +551,7 @@
         },
         upload_raw_media: async function (file_list) {
           this.$emit('upload_in_progress')
+          console.log('FILE LIST', file_list)
           if (this.$props.upload_mode === 'update') {
             await this.update_files(file_list)
           } else if (this.$props.upload_mode === 'new') {

--- a/frontend/src/components/input/upload_wizard_sheet.vue
+++ b/frontend/src/components/input/upload_wizard_sheet.vue
@@ -186,6 +186,7 @@
             :pre_labeled_data="pre_labeled_data"
             @change_step_wizard="check_errors_and_go_to_step(5)"
             @complete_question="set_completed_questions"
+            @set_prelabeled_data="set_prelabeled_data"
             @set_included_instance_types="included_instance_types = $event"
             :previously_completed_questions="5"
           ></file_schema_mapper>
@@ -211,10 +212,11 @@
         <v-stepper-content step="6">
           <upload_summary
             style="height: 100%"
-            v-if="!upload_in_progress && file_list_to_upload"
+            v-if="!upload_in_progress && file_list_to_upload && el=== '6'"
             :file_list="file_list_to_upload.filter(f => f.data_type === 'Raw Media')"
             :upload_mode="upload_mode"
             :project_string_id="project_string_id"
+            :total_instance_count="pre_labeled_data.length"
             :pre_labeled_data="pre_labeled_data"
             :current_directory="current_directory"
             :diffgram_schema_mapping="diffgram_schema_mapping"
@@ -495,6 +497,10 @@
 
           this.check_errors_and_go_to_step(2)
         },
+        set_prelabeled_data: function(new_data){
+          Object.freeze(new_data);
+          this.pre_labeled_data = new_data;
+        },
         set_completed_questions: function (value) {
           this.completed_questions = value;
 
@@ -542,7 +548,9 @@
 
           if (file.type === 'application/json') {
             this.pre_labels_file_type = 'json';
-            this.pre_labeled_data = JSON.parse(text_data);
+            const parsed_data = JSON.parse(text_data);
+            Object.freeze(parsed_data);
+            this.pre_labeled_data = parsed_data
             const pre_label_keys = this.extract_pre_label_key_list(this.pre_labeled_data);
             this.pre_label_key_list = [...pre_label_keys];
             this.pre_labels_file_list.push(file);
@@ -562,6 +570,7 @@
               headers.forEach((h, i) => obj[h] = row[i]);
               return obj;
             })
+            Object.freeze(this.pre_labeled_data)
           } else {
             throw new Error('Invalid file type for loading annotations')
           }

--- a/frontend/src/utils/colorUtils.js
+++ b/frontend/src/utils/colorUtils.js
@@ -1,0 +1,268 @@
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.isCssColor = isCssColor;
+exports.classToHex = classToHex;
+exports.intToHex = intToHex;
+exports.HSVAtoRGBA = HSVAtoRGBA;
+exports.RGBAtoHSVA = RGBAtoHSVA;
+exports.HSVAtoHSLA = HSVAtoHSLA;
+exports.HSLAtoHSVA = HSLAtoHSVA;
+exports.RGBAtoCSS = RGBAtoCSS;
+exports.RGBtoCSS = RGBtoCSS;
+exports.RGBAtoHex = RGBAtoHex;
+exports.HexToRGBA = HexToRGBA;
+exports.HexToHSVA = HexToHSVA;
+exports.HSVAtoHex = HSVAtoHex;
+exports.parseHex = parseHex;
+exports.parseGradient = parseGradient;
+exports.RGBtoInt = RGBtoInt;
+
+
+function padEnd(str, length) {
+  var char = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '0';
+  return str + char.repeat(Math.max(0, length - str.length));
+}
+
+
+function chunk(str) {
+  var size = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
+  var chunked = [];
+  var index = 0;
+
+  while (index < str.length) {
+    chunked.push(str.substr(index, size));
+    index += size;
+  }
+
+  return chunked;
+}
+
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+function isCssColor(color) {
+  return !!color && !!color.match(/^(#|var\(--|(rgb|hsl)a?\()/);
+}
+
+
+
+function classToHex(color, colors, currentTheme) {
+  var _color$toString$trim$ = color.toString().trim().replace('-', '').split(' ', 2),
+    _color$toString$trim$2 = _slicedToArray(_color$toString$trim$, 2),
+    colorName = _color$toString$trim$2[0],
+    colorModifier = _color$toString$trim$2[1];
+
+  var hexColor = '';
+
+  if (colorName && colorName in colors) {
+    if (colorModifier && colorModifier in colors[colorName]) {
+      hexColor = colors[colorName][colorModifier];
+    } else if ('base' in colors[colorName]) {
+      hexColor = colors[colorName].base;
+    }
+  } else if (colorName && colorName in currentTheme) {
+    hexColor = currentTheme[colorName];
+  }
+
+  return hexColor;
+}
+
+function intToHex(color) {
+  var hexColor = color.toString(16);
+  if (hexColor.length < 6) hexColor = '0'.repeat(6 - hexColor.length) + hexColor;
+  return '#' + hexColor;
+}
+
+/**
+ * Converts HSVA to RGBA. Based on formula from https://en.wikipedia.org/wiki/HSL_and_HSV
+ *
+ * @param color HSVA color as an array [0-360, 0-1, 0-1, 0-1]
+ */
+
+
+function HSVAtoRGBA(hsva) {
+  var h = hsva.h,
+    s = hsva.s,
+    v = hsva.v,
+    a = hsva.a;
+
+  var f = function f(n) {
+    var k = (n + h / 60) % 6;
+    return v - v * s * Math.max(Math.min(k, 4 - k, 1), 0);
+  };
+
+  var rgb = [f(5), f(3), f(1)].map(function (v) {
+    return Math.round(v * 255);
+  });
+  return {
+    r: rgb[0],
+    g: rgb[1],
+    b: rgb[2],
+    a: a
+  };
+}
+/**
+ * Converts RGBA to HSVA. Based on formula from https://en.wikipedia.org/wiki/HSL_and_HSV
+ *
+ * @param color RGBA color as an array [0-255, 0-255, 0-255, 0-1]
+ */
+
+
+function RGBAtoHSVA(rgba) {
+  if (!rgba) return {
+    h: 0,
+    s: 1,
+    v: 1,
+    a: 1
+  };
+  var r = rgba.r / 255;
+  var g = rgba.g / 255;
+  var b = rgba.b / 255;
+  var max = Math.max(r, g, b);
+  var min = Math.min(r, g, b);
+  var h = 0;
+
+  if (max !== min) {
+    if (max === r) {
+      h = 60 * (0 + (g - b) / (max - min));
+    } else if (max === g) {
+      h = 60 * (2 + (b - r) / (max - min));
+    } else if (max === b) {
+      h = 60 * (4 + (r - g) / (max - min));
+    }
+  }
+
+  if (h < 0) h = h + 360;
+  var s = max === 0 ? 0 : (max - min) / max;
+  var hsv = [h, s, max];
+  return {
+    h: hsv[0],
+    s: hsv[1],
+    v: hsv[2],
+    a: rgba.a
+  };
+}
+
+function HSVAtoHSLA(hsva) {
+  var h = hsva.h,
+    s = hsva.s,
+    v = hsva.v,
+    a = hsva.a;
+  var l = v - v * s / 2;
+  var sprime = l === 1 || l === 0 ? 0 : (v - l) / Math.min(l, 1 - l);
+  return {
+    h: h,
+    s: sprime,
+    l: l,
+    a: a
+  };
+}
+
+function HSLAtoHSVA(hsl) {
+  var h = hsl.h,
+    s = hsl.s,
+    l = hsl.l,
+    a = hsl.a;
+  var v = l + s * Math.min(l, 1 - l);
+  var sprime = v === 0 ? 0 : 2 - 2 * l / v;
+  return {
+    h: h,
+    s: sprime,
+    v: v,
+    a: a
+  };
+}
+
+function RGBAtoCSS(rgba) {
+  return "rgba(".concat(rgba.r, ", ").concat(rgba.g, ", ").concat(rgba.b, ", ").concat(rgba.a, ")");
+}
+
+function RGBtoCSS(rgba) {
+  return RGBAtoCSS(_objectSpread({}, rgba, {
+    a: 1
+  }));
+}
+
+function RGBAtoHex(rgba) {
+  var toHex = function toHex(v) {
+    var h = Math.round(v).toString(16);
+    return ('00'.substr(0, 2 - h.length) + h).toUpperCase();
+  };
+
+  return "#".concat([toHex(rgba.r), toHex(rgba.g), toHex(rgba.b), toHex(Math.round(rgba.a * 255))].join(''));
+}
+
+function HexToRGBA(hex) {
+  var rgba = (0, chunk)(hex.slice(1), 2).map(function (c) {
+    return parseInt(c, 16);
+  });
+  return {
+    r: rgba[0],
+    g: rgba[1],
+    b: rgba[2],
+    a: Math.round(rgba[3] / 255 * 100) / 100
+  };
+}
+
+function HexToHSVA(hex) {
+  var rgb = HexToRGBA(hex);
+  return RGBAtoHSVA(rgb);
+}
+
+function HSVAtoHex(hsva) {
+  return RGBAtoHex(HSVAtoRGBA(hsva));
+}
+
+function parseHex(hex) {
+  if (hex.startsWith('#')) {
+    hex = hex.slice(1);
+  }
+
+  hex = hex.replace(/([^0-9a-f])/gi, 'F');
+
+  if (hex.length === 3 || hex.length === 4) {
+    hex = hex.split('').map(function (x) {
+      return x + x;
+    }).join('');
+  }
+
+  if (hex.length === 6) {
+    hex = (0, padEnd)(hex, 8, 'F');
+  } else {
+    hex = (0, padEnd)((0, padEnd)(hex, 6), 8, 'F');
+  }
+
+  return "#".concat(hex).toUpperCase().substr(0, 9);
+}
+
+function parseGradient(gradient, colors, currentTheme) {
+  return gradient.replace(/([a-z]+(\s[a-z]+-[1-5])?)(?=$|,)/gi, function (x) {
+    return classToHex(x, colors, currentTheme) || x;
+  }).replace(/(rgba\()#[0-9a-f]+(?=,)/gi, function (x) {
+    return 'rgba(' + Object.values(HexToRGBA(parseHex(x.replace(/rgba\(/, '')))).slice(0, 3).join(',');
+  });
+}
+
+function RGBtoInt(rgba) {
+  return (rgba.r << 16) + (rgba.g << 8) + rgba.b;
+}
+/**
+ * Returns the contrast ratio (1-21) between two colors.
+ *
+ * @param c1 First color
+ * @param c2 Second color
+ */
+

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -70,6 +70,7 @@ class Annotation_Update():
     video_mode = False
     is_new_file = False  # defaults to False, ie for images?
     video_parent_file = None
+    clean_instances: bool = False
     sequence = None
     allowed_model_run_id_list: list = None
     allowed_model_id_list: list = None
@@ -376,7 +377,7 @@ class Annotation_Update():
 
         """
 
-        if not self.instance_list_new:
+        if not self.instance_list_new and not self.clean_instances:
             return self.return_orginal_file_type()
         logger.debug('Bulding existing hash list...')
         self.build_existing_hash_list()
@@ -1494,8 +1495,8 @@ class Annotation_Update():
                         instance = None,
                         update_existing_only = False):
         logger.debug('Checking update sequence: video_mode:{} interpolated:{} machine_made:{}'.format(self.video_mode,
-                                                                                                      self.instance.interpolated,
-                                                                                                      self.instance.machine_made))
+                                                                                                      self.instance.interpolated if self.instance else None,
+                                                                                                      self.instance.machine_made if self.instance else None))
         if self.video_mode is False:
             return
 
@@ -1616,9 +1617,10 @@ class Annotation_Update():
         Use cross reference list for constant time operation here
 
         """
+        print('existing', self.instance_list_existing)
         if self.instance_list_existing is None:
             return
-
+        print('hash_list', self.hash_list)
         for remaining_hash in self.hash_list:
             index = self.hash_old_cross_reference[remaining_hash]
             instance = self.instance_list_existing[index]

--- a/shared/database/project.py
+++ b/shared/database/project.py
@@ -323,13 +323,12 @@ class Project(Base, Caching):
         file_list = WorkingDirFileLink.file_list(
             session=session,
             working_dir_id=self.directory_default_id,
-            limit=100,
+            limit=10000000,
             type="label",
             exclude_removed=False)  # eg for permissions
         if not self.label_dict:
             self.label_dict = {}
         self.label_dict['label_file_id_list'] = [file.id for file in file_list]
-        print(self.label_dict['label_file_id_list'])
 
     def serialize(self,
                   session=None):


### PR DESCRIPTION
When the wizard does not find the labels, add a button to create all the missing ones so the user can continue with the flow.

This helps specially for big uploads where you would have to manually create 100s or 1000s of labels one by one. This button removes the need to create them manually.