### PR TITLE
Silent Deletion Improvements

### DIFF
--- a/default/methods/source_control/file/file_cache_regen.py
+++ b/default/methods/source_control/file/file_cache_regen.py
@@ -1,0 +1,111 @@
+try:
+    from methods.regular.regular_api import *
+    from methods.source_control.file.remove import remove_core as file_remove_core
+    from methods.source_control.file.file_browser import File_Browser
+
+except:
+    from default.methods.regular.regular_api import *
+    from default.methods.source_control.file.remove import remove_core as file_remove_core
+    from default.methods.source_control.file.file_browser import File_Browser
+
+from shared.utils import job_dir_sync_utils
+from shared.utils.sync_events_manager import SyncEventManager
+from shared.utils.source_control.file.file_transfer_core import file_transfer_core
+from shared.database.batch.batch import InputBatch
+
+
+@routes.route('/api/v1/project/<string:project_string_id>/file/<int:file_id>/regenerate-cache',
+              methods = ['POST'])
+@Project_permissions.user_has_project(
+    Roles = ["admin", "Editor"],
+    apis_user_list = ['api_enabled_builder', 'security_email_verified'])
+@limiter.limit("300 per day")
+def api_file_cache_regen(project_string_id, file_id):
+    """
+    For limits for this, this route may be used for single files (not just lists)
+
+    """
+
+    # TODO how do we want to handle this for labels?
+    # I like enfocring a directory id with the request
+    # But labels requires using fallback. (project default)
+
+    spec_list = [{'frame_number': {
+        "required": False,
+        "kind": int
+    }}]
+
+    log, input, untrusted_input = regular_input.master(request = request,
+                                                       spec_list = spec_list)
+    if len(log["error"].keys()) >= 1:
+        return jsonify(log = log), 400
+
+    with sessionMaker.session_scope() as session:
+
+        user = User.get(session = session)
+        if user:
+            member = user.member
+        else:
+            client_id = request.authorization.get('username', None)
+            auth = Auth_api.get(session, client_id)
+            member = auth.member
+        project = Project.get(session, project_string_id)
+
+        result, log = cache_regeneration_core(
+            session = session,
+            project = project,
+            file_id = file_id,
+            frame_number = input.get('frame_number'),
+            log = log
+        )
+
+        if len(log["error"].keys()) >= 1:
+            return jsonify(log = log), 400
+
+        Event.new(
+            session = session,
+            kind = "cache_regeneration",
+            member_id = member.id,
+            project_id = project.id,
+            file_id = file_id,
+            description = str('Regenerated Cache. Frame {}'.format(input.get('frame_number')))
+        )
+
+        log['success'] = True
+        return jsonify(result = result, log = log), 200
+
+
+def cache_regeneration_core(session, project, file_id, frame_number, log):
+    result = {}
+
+    file = File.get_by_id(session, file_id = file_id)
+
+    if file.project_id != project.id:
+        log['error']['file_id'] = 'File {} project mismatch please provide a file within the give project: {}.'.format(
+            file_id,
+            project.project_string_id
+        )
+        return result, log
+
+    if file.type == 'video':
+        # Check that frame number exists
+        if not frame_number:
+            log['error']['frame_number'] = 'File {}: provide frame number.'.format(file_id)
+            return result, log
+        else:
+            file = session.query(File).filter(
+                File.video_parent_file_id == file_id,
+                File.frame_number == frame_number
+            ).first()
+            if not file:
+                log['error']['frame_number'] = 'Frame {} does not exists.'.format(frame_number)
+                return result, log
+    # Invalidate cache
+    file.set_cache_key_dirty('instance_list')
+    # Regenerate Cache
+    result['file_data'] = file.get_with_cache(
+        cache_key = 'instance_list',
+        cache_miss_function = file.serialize_instance_list_only,
+        session = session)
+    result['regenerated'] = True
+    return result, log

--- a/default/routes_init.py
+++ b/default/routes_init.py
@@ -119,3 +119,4 @@ def do_routes_importing():
 
     from methods.model.model_run_list import model_run_list_web
     from methods.query_engine.query_suggest import query_suggest_web
+    from methods.source_control.file.file_cache_regen import api_file_cache_regen

--- a/default/tests/methods/source_control/file/test_file_cache_regen.py
+++ b/default/tests/methods/source_control/file/test_file_cache_regen.py
@@ -1,0 +1,147 @@
+from methods.regular.regular_api import *
+from default.tests.test_utils import testing_setup
+from shared.tests.test_utils import common_actions, data_mocking
+from base64 import b64encode
+from shared.database.auth.member import Member
+from methods.discussions import discussion_comment_new
+from unittest.mock import patch
+import flask
+
+
+class TeseFileCacheRegen(testing_setup.DiffgramBaseTestCase):
+    """
+        
+        
+        
+    """
+
+    def setUp(self):
+        # TODO: this test is assuming the 'my-sandbox-project' exists and some object have been previously created.
+        # For future tests a mechanism of setting up and tearing down the database should be created.
+        super(TeseFileCacheRegen, self).setUp()
+        project_data = data_mocking.create_project_with_context(
+            {
+                'users': [
+                    {'username': 'Test',
+                     'email': 'test@test.com',
+                     'password': 'diffgram123',
+                     }
+                ]
+            },
+            self.session
+        )
+        self.project = project_data['project']
+        self.project_data = project_data
+        self.auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
+        self.member = self.auth_api.member
+
+    def test_api_file_cache_regen(self):
+        # Create mock tasks
+
+        file = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        instance1 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        instance2 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        serialized_instances = [instance1.serialize_with_label(), instance2.serialize_with_label()]
+        # Image case
+        request_data = {}
+        self.assertIsNone(file.cache_dict.get('instance_list'))
+        endpoint = "/api/v1/project/{}/file/{}/regenerate-cache".format(self.project.project_string_id, file.id)
+        credentials = b64encode("{}:{}".format(
+            self.auth_api.client_id,
+            self.auth_api.client_secret).encode()).decode('utf-8')
+
+        response = self.client.post(
+            endpoint,
+            data = json.dumps(request_data),
+            headers = {
+                'Authorization': 'Basic {}'.format(credentials)
+            }
+
+        )
+        data = response.json
+        print(data)
+        self.assertEqual(response.status_code, 200)
+        session2 = sessionMaker.session_factory()
+        file_with_cache = File.get_by_id(session2, file_id = file.id)
+        ids = [x['id'] for x in file_with_cache.cache_dict['instance_list']]
+        self.assertTrue(instance1.id in ids)
+        self.assertTrue(instance2.id in ids)
+
+        # Video case
+        video_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'video'}, self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        instance1 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': video_file.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        instance2 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': video_file.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        # No frame provided case
+        request_data = {}
+        self.assertIsNone(video_file.cache_dict.get('instance_list'))
+        endpoint = "/api/v1/project/{}/file/{}/regenerate-cache".format(self.project.project_string_id, video_file.id)
+        credentials = b64encode("{}:{}".format(
+            self.auth_api.client_id,
+            self.auth_api.client_secret).encode()).decode('utf-8')
+
+        response = self.client.post(
+            endpoint,
+            data = json.dumps(request_data),
+            headers = {
+                'Authorization': 'Basic {}'.format(credentials)
+            }
+
+        )
+        data = response.json
+        print(data)
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue('error' in data['log'])
+        self.assertTrue('frame_number' in data['log']['error'])
+
+        # Frame provided case
+        video_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'video'}, self.session)
+        frame_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': video_file.id, 'frame_number': 54}, self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        instance1 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': frame_file.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        instance2 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': frame_file.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        request_data = {
+            'frame_number': 54
+        }
+        self.assertIsNone(frame_file.cache_dict.get('instance_list'))
+        endpoint = "/api/v1/project/{}/file/{}/regenerate-cache".format(self.project.project_string_id, frame_file.id)
+        credentials = b64encode("{}:{}".format(
+            self.auth_api.client_id,
+            self.auth_api.client_secret).encode()).decode('utf-8')
+
+        response = self.client.post(
+            endpoint,
+            data = json.dumps(request_data),
+            headers = {
+                'Authorization': 'Basic {}'.format(credentials)
+            }
+
+        )
+        data = response.json
+        print(data)
+        self.assertEqual(response.status_code, 200)
+        session2 = sessionMaker.session_factory()
+        file_with_cache = File.get_by_id(session2, file_id = frame_file.id)
+        ids = [x['id'] for x in file_with_cache.cache_dict['instance_list']]
+        self.assertTrue(instance1.id in ids)
+        self.assertTrue(instance2.id in ids)
+

--- a/default/tests/shared/test_annotation.py
+++ b/default/tests/shared/test_annotation.py
@@ -37,17 +37,18 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
 
     def test__check_all_instances_available_in_new_instance_list(self):
         file1 = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id}, self.session)
         instance1 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id},
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
             self.session
         )
         instance2 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id},
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
             self.session
         )
 
         instance3 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id},
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
             self.session
         )
         old_payload = [instance1, instance2, instance3]
@@ -100,7 +101,7 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
 
         # Now test case with validations and a wrong payload and some existing deleted instances
         instance4 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'soft_delete': True},
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'soft_delete': True, 'label_file_id': label_file.id},
             self.session
         )
         ann_update = Annotation_Update(

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -200,7 +200,7 @@ Cypress.Commands.add('registerDataPlatformTestUser', function () {
   cy.wait(500);
   // cy.get('[data-cy="error-email"]').should('not.be.visible');
   cy.wait(3500);
-  cy.url().should('eq', 'http://localhost:8085/user/new')
+  cy.url().should('eq', 'http://localhost:8085/user/builder/signup')
   cy.wait(2000)
   cy.get('[data-cy=first_name]').click();
   cy.get('[data-cy=first_name]').type('Diffgram');

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -200,7 +200,7 @@ Cypress.Commands.add('registerDataPlatformTestUser', function () {
   cy.wait(500);
   // cy.get('[data-cy="error-email"]').should('not.be.visible');
   cy.wait(3500);
-  cy.url().should('eq', 'http://localhost:8085/user/builder/signup')
+  cy.url().should('eq', 'http://localhost:8085/user/new')
   cy.wait(2000)
   cy.get('[data-cy=first_name]').click();
   cy.get('[data-cy=first_name]').type('Diffgram');

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -63,17 +63,18 @@
                type="info">
         {{task_error.task_request}}
       </v-alert>
-      <div fluid v-if="display_refresh_cache_button">
-        <v-btn color="warning" @click="regenerate_file_cache" :loading="regenerate_file_cache_loading">
-          <v-icon>mdi-refresh</v-icon>
-          Regenerate File Cache
-        </v-btn>
-      </div>
+
       <v_error_multiple :error="save_error">
       </v_error_multiple>
-
+      <div fluid v-if="display_refresh_cache_button">
+        <v-btn small color="warning" @click="regenerate_file_cache" :loading="regenerate_file_cache_loading">
+          <v-icon>mdi-refresh</v-icon>
+          Refresh File Data
+        </v-btn>
+      </div>
       <v_error_multiple :error="error">
       </v_error_multiple>
+
 
       <v_error_multiple :error="instance_buffer_error">
       </v_error_multiple>
@@ -1795,14 +1796,23 @@ export default Vue.extend( {
     },
     regenerate_file_cache: async function(){
       this.regenerate_file_cache_loading = true;
-      if(this.video_mode){
-
+      let frame_number = this.current_frame;
+      let file_id = undefined;
+      if(this.$props.task){
+        file_id = this.$props.task.file_id;
       }
       else{
-
+        file_id = this.$props.file.id;
       }
-
-      const response = await axios.post()
+      const response = await axios.post(`/api/v1/project/${this.$props.project_string_id}/file/${file_id}/regenerate-cache`,
+        {
+          frame_number: frame_number
+        }
+      );
+      if(response.status === 200){
+        this.has_changed = false;
+        location.reload();
+      }
     },
     get_new_canvas: function () {
       this.html_image.crossOrigin = "Anonymous";
@@ -6480,6 +6490,7 @@ export default Vue.extend( {
           error.response.data.log &&
           error.response.data.log.error && error.response.data.log.error.missing_ids){
           this.display_refresh_cache_button = true;
+          clearInterval(this.interval_autosave);
         }
 
         this.save_error = this.$route_api_errors(error)

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -63,7 +63,12 @@
                type="info">
         {{task_error.task_request}}
       </v-alert>
-
+      <div fluid v-if="display_refresh_cache_button">
+        <v-btn color="warning" @click="regenerate_file_cache" :loading="regenerate_file_cache_loading">
+          <v-icon>mdi-refresh</v-icon>
+          Regenerate File Cache
+        </v-btn>
+      </div>
       <v_error_multiple :error="save_error">
       </v_error_multiple>
 
@@ -932,6 +937,8 @@ export default Vue.extend( {
 
       selected_instance_for_history: undefined,
       show_instance_history: false,
+      regenerate_file_cache_loading: false,
+      display_refresh_cache_button: false,
       get_instances_loading: false,
       canvas_mouse_tools: false,
       show_custom_snackbar: false,
@@ -1786,7 +1793,17 @@ export default Vue.extend( {
 
       return roi_canvas
     },
+    regenerate_file_cache: async function(){
+      this.regenerate_file_cache_loading = true;
+      if(this.video_mode){
 
+      }
+      else{
+
+      }
+
+      const response = await axios.post()
+    },
     get_new_canvas: function () {
       this.html_image.crossOrigin = "Anonymous";
 
@@ -6459,6 +6476,11 @@ export default Vue.extend( {
         }
       } catch (error) {
         this.save_loading = false
+        if(error.response.data &&
+          error.response.data.log &&
+          error.response.data.log.error && error.response.data.log.error.missing_ids){
+          this.display_refresh_cache_button = true;
+        }
 
         this.save_error = this.$route_api_errors(error)
         console.debug(error);

--- a/frontend/src/components/annotation/instance_detail_list_view.vue
+++ b/frontend/src/components/annotation/instance_detail_list_view.vue
@@ -49,7 +49,12 @@
               differently...
                -->
             <v-divider class="mt-4"></v-divider>
-            <h3>Instances: </h3>
+            <h3>
+              Instances:
+              <v-chip v-if="$store.state.user.current.is_super_admin == true" x-small>
+              {{instance_list_count}}
+              </v-chip>
+            </h3>
             <v-expansion-panels accordion flat v-model="panels">
               <v-expansion-panel v-for="grouped_list in filtered_instance_set">
                 <v-expansion-panel-header  ripple v-if="grouped_list.model_run">
@@ -627,6 +632,19 @@ import Vue from "vue";
         else{
           return false;
         }
+      },
+      instance_list_count: function(){
+        let count = 0;
+        for(const group of this.filtered_instance_set){
+          if(this.label_settings.show_removed_instances){
+            count += group.instance_list.length;
+          }
+          else{
+            count += group.instance_list.filter(inst => inst.soft_delete === false).length;
+          }
+
+        }
+        return count
       },
       filtered_instance_set: function(){
         const instance_list = this.instance_list.map((inst, i) => ({

--- a/frontend/src/components/regular/regular_error_handling.js
+++ b/frontend/src/components/regular/regular_error_handling.js
@@ -43,7 +43,6 @@ in data() in JS
 **/
 import store from '../../store';
 export function route_errors (error) {
-  console.log('AAAAA', error);
   if(error && error.message && error.message === 'Network Error'){
     store.commit('set_connection_error', error);
     return {

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -392,8 +392,10 @@ class Annotation_Update():
             self.log['error']['new_instance_list_missing_ids'] = 'Invalid payload sent to server, missing the following instances IDs {}'.format(
                 ids_not_included
             )
-            self.log['error']['information'] = 'Please try reloading page or check your network connection.'
-            self.log['error']['missing_ids'] =  ids_not_included
+            self.log['error']['information'] = 'Error: outdated instance list sent. This can happen when 2 users are working on the same file at the same time.' \
+                                               'Please try reloading page, clicking the refresh file data button or check your network connection. ' \
+                                               'Please contact use if this persists.'
+            self.log['error']['missing_ids'] = ids_not_included
             return False
         return True
 

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -377,14 +377,14 @@ class Annotation_Update():
             if inst.get('id'):
                 new_id_list.append(inst.get('id'))
 
-        print('NEW ID LIST', new_id_list)
-        print('instance_list_existing', self.instance_list_existing)
         ids_not_included = []
         for instance in self.instance_list_existing:
             # We don't check for soft_deleted instances
             if instance.soft_delete:
                 continue
             if instance.id not in new_id_list:
+                instance.hash_instance()
+                self.session.add(instance)
                 ids_not_included.append(instance.id)
 
         if len(ids_not_included) > 0:

--- a/shared/database/source_control/file.py
+++ b/shared/database/source_control/file.py
@@ -179,6 +179,9 @@ class File(Base, Caching):
     # For semantic segmentation,
     mask_joint_blob_name = Column(String())
 
+    # Warning: do not edit the cache manually. Especially for the instance list,
+    # the recommended way of updating instances is by callin Annotation_Update().main and then
+    # setting the cache to dirty with set_cache_key_dirty()
     cache_dict = Column(MutableDict.as_mutable(JSONEncodedDict),
                         default={})
 
@@ -504,6 +507,7 @@ class File(Base, Caching):
     # generally use WorkingDirFileLink.file_list()
     # Becuase we need to cross reference datasets
 
+    @staticmethod
     def get_by_id(session, file_id):
         return session.query(File).filter(File.id == file_id).first()
 


### PR DESCRIPTION
This improvements build on top if 2 realizations:

- If the file cache was manually/maliciously corrupted via a script, direct sql, etc. The user can get in a state where the file cannot be saved.
- If for some reason the file has was not regenerated re-saving the file won't soft delete  it.

So basically adding 2 additions:

1) Add a reload and regenerate cache button, so that if the above case happen at leas there is a way for the user to get back the correctly saved data and get back to annotating.
2) When we find a case of an instance not existing in the cache, we regenerate the hash to prevent the case where the instance does not match the hash, that way when the user refreshes and saves again the instance should have the correct hash.
