### PR TITLE
Add a unique constraint for frame numbers in video files

### DIFF
--- a/shared/alembic/versions_opencore/alembic_2021_07_09_08_38_9192f806a8cb_add_unique_together_to_frame_numbers.py
+++ b/shared/alembic/versions_opencore/alembic_2021_07_09_08_38_9192f806a8cb_add_unique_together_to_frame_numbers.py
@@ -17,8 +17,8 @@ depends_on = None
 
 
 def upgrade():
-    pass
+    op.create_unique_constraint('unique_frame_number', 'file', ['video_parent_file_id', 'frame_number'])
 
 
 def downgrade():
-    pass
+    op.drop_constraint('unique_frame_number', 'file')

--- a/shared/alembic/versions_opencore/alembic_2021_07_09_08_38_9192f806a8cb_add_unique_together_to_frame_numbers.py
+++ b/shared/alembic/versions_opencore/alembic_2021_07_09_08_38_9192f806a8cb_add_unique_together_to_frame_numbers.py
@@ -1,0 +1,24 @@
+"""Add Unique Together to Frame numbers
+
+Revision ID: 9192f806a8cb
+Revises: 5b9176d6cdcf
+Create Date: 2021-07-09 08:38:47.670954
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9192f806a8cb'
+down_revision = '5b9176d6cdcf'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/shared/database/source_control/file.py
+++ b/shared/database/source_control/file.py
@@ -17,6 +17,8 @@ from sqlalchemy.orm import joinedload
 from shared.shared_logger import get_shared_logger
 from shared.database.core import MutableDict
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import UniqueConstraint
+
 logger = get_shared_logger()
 
 
@@ -186,6 +188,7 @@ class File(Base, Caching):
                                         uselist=False,
                                         foreign_keys=[default_external_map_id])
 
+    __table_args__ = (UniqueConstraint('video_parent_file_id', 'frame_number', name='unique_frame_number_video'),)
     @staticmethod
     def get_files_in_project_id_list(session, project_id, id_list):
         file_list_db = session.query(File).filter(File.id.in_(id_list), File.project_id == project_id).all()


### PR DESCRIPTION
Idea is to prevent the DB to have an undesired state by limiting a unique frame number per video parent file id.

- This will mitigate the issue of having to threads process the same video (due to users retrying the same video 2 times or more)