### PR TITLE
Prevent Silent Deletion of Instances in Annotation_Update

### DIFF
--- a/default/tests/shared/test_annotation.py
+++ b/default/tests/shared/test_annotation.py
@@ -96,3 +96,27 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         self.assertTrue('missing_ids' in ann_update.log['error'])
         self.assertTrue(instance2.id in ann_update.log['error']['missing_ids'])
         self.assertTrue(instance3.id in ann_update.log['error']['missing_ids'])
+
+
+        # Now test case with validations and a wrong payload and some existing deleted instances
+        instance4 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'soft_delete': True},
+            self.session
+        )
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = new_list_payload_wrong,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
+
+        self.assertFalse(result)
+        self.assertTrue(len(ann_update.log['error'].keys()) > 0)
+        self.assertTrue('new_instance_list_missing_ids' in ann_update.log['error'])
+        self.assertTrue('information' in ann_update.log['error'])
+        self.assertTrue('missing_ids' in ann_update.log['error'])
+        self.assertTrue(instance2.id in ann_update.log['error']['missing_ids'])
+        self.assertTrue(instance3.id in ann_update.log['error']['missing_ids'])
+        self.assertTrue(instance4.id not in ann_update.log['error']['missing_ids'])

--- a/default/tests/shared/test_annotation.py
+++ b/default/tests/shared/test_annotation.py
@@ -15,7 +15,7 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
     def setUp(self):
         # TODO: this test is assuming the 'my-sandbox-project' exists and some object have been previously created.
         # For future tests a mechanism of setting up and tearing down the database should be created.
-        super(TestQueryCreator, self).setUp()
+        super(TestAnnotationUpdate, self).setUp()
         project_data = data_mocking.create_project_with_context(
             {
                 'users': [
@@ -38,6 +38,61 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
     def test__check_all_instances_available_in_new_instance_list(self):
         file1 = data_mocking.create_file({'project_id': self.project.id}, self.session)
         instance1 = data_mocking.create_instance(
-            {'x_min': 1,'x_max': 10, 'y_min': 1, 'y_max': 10},
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id},
             self.session
         )
+        instance2 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id},
+            self.session
+        )
+
+        instance3 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id},
+            self.session
+        )
+        old_payload = [instance1, instance2, instance3]
+        new_list_payload = [x.serialize_with_label() for x in old_payload]
+        new_list_payload_wrong = [instance1.serialize_with_label()]
+
+        # Test Case where we don't want to run verification
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = new_list_payload,
+            file = file1,
+            do_init_existing_instances = False
+        )
+        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
+
+        self.assertIsNone(result)
+
+        # Now test case with validations
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = new_list_payload,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
+
+        self.assertTrue(result)
+
+
+        # Now test case with validations and a wrong payload
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = new_list_payload_wrong,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
+
+        self.assertFalse(result)
+        self.assertTrue(len(ann_update.log['error'].keys()) > 0)
+        self.assertTrue('new_instance_list_missing_ids' in ann_update.log['error'])
+        self.assertTrue('information' in ann_update.log['error'])
+        self.assertTrue('missing_ids' in ann_update.log['error'])
+        self.assertTrue(instance2.id in ann_update.log['error']['missing_ids'])
+        self.assertTrue(instance3.id in ann_update.log['error']['missing_ids'])

--- a/default/tests/shared/test_annotation.py
+++ b/default/tests/shared/test_annotation.py
@@ -64,7 +64,7 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         )
         result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
 
-        self.assertIsNone(result)
+        self.assertTrue(result)
 
         # Now test case with validations
         ann_update = Annotation_Update(

--- a/default/tests/shared/test_annotation.py
+++ b/default/tests/shared/test_annotation.py
@@ -1,0 +1,43 @@
+from methods.regular.regular_api import *
+from default.tests.test_utils import testing_setup
+from shared.tests.test_utils import common_actions, data_mocking
+from base64 import b64encode
+from shared.annotation import Annotation_Update
+
+
+class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
+    """
+
+
+
+    """
+
+    def setUp(self):
+        # TODO: this test is assuming the 'my-sandbox-project' exists and some object have been previously created.
+        # For future tests a mechanism of setting up and tearing down the database should be created.
+        super(TestQueryCreator, self).setUp()
+        project_data = data_mocking.create_project_with_context(
+            {
+                'users': [
+                    {'username': 'Test',
+                     'email': 'test@test.com',
+                     'password': 'diffgram123',
+                     }
+                ]
+            },
+            self.session
+        )
+        self.project = project_data['project']
+        self.project_data = project_data
+        self.auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
+        self.member = self.auth_api.member
+
+        self.credentials = b64encode("{}:{}".format(self.auth_api.client_id,
+                                                    self.auth_api.client_secret).encode()).decode('utf-8')
+
+    def test__check_all_instances_available_in_new_instance_list(self):
+        file1 = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        instance1 = data_mocking.create_instance(
+            {'x_min': 1,'x_max': 10, 'y_min': 1, 'y_max': 10},
+            self.session
+        )

--- a/frontend/cypress/integration/diffgram/annotate_files/annotate_files_data_integrity.js
+++ b/frontend/cypress/integration/diffgram/annotate_files/annotate_files_data_integrity.js
@@ -1,0 +1,112 @@
+import testUser from '../../../fixtures/users.json';
+import testLabels from '../../../fixtures/labels.json';
+import {get_transformed_coordinates} from '../../../support/utils'
+
+describe('Annotate Files Tests', () => {
+
+  context('Test Annotate files Data Integrity ', () => {
+    before(function () {
+      Cypress.Cookies.debug(true, {verbose: true})
+      Cypress.Cookies.defaults({
+        preserve: ['session']
+      })
+      // login before all tests
+      cy.loginByForm(testUser.email, testUser.password);
+      cy.gotToProject(testUser.project_string_id);
+      cy.createLabels(testLabels)
+      cy.uploadAndViewSampleImage(testUser.project_string_id);
+
+    })
+
+    context('It Correctly raises an error when frontend sends invalid instance list.', () => {
+      it('Correctly raises an instance_list integrity error.', () => {
+        cy.intercept(`api/project/*/file/*/annotation/update`).as('annotation_update')
+
+
+        // Draw 3 boxes
+        const boxes = [
+          {
+            min_x: 75,
+            min_y: 75,
+            max_x: 120,
+            max_y: 120,
+          },
+          {
+            min_x: 150,
+            min_y: 150,
+            max_x: 220,
+            max_y: 220,
+          },
+          {
+            min_x: 275,
+            min_y: 275,
+            max_x: 320,
+            max_y: 320,
+          }
+        ]
+        for (let box of boxes) {
+          cy.mousedowncanvas(box.min_x, box.min_x);
+          cy.wait(500)
+
+          cy.mouseupcanvas();
+          cy.wait(1000)
+
+          cy.mousedowncanvas(box.max_x, box.max_x);
+          cy.wait(500)
+          cy.mouseupcanvas();
+
+          cy.wait(2000)
+        }
+
+
+        cy.get('[data-cy="save_button"]').click({force: true})
+        cy.wait('@annotation_update')
+          .should(({request, response}) => {
+            expect(request.method).to.equal('POST')
+            // it is a good practice to add assertion messages
+            // as the 2nd argument to expect()
+            expect(response.statusCode, 'response status').to.eq(200)
+          })
+        // Now Manually remove an instance and send payload again with a new box
+        cy.window().then(window => {
+          window.AnnotationCore.instance_list.shift();
+          // Draw one more box
+          const box = {
+            min_x: 175,
+            min_y: 175,
+            max_x: 224,
+            max_y: 224,
+          }
+          cy.mousedowncanvas(box.min_x, box.min_x);
+          cy.wait(500)
+
+          cy.mouseupcanvas();
+          cy.wait(1000)
+
+          cy.mousedowncanvas(box.max_x, box.max_x);
+          cy.wait(500)
+          cy.mouseupcanvas();
+
+          cy.wait(2000)
+          cy.get('[data-cy="save_button"]').click({force: true})
+          cy.wait('@annotation_update')
+            .should(({request, response}) => {
+              expect(request.method).to.equal('POST')
+              // it is a good practice to add assertion messages
+              // as the 2nd argument to expect()
+              console.log('respoonsee', response.error, response.data)
+              expect(response.statusCode, 'response status').to.eq(400)
+              expect(response.body.log.error).to.have.all.keys(
+                'new_instance_list_missing_ids',
+                'information',
+                'missing_ids'
+                )
+
+            })
+        });
+      })
+    })
+
+  })
+
+})

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -370,13 +370,15 @@ class Annotation_Update():
         return self.new_added_instances
 
     def __check_all_instances_available_in_new_instance_list(self):
-        if not self.init_existing_instances:
+        if not self.do_init_existing_instances:
             return
         new_id_list = []
         for inst in self.instance_list_new:
             if inst.get('id'):
                 new_id_list.append(inst.get('id'))
 
+        print('NEW ID LIST', new_id_list)
+        print('instance_list_existing', self.instance_list_existing)
         ids_not_included = []
         for instance in self.instance_list_existing:
             if instance.id not in new_id_list:
@@ -388,6 +390,7 @@ class Annotation_Update():
                 ids_not_included
             )
             self.log['error']['information'] = 'Please try reloading page or check your network connection.'
+            self.log['error']['missing_ids'] =  ids_not_included
             return False
         return True
 

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -371,7 +371,7 @@ class Annotation_Update():
 
     def __check_all_instances_available_in_new_instance_list(self):
         if not self.do_init_existing_instances:
-            return
+            return True
         new_id_list = []
         for inst in self.instance_list_new:
             if inst.get('id'):

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -381,6 +381,9 @@ class Annotation_Update():
         print('instance_list_existing', self.instance_list_existing)
         ids_not_included = []
         for instance in self.instance_list_existing:
+            # We don't check for soft_deleted instances
+            if instance.soft_delete:
+                continue
             if instance.id not in new_id_list:
                 ids_not_included.append(instance.id)
 

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -369,6 +369,28 @@ class Annotation_Update():
 
         return self.new_added_instances
 
+    def __check_all_instances_available_in_new_instance_list(self):
+        if not self.init_existing_instances:
+            return
+        new_id_list = []
+        for inst in self.instance_list_new:
+            if inst.get('id'):
+                new_id_list.append(inst.get('id'))
+
+        ids_not_included = []
+        for instance in self.instance_list_existing:
+            if instance.id not in new_id_list:
+                ids_not_included.append(instance.id)
+
+        if len(ids_not_included) > 0:
+            logger.error('Invalid payload on annotation update missing IDs {}'.format(ids_not_included))
+            self.log['error']['new_instance_list_missing_ids'] = 'Invalid payload sent to server, missing the following instances IDs {}'.format(
+                ids_not_included
+            )
+            self.log['error']['information'] = 'Please try reloading page or check your network connection.'
+            return False
+        return True
+
     def annotation_update_main(self):
 
         """
@@ -380,6 +402,14 @@ class Annotation_Update():
         if not self.instance_list_new and not self.clean_instances:
             return self.return_orginal_file_type()
         logger.debug('Bulding existing hash list...')
+
+        payload_includes_all_instances = self.__check_all_instances_available_in_new_instance_list()
+
+        if not payload_includes_all_instances:
+            logger.error('Error updating annotation {}'.format(str(self.log)))
+            logger.error('Instance list is: {}'.format(self.instance_list_new))
+            return self.return_orginal_file_type()
+
         self.build_existing_hash_list()
 
         ### Main work


### PR DESCRIPTION
In some cases the frontend can have unexpected bugs which makes the instance_list to not be sent completely to the backend.

Old versions assume that if instance was not present, it should be deleted, which caused unexpected silent deletion in some cases.

Now we double check that all the instances are available on the request payload before executing any logic in Annotation_Update