### PR TITLE
Save temp file in cloud storage

### DIFF
--- a/default/tests/shared/query_engine/test_sqlalchemy_query_executor.py
+++ b/default/tests/shared/query_engine/test_sqlalchemy_query_executor.py
@@ -154,6 +154,7 @@ class TestQueryCreator(testing_setup.DiffgramBaseTestCase):
             executor = SqlAlchemyQueryExecutor(session = self.session, diffgram_query = diffgram_query_obj)
             sql_alchemy_query, execution_log = executor.execute_query()
             result = executor.factor(diffgram_query_obj.tree.children[0].children[0].children[0])
+        print(execution_log)
         self.assertIsNotNone(execution_log['error'].get('label_name'))
         self.assertIsNone(result)
         self.assertFalse(executor.valid)

--- a/frontend/src/components/source_control/dataset_explorer.vue
+++ b/frontend/src/components/source_control/dataset_explorer.vue
@@ -5,7 +5,7 @@
       <v-toolbar-title class="d-flex align-center mb-0">
         <tooltip_button
           tooltip_message="Refresh"
-          datacy="refresh_button"
+          datacy="refresh_explorer"
           @click="fetch_file_list"
           icon="refresh"
           :icon_style="true"
@@ -97,6 +97,7 @@
     <v-layout id="infinite-list"
               fluid
               class="files-container d-flex justify-start"
+              data-cy="file_review_container"
               :style="{height: full_screen ? '760px' : '350px', overflowY: 'auto', ['flex-flow']: 'row wrap', oveflowX: 'hidden'}">
 
       <v-progress-linear indeterminate v-if="loading"></v-progress-linear>
@@ -148,6 +149,9 @@
 
     ],
     mounted() {
+      if (window.Cypress) {
+        window.DatasetExplorer = this;
+      }
       if(!this.metadata.directory_id){
         this.metadata.directory_id = this.$props.directory.directory_id;
 

--- a/shared/alembic/versions_opencore/alembic_2021_07_05_20_52_5b9176d6cdcf_add_temp_cloud_storage_fields.py
+++ b/shared/alembic/versions_opencore/alembic_2021_07_05_20_52_5b9176d6cdcf_add_temp_cloud_storage_fields.py
@@ -1,0 +1,29 @@
+"""Add Temp Cloud storage fields
+
+Revision ID: 5b9176d6cdcf
+Revises: 13e0cabfe99b
+Create Date: 2021-07-05 20:52:41.814985
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from shared.database.core import MutableDict, JSONEncodedDict
+
+# revision identifiers, used by Alembic.
+revision = '5b9176d6cdcf'
+down_revision = '13e0cabfe99b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('input_batch', sa.Column('upload_aws_id', sa.String))
+    op.add_column('input_batch', sa.Column('upload_aws_parts_list', MutableDict.as_mutable(JSONEncodedDict)))
+    op.add_column('input_batch', sa.Column('upload_azure_block_list', MutableDict.as_mutable(JSONEncodedDict)))
+
+
+def downgrade():
+    op.drop_column('input_batch', 'upload_aws_id')
+    op.drop_column('input_batch', 'upload_aws_parts_list')
+    op.drop_column('input_batch', 'upload_azure_block_list')
+

--- a/shared/data_tools_core_gcp.py
+++ b/shared/data_tools_core_gcp.py
@@ -50,11 +50,11 @@ class DataToolsGCP:
         General concept here is just getting a signed url to a resource given this information
         that we can hit later to pass info
         """
-        if input is None:
-            raise Exception('Provide Input for resumable Upload creation')
+
         blob = self.bucket.blob(blob_path)
         url = blob.create_resumable_upload_session(content_type = content_type)
-        input.resumable_url = url
+        if input is not None:
+            input.resumable_url = url
         return url
 
     def transmit_chunk_of_resumable_upload(
@@ -68,7 +68,8 @@ class DataToolsGCP:
             total_size: int,  # total size of whole upload (not chunk),
             total_parts_count: int,
             chunk_index: int,
-            input: object
+            input: object,
+            batch: object = None
     ):
 
         """
@@ -110,11 +111,16 @@ class DataToolsGCP:
         # it's "includsive" ?
 
         end = int(content_start) + int(content_size) - 1
+        print('content_start', content_start)
+        print('content_size', content_size)
+        print('total_size', total_size)
+        print('stream', len(stream))
+        print('end', end)
 
         content_range_extended: str = "bytes " + str(content_start) + \
                                       "-" + str(end) + "/" + str(total_size)
 
-        # print(content_range_extended)
+        print(content_range_extended)
         headers = {"Content-Range": content_range_extended}
 
         try:
@@ -123,12 +129,14 @@ class DataToolsGCP:
                 data = stream,
                 headers = headers
             )
-        except:
+        except Exception as e:
+            raise e
             # TODO if we are going to have a try block
             # here should we error / pass this to Input instance in some way?
             return False
 
-        # print(response.text)
+        print('AAAAAAAAA', response, response.status_code)
+        print(response.text)
 
         return response
 

--- a/shared/database/batch/batch.py
+++ b/shared/database/batch/batch.py
@@ -19,7 +19,13 @@ class InputBatch(Base):
     directory_id = Column(Integer, ForeignKey('working_dir.id'))  # target directory
     directory = relationship("WorkingDir", foreign_keys = [directory_id])
 
+    # For temp storage of huge JSON pre labeled data.
     data_temp_dir = Column(String)
+    # For AWS S3 Uploads
+    upload_aws_id = Column(String())
+    upload_aws_parts_list = Column(MutableDict.as_mutable(JSONEncodedDict))
+    # For Azure Uploads
+    upload_azure_block_list = Column(MutableDict.as_mutable(JSONEncodedDict))
 
     source_directory_id = Column(Integer, ForeignKey('working_dir.id'))  # For internal only
     source_directory = relationship("WorkingDir", foreign_keys = [source_directory_id])

--- a/shared/model/model_manager.py
+++ b/shared/model/model_manager.py
@@ -23,7 +23,6 @@ class ModelManager:
         """
         create_models = []
         created_runs = []
-        print('CREATING MODELS FOR ', self.instance_list)
         for instance in self.instance_list:
             if instance.get('model_ref') is None and instance.get('model_id') is None:
                 continue

--- a/shared/tests/test_utils/data_mocking.py
+++ b/shared/tests/test_utils/data_mocking.py
@@ -347,6 +347,7 @@ def create_label_file(label_file_data, session):
     label_file.label = label_file_data.get('label')
     label_file.label_id = label_file_data.get('label').id
     label_file.project_id = label_file_data['project_id']
+    label_file.state = label_file_data.get('state', 'added')
     label_file.type = 'label'
     session.add(label_file)
     regular_methods.commit_with_rollback(session)


### PR DESCRIPTION
To avoid using local temp folders since uploads can fail if the deployment has multiple servers in a load balancer.