### PR TITLE
Add get prelabeled data from cloud on Batch Objects

### DIFF
--- a/default/methods/batch/append_to_batch.py
+++ b/default/methods/batch/append_to_batch.py
@@ -121,11 +121,10 @@ def append_to_batch_core(session, log, batch_id, member, project, request):
         session.add(batch)
         if chunk_end == (size - 1):
             # Get the complete file and write it to the input batch.
-            data = data_tools.download_bytes(temp_dir_path)
-            # Goto the offset, aka after the chunks we already wrote
-            data = json.loads(data)
-            batch.pre_labeled_data = data
+            batch.data_temp_dir = temp_dir_path
+            batch.pre_labeled_data = None
             session.add(batch)
+            result = batch.get_pre_labeled_data_cloud_url()
     else:
         log['error']['content_range'] = 'Invalid content range header.'
         return False, log

--- a/frontend/src/components/input/upload_summary.vue
+++ b/frontend/src/components/input/upload_summary.vue
@@ -235,8 +235,8 @@
         create_batch: async function (labels_payload) {
           try {
 
-            const chunk_size_bytes = 5 * 1024 * 1024; // 5 mb
-            // const chunk_size_bytes = 256 * 1024 // 256KB;
+            // const chunk_size_bytes = 5 * 1024 * 1024; // 5 mb
+            const chunk_size_bytes = 256 * 1024 // 256KB;
             const str = JSON.stringify(labels_payload);
             const bytes = new TextEncoder().encode(str);
             const blob = new Blob([bytes], {

--- a/shared/database/batch/batch.py
+++ b/shared/database/batch/batch.py
@@ -1,7 +1,7 @@
 # OPENCORE - ADD
 from shared.database.common import *
 from shared.database.input import Input
-
+from shared.data_tools_core import Data_tools
 
 class InputBatch(Base):
     __tablename__ = 'input_batch'
@@ -70,6 +70,12 @@ class InputBatch(Base):
             session.flush()
 
         return batch
+
+    def get_pre_labeled_data_cloud_url(self):
+        data_tools = Data_tools().data_tools
+        url = data_tools.build_secure_url(self.data_temp_dir)
+        return url
+
 
     def serialize(self):
 


### PR DESCRIPTION
For the case of huge payloads we will not save them on postgres and only save the cloud url since postgres columns max size is 1gb