### PR TITLE
Small bug fix - upgrade to latest call back

### DIFF
--- a/frontend/src/components/user/account/user_password.vue
+++ b/frontend/src/components/user/account/user_password.vue
@@ -17,7 +17,7 @@
           </v-alert>
 
           <v-text-field :append-icon="password_hide ? 'visibility' : 'visibility_off'"
-                        :append-icon-cb="() => (password_hide = !password_hide)"
+                        @click:append="() => (password_hide = !password_hide)"
                         :type="password_hide ? 'password' : 'text'"
                         label="Password"
                         data-cy="password1"
@@ -27,7 +27,7 @@
           </v-text-field>
 
           <v-text-field :append-icon="password_hide_check ? 'visibility' : 'visibility_off'"
-                        :append-icon-cb="() => (password_hide_check = !password_hide_check)"
+                        @click:append="() => (password_hide_check = !password_hide_check)"
                         :type="password_hide_check ? 'password' : 'text'"
                         label="Retype Password"
                         validate-on-blur


### PR DESCRIPTION
append-icon-cb was deprecated and causing this function to not work
did manual test and appears to be working as expected

context is that now that we default to requiring password, this was preventing a user from copying and pasting or inspecting their password.

this is a small bug fix will merge once tests pass