### PR TITLE
Allow 0 values on polygon instances

### DIFF
--- a/frontend/src/components/input/instance_schema_mapper.vue
+++ b/frontend/src/components/input/instance_schema_mapper.vue
@@ -823,7 +823,7 @@
                 return
               }
               for (const point of value) {
-                if ((!point.x || isNaN(point.x)) || (!point.y || isNaN(point.y))) {
+                if ((point.x == undefined || isNaN(point.x)) || (point.y === undefined || isNaN(point.y))) {
                   this.error_polygon_instance['points'] = 'Points should have an array of X,Y values objects({x: number, y: number})'
                   this.error_polygon_instance['row_number'] = i
                   this.error_polygon_instance['data'] = JSON.stringify(value);

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -1566,7 +1566,7 @@ class Annotation_Update():
         filtered_points = []
         for index, point in enumerate(self.instance.points['points']):
 
-            if not isinstance(point, dict) or not point[x] or not point[y]:
+            if not isinstance(point, dict) or point[x] is None or point[y] is None:
                 continue
 
             filtered_points.append(
@@ -1597,7 +1597,6 @@ class Annotation_Update():
                 return False
 
         self.instance.points['points'] = filtered_points
-
         return True
 
     def build_existing_hash_list(self):


### PR DESCRIPTION
This was a bug where the validation was checking for a falsy value and when x,y where 0 the point would not be added to the image.