### PR TITLE
Add borders in solid case

### DIFF
--- a/frontend/src/components/vue_canvas/instance_list.vue
+++ b/frontend/src/components/vue_canvas/instance_list.vue
@@ -423,6 +423,9 @@
               else{
                 strokeColor = this.colour.hex
               }
+              if(this.$props.default_instance_opacity === 1){
+                strokeColor = "#FFFFFF"
+              }
 
             }
             if(instance.override_color && !instance.selected){


### PR DESCRIPTION
When instances have no opacity, add a white border line to differentiate between instances.