### PR TITLE
fix: avoid race conditions and concurrent updates on annotation update

### DIFF
--- a/default/methods/annotation/annotation.py
+++ b/default/methods/annotation/annotation.py
@@ -6,91 +6,99 @@ from shared.annotation import annotation_update_web
 from shared.annotation import task_annotation_update
 
 
-@routes.route('/api/project/<string:project_string_id>/file/<int:file_id>/annotation/update', 
-			methods=['POST'])
+@routes.route('/api/project/<string:project_string_id>/file/<int:file_id>/annotation/update',
+              methods = ['POST'])
 @Project_permissions.user_has_project(["admin", "Editor"])
 def annotation_update_via_project_api(project_string_id, file_id):
 
-	with sessionMaker.session_scope() as session:
+    log = regular_log.default()
+    with sessionMaker.session_scope() as session:
 
-		new_file, annotation_update = annotation_update_web(
-			session = session,
-			project_string_id = project_string_id, 
-			file_id = file_id)
+        new_file, annotation_update = annotation_update_web(
+            session = session,
+            project_string_id = project_string_id,
+            file_id = file_id,
+            log = log)
 
-		if len(annotation_update.log["error"].keys()) >= 1:
-			return jsonify(log=annotation_update.log), 400
+        if len(log["error"].keys()) >= 1:
+            return jsonify(log = log), 400
 
-		sequence = None
-		if annotation_update.sequence:
-			sequence = annotation_update.sequence.serialize_for_label_subset(
-				session = session)
+        if len(annotation_update.log["error"].keys()) >= 1:
+            return jsonify(log = annotation_update.log), 400
 
-		deleted_instances = annotation_update.new_deleted_instances
-		added_instances = annotation_update.new_added_instances
-		# We need to serialize all the instances for the frontend to render them correctly.
-		added_instances = [x.serialize() for x in added_instances]
+        sequence = None
+        if annotation_update.sequence:
+            sequence = annotation_update.sequence.serialize_for_label_subset(
+                session = session)
 
-		return jsonify( 
-			success = True,
-			log = annotation_update.log,
-			new_file= new_file,
-			added_instances = added_instances,
-			deleted_instances = deleted_instances,
-			sequence = sequence), 200
+        deleted_instances = annotation_update.new_deleted_instances
+        added_instances = annotation_update.new_added_instances
+        # We need to serialize all the instances for the frontend to render them correctly.
+        added_instances = [x.serialize() for x in added_instances]
+
+        return jsonify(
+            success = True,
+            log = annotation_update.log,
+            new_file = new_file,
+            added_instances = added_instances,
+            deleted_instances = deleted_instances,
+            sequence = sequence), 200
 
 
-@routes.route('/api/v1/task/<int:task_id>/annotation/update', methods=['POST'])
-@Permission_Task.by_task_id(apis_user_list=["builder_or_trainer"])
+@routes.route('/api/v1/task/<int:task_id>/annotation/update', methods = ['POST'])
+@Permission_Task.by_task_id(apis_user_list = ["builder_or_trainer"])
 def task_annotation_update_api(task_id):
+    # None for now since may be empty if no changes
+    """
+    If the type is a video, we assume the front end will pass the correct frame_number
+    to be used. We get the image file using the frame id and the task.file_id as the
+    parent.
 
-	# None for now since may be empty if no changes
-	"""
-	If the type is a video, we assume the front end will pass the correct frame_number
-	to be used. We get the image file using the frame id and the task.file_id as the 
-	parent.
+    """
 
-	"""
+    spec_list = [{"instance_list": None},
+                 {"and_complete": bool},
+                 {"video_data": {
+                     'kind': dict,
+                     'default': None
+                 }
+                 }]
 
-	spec_list = [{"instance_list": None},
-				 {"and_complete": bool},
-				 {"video_data": {
-					'kind': dict,
-					'default': None				
-					}
-				}]
+    log, input, untrusted_input = regular_input.master(request = request,
+                                                       spec_list = spec_list)
+    if len(log["error"].keys()) >= 1:
+        return jsonify(log = log), 400
 
-	log, input, untrusted_input = regular_input.master(request=request,
-													   spec_list=spec_list)
-	if len(log["error"].keys()) >= 1:
-		return jsonify(log=log), 400
+    # MAIN
+    with sessionMaker.session_scope() as session:
 
-	# MAIN
-	with sessionMaker.session_scope() as session:
+        new_file, annotation_update = task_annotation_update(
+            session = session,
+            task_id = task_id,
+            input = input,
+            untrusted_input = untrusted_input,
+            log = log)
 
-		new_file, annotation_update = task_annotation_update(
-			session = session,
-			task_id = task_id, 
-			input = input,
-			untrusted_input = untrusted_input)
-			
-		if len(annotation_update.log["error"].keys()) >= 1:
-			return jsonify(log=annotation_update.log), 400
+        if len(log["error"].keys()) >= 1:
+            return jsonify(log = log), 400
 
-		sequence = None
-		if annotation_update.sequence:
-			sequence = annotation_update.sequence.serialize_for_label_subset(
-				session = session)
+        if len(annotation_update.log["error"].keys()) >= 1:
+            return jsonify(log = annotation_update.log), 400
 
-		deleted_instances = annotation_update.new_deleted_instances
-		added_instances = annotation_update.new_added_instances
-		# We need to serialize all the instances for the frontend to render them correctly.
-		added_instances = [x.serialize() for x in added_instances]
+        sequence = None
+        if annotation_update.sequence:
+            sequence = annotation_update.sequence.serialize_for_label_subset(
+                session = session)
 
-		return jsonify(
-			success = True,
-			log = annotation_update.log,
-			new_file= new_file,
-			added_instances= added_instances,
-			deleted_instances= deleted_instances,
-			sequence = sequence), 200
+        deleted_instances = annotation_update.new_deleted_instances
+        added_instances = annotation_update.new_added_instances
+        # We need to serialize all the instances for the frontend to render them correctly.
+        added_instances = [x.serialize() for x in added_instances]
+
+        return jsonify(
+            success = True,
+            log = annotation_update.log,
+            new_file = new_file,
+            added_instances = added_instances,
+            deleted_instances = deleted_instances,
+            sequence = sequence), 200

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6270,6 +6270,8 @@ export default Vue.extend( {
         edges: edges,
         version: undefined,
         root_id: undefined,
+        previous_id: undefined,
+        next_id: undefined,
         attribute_groups: {...instance_to_copy.attribute_groups}
       };
 
@@ -6363,6 +6365,7 @@ export default Vue.extend( {
         }
 
       }
+
 
       const current_frontend_instances = instance_list.map(id => id);
 

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6272,6 +6272,7 @@ export default Vue.extend( {
         root_id: undefined,
         previous_id: undefined,
         next_id: undefined,
+        creation_ref_id: undefined,
         attribute_groups: {...instance_to_copy.attribute_groups}
       };
 

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -561,6 +561,7 @@
                   :current_video="current_video"
                   :video_mode="video_mode"
                   :player_height="'80px'"
+                  :parent_save="this.detect_is_ok_to_save"
                   :video_primary_id="'video_primary'"
                   @playing="video_playing = true"
                   @pause="video_playing = false"
@@ -2435,9 +2436,9 @@ export default Vue.extend( {
       this.interval_autosave = setInterval(this.detect_is_ok_to_save, 15*1000);
     },
 
-    detect_is_ok_to_save: function() {
+    detect_is_ok_to_save: async function() {
       if (this.has_changed) {
-        this.save();
+        await this.save();
       }
     },
 
@@ -6268,6 +6269,7 @@ export default Vue.extend( {
         nodes: nodes,
         edges: edges,
         version: undefined,
+        root_id: undefined,
         attribute_groups: {...instance_to_copy.attribute_groups}
       };
 
@@ -6362,6 +6364,8 @@ export default Vue.extend( {
 
       }
 
+      const current_frontend_instances = instance_list.map(id => id);
+
     },
 
     save: async function (and_complete=false) {
@@ -6453,10 +6457,10 @@ export default Vue.extend( {
         this.save_count += 1;
         this.add_ids_to_new_instances_and_delete_old(response, video_data);
 
-        this.has_changed = false
+
         this.check_if_pending_created_instance();
         this.$emit('save_response_callback', true)
-        this.save_loading = false
+
         if(this.instance_buffer_metadata[this.current_frame]){
           this.instance_buffer_metadata[this.current_frame].pending_save = false;
         }
@@ -6496,7 +6500,8 @@ export default Vue.extend( {
          * We simply go to the "well" so to speak and request the next task here
          * using the "change_file".
          */
-
+        this.save_loading = false
+        this.has_changed = false
         if (and_complete == true) {
           // now that complete completes whole video, we can move to next as expected.
           this.snackbar_success = true

--- a/frontend/src/components/annotation/userscript/userscript.vue
+++ b/frontend/src/components/annotation/userscript/userscript.vue
@@ -626,7 +626,7 @@ import userscript_sources_selector from './userscript_sources_selector.vue'
       update_userscript_with_servercall: async function(){
 
         //console.debug(this.userscript_literal)
-        if (!this.userscript_literal) { return }
+        if (!this.userscript_literal || !this.userscript_literal.id) { return }
 
         this.loading = true;
         this.error = {}

--- a/frontend/src/components/video/video.vue
+++ b/frontend/src/components/video/video.vue
@@ -434,6 +434,9 @@ export default Vue.extend( {
       },
       'user_nav_width_for_frame_previews':{
         default: true
+      },
+      'parent_save':{
+        default: undefined
       }
     },
   components: {
@@ -693,11 +696,7 @@ export default Vue.extend( {
        *    but the channel between video and annotation core is not great
        */
 
-      this.$emit('request_save')
-
-      if (this.has_changed == true) {
-        await this.sleep(200) // give it a chance to save / fire off thing
-      }
+      await this.$props.parent_save()
 
       return true
 

--- a/frontend/src/components/video/video.vue
+++ b/frontend/src/components/video/video.vue
@@ -695,6 +695,9 @@ export default Vue.extend( {
        *    data ownership in vue components. like logically video should be a seperate thing
        *    but the channel between video and annotation core is not great
        */
+      if(!this.$props.parent_save){
+        return
+      }
 
       await this.$props.parent_save()
 

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -578,7 +578,8 @@ class Annotation_Update():
         self.instance_list_existing = Instance.list(session = self.session,
                                                     file_id = self.file.id,
                                                     limit = None,
-                                                    exclude_removed = False)
+                                                    exclude_removed = False,
+                                                    with_for_update = True)
         for instance in self.instance_list_existing:
             self.instance_list_existing_dict[instance.id] = instance
 

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -544,7 +544,9 @@ class Annotation_Update():
             self.file = File.get_frame_from_video(
                 session = self.session,
                 video_parent_file_id = self.video_parent_file.id,
-                frame_number = self.frame_number)
+                frame_number = self.frame_number,
+                with_for_update = True
+            )
 
             if self.file:
                 return
@@ -1758,10 +1760,11 @@ def task_annotation_update(
     instance_list_new = untrusted_input.get('instance_list', None)
     gold_standard_file = untrusted_input.get('gold_standard_file', None)
 
+    file = File.get_by_id(session = session, file_id = task.file_id, with_for_update = True)
     annotation_update = Annotation_Update(
         session = session,
         task = task,
-        file = task.file,
+        file = file,
         project = project,
         instance_list_new = instance_list_new,
         video_data = input['video_data'],
@@ -1834,7 +1837,8 @@ def annotation_update_web(
     file = File.get_by_id_and_project(
         session = session,
         project_id = project.id,
-        file_id = file_id)
+        file_id = file_id,
+        with_for_update = True)
 
     # If file permission error make sure it's sending image_file
     # and not video file.

--- a/shared/database/annotation/instance.py
+++ b/shared/database/annotation/instance.py
@@ -205,7 +205,8 @@ class Instance(Base):
         return_kind = "objects",
         date_to = None,
         date_from = None,
-        frame_number = None
+        frame_number = None,
+        with_for_update = False
     ):
         """
 
@@ -220,7 +221,8 @@ class Instance(Base):
 
         # Base Query
         query = session.query(Instance)
-
+        if with_for_update:
+            query = query.with_for_update()
         if file_id:
             query = query.filter(Instance.file_id == file_id)
 

--- a/shared/database/source_control/file.py
+++ b/shared/database/source_control/file.py
@@ -957,7 +957,10 @@ class File(Base, Caching):
                             user_id,
                             project_string_id,
                             file_id,
-                            directory_id=None):
+                            directory_id=None,
+                            with_for_update = False,
+                            nowait = False,
+                            skip_locked = False):
         """
 
         Even if we trust the directory (ie from project default),
@@ -981,9 +984,14 @@ class File(Base, Caching):
         working_dir_sub_query = session.query(WorkingDirFileLink).filter(
             WorkingDirFileLink.working_dir_id == directory_id).subquery('working_dir_sub_query')
 
-        file = session.query(File).filter(
-            File.id == working_dir_sub_query.c.file_id,
-            File.id == file_id).first()
+        if with_for_update:
+            file = session.query(File).with_for_update(nowait = nowait, skip_locked = skip_locked).filter(
+                File.id == working_dir_sub_query.c.file_id,
+                File.id == file_id).first()
+        else:
+            file = session.query(File).filter(
+                File.id == working_dir_sub_query.c.file_id,
+                File.id == file_id).first()
 
         # end_time = time.time()
         # print("File access time", end_time - start_time)

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -1536,10 +1536,15 @@ class Process_Media():
                 'current_frame': self.frame_number  # TODO Consider this from input for better consistency
             }
 
-        file = File.get_by_id(self.session, file_id)  # For video, expects it to be parent video file, not a frame
+
         allowed_model_id_list = self.__get_allowed_model_ids()
         allowed_model_runs_id_list = self.__get_allowed_model_run_ids()
         try:
+            file = File.get_by_id(self.session,
+                                  file_id,
+                                  with_for_update = True,
+                                  nowait = True)  # For video, expects it to be parent video file, not a frame
+
             annotation_update = Annotation_Update(
                 session=self.session,
                 file=file,

--- a/walrus/methods/video/interpolation.py
+++ b/walrus/methods/video/interpolation.py
@@ -7,620 +7,622 @@ from scipy.interpolate import interp1d
 import numpy as np
 
 from shared.annotation import Annotation_Update
-
+import traceback
 
 # TODO maybe rename this is interfering with scipy namespace
 class Interpolate():
 
+    def __init__(self, session, project, video_file, log):
 
-	def __init__(self, session, project, video_file, log):
+        self.session = session
+        self.project = project
+        self.video_file = video_file
+        self.log = log
 
-		self.session = session
-		self.project = project
-		self.video_file = video_file
-		self.log = log
+        self.member = get_member(session = session)
 
-		self.member = get_member(session=session)
+    def interpolate_all_sequences_in_video(self):
+        """
+        (All frames) Runs pipeline for frames to be interpolated
 
-	def interpolate_all_sequences_in_video(self):
-		"""
-		(All frames) Runs pipeline for frames to be interpolated
+        Identify not yet modified key frames?
 
-		Identify not yet modified key frames?
+        - Start at 0
+        - Find next keyframe
+        - Interpolate between those keyframes
+        - When at last keyframe, end
 
-		- Start at 0
-		- Find next keyframe
-		- Interpolate between those keyframes
-		- When at last keyframe, end
+        """
 
-		"""
+        assert self.video_file is not None
 
-		assert self.video_file is not None
+        # Careful, the images should be sorted by frame number
+        # And the instance list too...
+        # Image list is needed for interpolated images (boxes can access image with box)
 
-		# Careful, the images should be sorted by frame number
-		# And the instance list too...
-		# Image list is needed for interpolated images (boxes can access image with box)
+        """
+         Caution, note that in the new syntax we call
+         it video_parent_file_id and in the sequence
+         it's valled video_file_id, but this should be 
+         referring to same thing. 
+        
+        """
 
-		"""
-		 Caution, note that in the new syntax we call
-		 it video_parent_file_id and in the sequence
-		 it's valled video_file_id, but this should be 
-		 referring to same thing. 
-		
-		"""
+        sequence_list = self.session.query(Sequence).filter(
+            Sequence.video_file_id == self.video_file.id,
+            Sequence.single_frame == False,
+            Sequence.archived == False
+        ).all()
 
-		sequence_list = self.session.query(Sequence).filter(
-			Sequence.video_file_id == self.video_file.id,
-			Sequence.single_frame == False,
-			Sequence.archived == False
-			).all()
+        self.log['sequence'] = {}
 
-		self.log['sequence'] = {}
+        if len(sequence_list) == 0:
+            self.log['sequence']['error'] = {}
+            self.log['sequence']['error']['error'] = 'No sequences. Click a label to open sequence navigator.'
+            # Front end (as of 3/16/19 expects a sequence id as second key so double error key)
+            return
 
-		if len(sequence_list) == 0:
-			self.log['sequence']['error'] = {}
-			self.log['sequence']['error']['error'] = 'No sequences. Click a label to open sequence navigator.'
-			# Front end (as of 3/16/19 expects a sequence id as second key so double error key)
-			return
+        # QUESTION should we just use a standard serialization method for sequence?
 
-		# QUESTION should we just use a standard serialization method for sequence?
+        for sequence in sequence_list:
+            self.interpolate_sequence(sequence)
 
-		for sequence in sequence_list:
-			self.interpolate_sequence(sequence)
-			
-		
-		self.log['success'] = True
+        self.log['success'] = True
 
-	def interpolate_sequence(
-			self,
-			sequence):
-		"""
-		Process description
+    def interpolate_sequence(
+        self,
+        sequence):
+        """
+        Process description
 
-			1. Delete existing instances
-			2. 
+            1. Delete existing instances
+            2.
 
-		"""
+        """
 
-		self.prepare_sequence_log(sequence)
+        self.prepare_sequence_log(sequence)
 
-		if sequence.has_changes != True:
-			return
+        if sequence.has_changes != True:
+            return
 
-		# TODO This is not checking for being an interpolated instance correctly?
-		# ie it should have at least 2 KEYFRAME instances to interpolate
+        # TODO This is not checking for being an interpolated instance correctly?
+        # ie it should have at least 2 KEYFRAME instances to interpolate
 
-		if len(sequence.instance_list) <= 1:  # must have at least 2 instances to interpolate
-			self.log['sequence'][sequence.id]['error'] = "Sequence must have at least 2 keyframe instances of type Box to interpolate"
-			return
+        if len(sequence.instance_list) <= 1:  # must have at least 2 instances to interpolate
+            self.log['sequence'][sequence.id][
+                'error'] = "Sequence must have at least 2 keyframe instances of type Box to interpolate"
+            return
 
-		# This is getting wrong count
-		#self.log['sequence'][sequence.id]['keyframe_count'] = len(sequence.instance_list)
+        # This is getting wrong count
+        # self.log['sequence'][sequence.id]['keyframe_count'] = len(sequence.instance_list)
 
-		instances_to_interpolate_list = []
+        instances_to_interpolate_list = []
 
-		for instance in sequence.instance_list:
+        for instance in sequence.instance_list:
 
-			# Delete old boxes
-			if instance.interpolated is True:
+            # Delete old boxes
+            if instance.interpolated is True:
+                # TODO can't delete if through source control BUT
+                # need to clarify what's actually getting deleted?
+                # ie if not comitted can delete right?
+                # soft delete becomes ungainly as it make interpolation slower with every pass...
+                # AND if comitted, wouldn't copy interpolated ones anyway...
 
-				# TODO can't delete if through source control BUT 
-				# need to clarify what's actually getting deleted?
-				# ie if not comitted can delete right?
-				# soft delete becomes ungainly as it make interpolation slower with every pass...
-				# AND if comitted, wouldn't copy interpolated ones anyway...
+                # Careful, need this in 2 places
+                # May be some files that get deleted but not recreated
+                instance.file.set_cache_key_dirty('instance_list')
+                self.session.delete(instance)
 
-				# Careful, need this in 2 places
-				# May be some files that get deleted but not recreated
-				instance.file.set_cache_key_dirty('instance_list')
-				self.session.delete(instance)
-
-
-			# TODO issue here with instances 
-			# when editing
-			if instance.interpolated is not True and \
-			instance.soft_delete is not True and instance.frame_number is not None:
-				instances_to_interpolate_list.append(instance)
-							
-
-		# Careful to sort by frame rate at some point in this process!!
-		instances_to_interpolate_list.sort(key= lambda x: x.file.frame_number) 
-
-		self.__literal_interpolate_sequence(self.session, 
-									instances_to_interpolate_list,
-									sequence)
-		sequence.has_changes = False
-
-
-	def prepare_sequence_log(
-			self,
-			sequence):
-		
-		self.log['sequence'][sequence.id] = {}
-		self.log['sequence'][sequence.id]['number'] = sequence.number
-		self.log['sequence'][sequence.id]['label_name'] = sequence.label_file.label.name				
-		self.log['sequence'][sequence.id]['has_changes'] = sequence.has_changes
-
-
-	def interpolate_description(
-			self):
-		pass
-
-
-	def __check_if_instance_list_ok_to_opreate_on(
-			self,
-			instance_list):
-
-		if len(instance_list) < 2:
-			return False
-
-		return True
-
-	# TODO use self.session
-	def __literal_interpolate_sequence(
-			self, 
-			session, 
-			instance_list, 
-			sequence):
-		"""
-		Takes start and end points (annotations) and does interpolation
-
-		Arguments:
-			start, db box instance object
-			end, db box instance object
-		"""
-
-
-		#start = instance_list[index]
-		#end = instance_list[index + 1]
-
-		if not self.__check_if_instance_list_ok_to_opreate_on(
-			instance_list = instance_list): return
-
-		# Start and end must be in different frames?
-
-		start = instance_list[0]
-		end = instance_list[-1]
-
-		# Length of instances != frames to interpolate
-		# For example could have 4 keyframes and 68 frames to interpoalte over
-
-		# Is this right? feel like we need to be more clear on "exclusive" vs "inclusive"
-		# for key rames...
-
-		frames_to_interpolate = abs(end.frame_number - start.frame_number)
-
-		interpolation_description = "Start frame", start.frame_number, \
-									"End frame", end.frame_number, \
-									"Instances interpolated", frames_to_interpolate
-
-		self.log['sequence'][sequence.id]['interpolation_description'] = interpolation_description
-
-		# Segment is the division or "slice" that we are operating on
-		# ie distance between 10 and 20 is 10. If there's 23 frames than
-		# each segment is 10 / 23 or .43
-		# Feel like this should be more generic ie for min vs max... 
-			
-		# The first and last frames are keyframes, we already have data for them
-		# ie frame 2 to 10, start at frame 3 and go to frame 9 (inclusive of 9)
-		# So 10 - 2 = 8, 
-
-		for index, instance in enumerate(instance_list):
-			 self.__operate_on_sub_sequence(
-				 starting_instance = instance,
-				 index = index,
-				 instance_list = instance_list,
-				 sequence = sequence
-				 )
-
-
-	def __operate_on_sub_sequence(
-			self,
-			starting_instance,
-			index,
-			instance_list,
-			sequence
-			):
-		
-		min_points_x = []	# TODO clarify this is a list
-		min_points_y = []
-		max_points_x = []
-		max_points_y = []
-
-		# We change the new x segment with each new grouping of keyframes
-		if index + 1 == len(instance_list):
-			return
-
-		# Because of slice notation we do 1 more then we want basically
-		end_index = index + 2 # end slice notation 
-		# ie index >= len(x) then use last element like -1, actually slice handles this.
-			
-		# Careful that the end index for the spline is equal to (or greater) 
-		# than where we are interpolating too
-		spline_instance_list = instance_list[index : end_index]
-
-		start = instance_list[index]
-		end = instance_list[index + 1]
-
-		for instance in spline_instance_list:
-			min_points_x.append(instance.x_min)
-			min_points_y.append(instance.y_min)
-
-			max_points_x.append(instance.x_max)
-			max_points_y.append(instance.y_max)
-
-		interpt_y_given_x_min = self.build_interpt_y_given_x(
-			min_points_x,
-			min_points_y, 
-			len(spline_instance_list))
-
-
-		interpt_y_given_x_max = self.build_interpt_y_given_x(
-			max_points_x, 
-			max_points_y, 
-			len(spline_instance_list))
-
-		frames_to_interpolate = abs(end.frame_number - start.frame_number)
-		if frames_to_interpolate < 1:
-			return
-
-		new_x_segment_min = abs(start.x_min - end.x_min) / frames_to_interpolate
-		new_x_segment_max = abs(start.x_max - end.x_max) / frames_to_interpolate
-
-		for interpolate_index in range(1, frames_to_interpolate):
-
-			result, frame_index, new_instance_dict = self.__interpolate_specific_range_after_all_prep_done(
-				start,
-				end,
-				new_x_segment_min,
-				interpt_y_given_x_min,
-				new_x_segment_max,
-				interpt_y_given_x_max,
-				interpolate_index
-				)
-
-			if result is False: continue
-
-			self.__create_literal_annotations_after_known_good_new_instance(
-				frame_index = frame_index,
-				new_instance_dict = new_instance_dict,
-				label_file_id = starting_instance.label_file_id,
-				sequence = sequence	)
-
-
-	def __interpolate_specific_range_after_all_prep_done(
-			self,
-			start,	# object
-			end,		# object
-			new_x_segment_min,
-			interpt_y_given_x_min,
-			new_x_segment_max,
-			interpt_y_given_x_max,
-			interpolate_index):
-
-		result_min, interpolated_y_min, new_x_min = self.interpolate_x_y(	
-			start.x_min,
-			end.x_min,
-			new_x_segment_min,
-			interpt_y_given_x_min,
-			interpolate_index)
-
-		result_max, interpolated_y_max, new_x_max = self.interpolate_x_y(	
-			start.x_max,
-			end.x_max,
-			new_x_segment_max,
-			interpt_y_given_x_max,
-			interpolate_index)
-
-
-		if result_min == "success" and \
-		   result_max == "success" and \
-		   start.frame_number <= end.frame_number:
-
-			new_instance = {
-				'y_min': interpolated_y_min,
-				'x_min': new_x_min,
-				'y_max': interpolated_y_max,
-				'x_max': new_x_max
-				}
-
-			frame_index = start.frame_number + interpolate_index
-			return True, frame_index, new_instance
-
-		return False, None, None
-
-
-	def __create_literal_annotations_after_known_good_new_instance(
-			self,
-			frame_index,		# int
-			new_instance_dict,
-			label_file_id,	# int
-			sequence		# class Sequence
-			):
-
-		# Annotation_Update is similar for all
-		# frames, may be a way to reuse this object better
-		video_data = 	{
-			"video_mode": True,
-			"video_file_id": self.video_file.id,
-			"current_frame": frame_index
-		}
-
-		annotation_update = Annotation_Update(
-			session = self.session,
-			file = self.video_file,
-			project = self.project,
-			video_data = video_data,		
-			do_init_existing_instances = False,
-			member = self.member			# Big performance improvement
-		)
-
-		annotation_update.update_instance(
-			type = "box",
-			x_min = new_instance_dict['x_min'], 
-			y_min = new_instance_dict['y_min'],
-			x_max = 	new_instance_dict['x_max'],
-			y_max = new_instance_dict['y_max'],
-			label_file_id = label_file_id,
-			number = sequence.number,
-			sequence_id = sequence.id,
-			interpolated = True
-			)
-
-		# Caution, may be existing files from another sequence
-		# So we need to clear any new ones we create
-		# (2/2 cases so far?) See deletion for other case
-		annotation_update.file.set_cache_key_dirty('instance_list')
-
-
-	def build_interpt_y_given_x( self, 
-								 points_x, points_y, 
-								 len_instance_list):
-		"""
-		Builds a scipy interpolate 1d function
-
-		Args:
-			start_x, start_y, end_x, end_y  (TODO change this to accept array of points)
-			frame_count, integer
-
-		Returns:
-			interpt_y_given_x, function
-			new_x_segment, integer
-		"""  
-		#points = zip(points_x, points_y)
-
-		# Sort list of tuples by x-value
-		#points = sorted(points, key=lambda point: point[0])
-
-		# Split list of tuples into two list of x values any y values
-		#x1, y1 = zip(*points)
-
-		x = np.array(points_x)
-		y = np.array(points_y)
-
-		kind = 'linear'
-		if len_instance_list > 2:
-			kind = 'zero'
-		if len_instance_list > 3:
-			kind = 'slinear'
-		#if len_instance_list > 3:
-			#kind = 'quadratic'
-			#knots = interpolate.splprep([x, y])[0]
-			#interpolated_y = interpolate.splev(points_x, knots, der=0)
-			#print(interpolated_y)
-			#return interpolated_y
-
-		#print("kind", kind)
-		try:
-			interpt_y_given_x = interp1d(x, y, assume_sorted=False, kind=kind, fill_value="extrapolate")
-		except Exception as exception:
-			print(exception)
-			interpt_y_given_x = interp1d(x, y, assume_sorted=False, kind='linear', fill_value="extrapolate")
-
-		return interpt_y_given_x
-
-
-	def interpolate_x_y(
-			self,
-			start_x, 
-			end_x, 
-			new_x_segment, 
-			interpt_y_given_x,		# function
-		    frame_index):
-		"""
-		Given an x value function returns y value
-
-		Interpolation handles y value changing positive/negative direction,
-		given correct new_x value
-
-		Args:
-			start_x, end_x, integers
-			new_x_segment, integer
-			interpt_y_given_x, function
-			frame_index, integer
-		"""  
-
-		if start_x <= end_x:  # Handle reversing direction for x
-
-			# update x based on where we are in the index
-			new_x = start_x + (new_x_segment * frame_index)
-		else:
-			new_x = start_x - (new_x_segment * frame_index)
-
-		#interpolated_y = interpolate.splev(new_x, interpt_y_given_x, der=0)
-		interpolated_y = interpt_y_given_x(new_x)
-
-		#print(interpolated_y)
-		if math.isnan(interpolated_y):
-			return "error", None, None
-
-		interpolated_y = int(interpolated_y)
-		new_x = int(new_x)
-
-		return "success", interpolated_y, new_x
-
-
+            # TODO issue here with instances
+            # when editing
+            if instance.interpolated is not True and \
+                instance.soft_delete is not True and instance.frame_number is not None:
+                instances_to_interpolate_list.append(instance)
+
+        # Careful to sort by frame rate at some point in this process!!
+        instances_to_interpolate_list.sort(key = lambda x: x.file.frame_number)
+
+        self.__literal_interpolate_sequence(self.session,
+                                            instances_to_interpolate_list,
+                                            sequence)
+        sequence.has_changes = False
+
+    def prepare_sequence_log(
+        self,
+        sequence):
+
+        self.log['sequence'][sequence.id] = {}
+        self.log['sequence'][sequence.id]['number'] = sequence.number
+        self.log['sequence'][sequence.id]['label_name'] = sequence.label_file.label.name
+        self.log['sequence'][sequence.id]['has_changes'] = sequence.has_changes
+
+    def interpolate_description(
+        self):
+        pass
+
+    def __check_if_instance_list_ok_to_opreate_on(
+        self,
+        instance_list):
+
+        if len(instance_list) < 2:
+            return False
+
+        return True
+
+    # TODO use self.session
+    def __literal_interpolate_sequence(
+        self,
+        session,
+        instance_list,
+        sequence):
+        """
+        Takes start and end points (annotations) and does interpolation
+
+        Arguments:
+            start, db box instance object
+            end, db box instance object
+        """
+
+        # start = instance_list[index]
+        # end = instance_list[index + 1]
+
+        if not self.__check_if_instance_list_ok_to_opreate_on(
+            instance_list = instance_list): return
+
+        # Start and end must be in different frames?
+
+        start = instance_list[0]
+        end = instance_list[-1]
+
+        # Length of instances != frames to interpolate
+        # For example could have 4 keyframes and 68 frames to interpoalte over
+
+        # Is this right? feel like we need to be more clear on "exclusive" vs "inclusive"
+        # for key rames...
+
+        frames_to_interpolate = abs(end.frame_number - start.frame_number)
+
+        interpolation_description = "Start frame", start.frame_number, \
+                                    "End frame", end.frame_number, \
+                                    "Instances interpolated", frames_to_interpolate
+
+        self.log['sequence'][sequence.id]['interpolation_description'] = interpolation_description
+
+        # Segment is the division or "slice" that we are operating on
+        # ie distance between 10 and 20 is 10. If there's 23 frames than
+        # each segment is 10 / 23 or .43
+        # Feel like this should be more generic ie for min vs max...
+
+        # The first and last frames are keyframes, we already have data for them
+        # ie frame 2 to 10, start at frame 3 and go to frame 9 (inclusive of 9)
+        # So 10 - 2 = 8,
+
+        for index, instance in enumerate(instance_list):
+            self.__operate_on_sub_sequence(
+                starting_instance = instance,
+                index = index,
+                instance_list = instance_list,
+                sequence = sequence
+            )
+
+    def __operate_on_sub_sequence(
+        self,
+        starting_instance,
+        index,
+        instance_list,
+        sequence
+    ):
+
+        min_points_x = []  # TODO clarify this is a list
+        min_points_y = []
+        max_points_x = []
+        max_points_y = []
+
+        # We change the new x segment with each new grouping of keyframes
+        if index + 1 == len(instance_list):
+            return
+
+        # Because of slice notation we do 1 more then we want basically
+        end_index = index + 2  # end slice notation
+        # ie index >= len(x) then use last element like -1, actually slice handles this.
+
+        # Careful that the end index for the spline is equal to (or greater)
+        # than where we are interpolating too
+        spline_instance_list = instance_list[index: end_index]
+
+        start = instance_list[index]
+        end = instance_list[index + 1]
+
+        for instance in spline_instance_list:
+            min_points_x.append(instance.x_min)
+            min_points_y.append(instance.y_min)
+
+            max_points_x.append(instance.x_max)
+            max_points_y.append(instance.y_max)
+
+        interpt_y_given_x_min = self.build_interpt_y_given_x(
+            min_points_x,
+            min_points_y,
+            len(spline_instance_list))
+
+        interpt_y_given_x_max = self.build_interpt_y_given_x(
+            max_points_x,
+            max_points_y,
+            len(spline_instance_list))
+
+        frames_to_interpolate = abs(end.frame_number - start.frame_number)
+        if frames_to_interpolate < 1:
+            return
+
+        new_x_segment_min = abs(start.x_min - end.x_min) / frames_to_interpolate
+        new_x_segment_max = abs(start.x_max - end.x_max) / frames_to_interpolate
+
+        for interpolate_index in range(1, frames_to_interpolate):
+
+            result, frame_index, new_instance_dict = self.__interpolate_specific_range_after_all_prep_done(
+                start,
+                end,
+                new_x_segment_min,
+                interpt_y_given_x_min,
+                new_x_segment_max,
+                interpt_y_given_x_max,
+                interpolate_index
+            )
+
+            if result is False: continue
+
+            self.__create_literal_annotations_after_known_good_new_instance(
+                frame_index = frame_index,
+                new_instance_dict = new_instance_dict,
+                label_file_id = starting_instance.label_file_id,
+                sequence = sequence)
+
+    def __interpolate_specific_range_after_all_prep_done(
+        self,
+        start,  # object
+        end,  # object
+        new_x_segment_min,
+        interpt_y_given_x_min,
+        new_x_segment_max,
+        interpt_y_given_x_max,
+        interpolate_index):
+
+        result_min, interpolated_y_min, new_x_min = self.interpolate_x_y(
+            start.x_min,
+            end.x_min,
+            new_x_segment_min,
+            interpt_y_given_x_min,
+            interpolate_index)
+
+        result_max, interpolated_y_max, new_x_max = self.interpolate_x_y(
+            start.x_max,
+            end.x_max,
+            new_x_segment_max,
+            interpt_y_given_x_max,
+            interpolate_index)
+
+        if result_min == "success" and \
+            result_max == "success" and \
+            start.frame_number <= end.frame_number:
+            new_instance = {
+                'y_min': interpolated_y_min,
+                'x_min': new_x_min,
+                'y_max': interpolated_y_max,
+                'x_max': new_x_max
+            }
+
+            frame_index = start.frame_number + interpolate_index
+            return True, frame_index, new_instance
+
+        return False, None, None
+
+    def __create_literal_annotations_after_known_good_new_instance(
+        self,
+        frame_index,  # int
+        new_instance_dict,
+        label_file_id,  # int
+        sequence  # class Sequence
+    ):
+
+        # Annotation_Update is similar for all
+        # frames, may be a way to reuse this object better
+        video_data = {
+            "video_mode": True,
+            "video_file_id": self.video_file.id,
+            "current_frame": frame_index
+        }
+
+        annotation_update = Annotation_Update(
+            session = self.session,
+            file = self.video_file,
+            project = self.project,
+            video_data = video_data,
+            do_init_existing_instances = False,
+            member = self.member  # Big performance improvement
+        )
+
+        annotation_update.update_instance(
+            type = "box",
+            x_min = new_instance_dict['x_min'],
+            y_min = new_instance_dict['y_min'],
+            x_max = new_instance_dict['x_max'],
+            y_max = new_instance_dict['y_max'],
+            label_file_id = label_file_id,
+            number = sequence.number,
+            sequence_id = sequence.id,
+            interpolated = True
+        )
+
+        # Caution, may be existing files from another sequence
+        # So we need to clear any new ones we create
+        # (2/2 cases so far?) See deletion for other case
+        annotation_update.file.set_cache_key_dirty('instance_list')
+
+    def build_interpt_y_given_x(self,
+                                points_x, points_y,
+                                len_instance_list):
+        """
+        Builds a scipy interpolate 1d function
+
+        Args:
+            start_x, start_y, end_x, end_y  (TODO change this to accept array of points)
+            frame_count, integer
+
+        Returns:
+            interpt_y_given_x, function
+            new_x_segment, integer
+        """
+        # points = zip(points_x, points_y)
+
+        # Sort list of tuples by x-value
+        # points = sorted(points, key=lambda point: point[0])
+
+        # Split list of tuples into two list of x values any y values
+        # x1, y1 = zip(*points)
+
+        x = np.array(points_x)
+        y = np.array(points_y)
+
+        kind = 'linear'
+        if len_instance_list > 2:
+            kind = 'zero'
+        if len_instance_list > 3:
+            kind = 'slinear'
+        # if len_instance_list > 3:
+        # kind = 'quadratic'
+        # knots = interpolate.splprep([x, y])[0]
+        # interpolated_y = interpolate.splev(points_x, knots, der=0)
+        # print(interpolated_y)
+        # return interpolated_y
+
+        # print("kind", kind)
+        try:
+            interpt_y_given_x = interp1d(x, y, assume_sorted = False, kind = kind, fill_value = "extrapolate")
+        except Exception as exception:
+            print(exception)
+            interpt_y_given_x = interp1d(x, y, assume_sorted = False, kind = 'linear', fill_value = "extrapolate")
+
+        return interpt_y_given_x
+
+    def interpolate_x_y(
+        self,
+        start_x,
+        end_x,
+        new_x_segment,
+        interpt_y_given_x,  # function
+        frame_index):
+        """
+        Given an x value function returns y value
+
+        Interpolation handles y value changing positive/negative direction,
+        given correct new_x value
+
+        Args:
+            start_x, end_x, integers
+            new_x_segment, integer
+            interpt_y_given_x, function
+            frame_index, integer
+        """
+
+        if start_x <= end_x:  # Handle reversing direction for x
+
+            # update x based on where we are in the index
+            new_x = start_x + (new_x_segment * frame_index)
+        else:
+            new_x = start_x - (new_x_segment * frame_index)
+
+        # interpolated_y = interpolate.splev(new_x, interpt_y_given_x, der=0)
+        interpolated_y = interpt_y_given_x(new_x)
+
+        # print(interpolated_y)
+        if math.isnan(interpolated_y):
+            return "error", None, None
+
+        interpolated_y = int(interpolated_y)
+        new_x = int(new_x)
+
+        return "success", interpolated_y, new_x
 
 
 # WIP WIP WIP
-@routes.route('/api/walrus/video/interpolate', 
-			  methods=['POST'])
+@routes.route('/api/walrus/video/interpolate',
+              methods = ['POST'])
 def interpolate_api(task_id):
-	"""
-	Uses new permission through regular list system
-		(that way can support the multiple permissions ie task / project)
-	"""
+    """
+    Uses new permission through regular list system
+        (that way can support the multiple permissions ie task / project)
+    """
 
-	spec_list = [
-		 {"task_id" : 
-			{
-			'kind': int,
-			'permission': 'task'
-			}
-		},
-		{"file_id" : 
-			{
-			'kind': int,
-			'permission': 'project'
-			}
-		},
-		{"sequence_id" : 
-			{
-			'kind': int,
-			}
-		}]
+    spec_list = [
+        {"task_id":
+            {
+                'kind': int,
+                'permission': 'task'
+            }
+        },
+        {"file_id":
+            {
+                'kind': int,
+                'permission': 'project'
+            }
+        },
+        {"sequence_id":
+            {
+                'kind': int,
+            }
+        }]
 
-	log, input, untrusted_input = regular_input.master(request=request,
-													   spec_list=spec_list)
-	if len(log["error"].keys()) >= 1:
-		return jsonify(log=log), 400
-	
-	with sessionMaker.session_scope() as session:
+    log, input, untrusted_input = regular_input.master(request = request,
+                                                       spec_list = spec_list)
+    if len(log["error"].keys()) >= 1:
+        return jsonify(log = log), 400
 
-		task = Task.get_by_id(	
-			session = session,
-			task_id = task_id)
+    with sessionMaker.session_scope() as session:
 
-		# TODO get get file by id untrusted (can't remember the name)
+        task = Task.get_by_id(
+            session = session,
+            task_id = task_id)
 
-		if file.type != "video":
-			return "File is not a video", 400
+        # TODO get get file by id untrusted (can't remember the name)
+        try:
+            file = File.get_by_id_untrusted(
+                project_string_id = task.project.project_string_id,
+                file_id = task.file.id,
+                with_for_update = True,
+                nowait = True
+            )
+        except Exception as e:
+            trace = traceback.format_exc()
+            logger.error('File {} is Locked'.format(task.file.id))
+            logger.error(trace)
+            log['error']['file_locked'] = 'File is being saved by another process, please try again later.'
+            return jsonify(log), 400
+        if file.type != "video":
+            return "File is not a video", 400
 
-		# TODO get sequence
+        # TODO get sequence
 
-		return interpolate_api_shared(
-			session, log, task.project, task.file)
+        return interpolate_api_shared(session, log, task.project, file)
 
 
 # WIP WIP WIP
 def interpolate_api_shared(
-		session, 
-		project, 
-		video_file,
-		sequence
-		):
+    session,
+    project,
+    video_file,
+    sequence
+):
+    interpolate_diffgram = Interpolate(
+        session = session,
+        log = log,
+        project = project,
+        video_file = video_file)
 
-	interpolate_diffgram = Interpolate(		
-		session = session,
-		log = log,
-		project = project,
-		video_file = video_file)
+    interpolate_diffgram.single()
 
-	interpolate_diffgram.single()
-
-	return jsonify(log = interpolate_diffgram.log), 200
-
-
-
+    return jsonify(log = interpolate_diffgram.log), 200
 
 
 # PENDING DEPRECREATION / REMOVAL  (In favor of single sequence)
 
-@routes.route('/api/walrus/task/<int:task_id>' 
-			  '/video/interpolate', 
-			  methods=['POST'])
-@Permission_Task.by_task_id(apis_user_list=["builder_or_trainer"])
+@routes.route('/api/walrus/task/<int:task_id>'
+              '/video/interpolate',
+              methods = ['POST'])
+@Permission_Task.by_task_id(apis_user_list = ["builder_or_trainer"])
 def interpolate_all_frames_using_task(task_id):
-	
-	with sessionMaker.session_scope() as session:
+    with sessionMaker.session_scope() as session:
+        task = Task.get_by_id(
+            session = session,
+            task_id = task_id)
 
-		task = Task.get_by_id(	
-			session = session,
-			task_id = task_id)
+        log = regular_log.default_api_log()
 
-		log = regular_log.default_api_log()
+        try:
+            file = File.get_by_id_untrusted(
+                project_string_id = task.project.project_string_id,
+                file_id = task.file.id,
+                with_for_update = True,
+                nowait = True
+            )
+        except Exception as e:
+            trace = traceback.format_exc()
+            logger.error('File {} is Locked'.format(task.file.id))
+            logger.error(trace)
+            log['error']['file_locked'] = 'File is being saved by another process, please try again later.'
+            return jsonify(log), 400
 
-		# could be a valid task id that's not a video
-		if task.file.type != "video":
-			return "Task file is not a video", 400
+        # could be a valid task id that's not a video
+        if file.type != "video":
+            return "Task file is not a video", 400
 
-		return interpolate_api_shared(
-			session, log, task.project, task.file)
+        return interpolate_api_shared(session, log, task.project, file)
+
 
 # PENDING DEPRECREATION / REMOVAL   (In facvor of single sequence)
 
 @routes.route('/api/walrus/project/<string:project_string_id>'
-			  '/video/single/<string:video_file_id>'
-			  '/interpolate', 
-			  methods=['POST'])
+              '/video/single/<string:video_file_id>'
+              '/interpolate',
+              methods = ['POST'])
 @Project_permissions.user_has_project(["admin", "Editor"])
 def interpolate_all_frames(project_string_id, video_file_id):
-	
-	"""
+    """
 
-	This may be a long running operation for longer videos.
-	Prior we had this start running on a new thread, but that doesn't really make sense since
-	* The user likely wants to see results from this before proceeding
-	* We want to make errors louder, ie not having enough instances etc.
-	* For an "average" case it completes in less < 10 seconds so it's not really that long running
+    This may be a long running operation for longer videos.
+    Prior we had this start running on a new thread, but that doesn't really make sense since
+    * The user likely wants to see results from this before proceeding
+    * We want to make errors louder, ie not having enough instances etc.
+    * For an "average" case it completes in less < 10 seconds so it's not really that long running
 
-	"""
-	
-	spec_list = [{'directory_id' : int}]
+    """
 
-	log, input, untrusted_input = regular_input.master(request=request,
-													   spec_list=spec_list)
-	if len(log["error"].keys()) >= 1:
-		return jsonify(log=log), 400
+    spec_list = [{'directory_id': int}]
 
-	with sessionMaker.session_scope() as session:
+    log, input, untrusted_input = regular_input.master(request = request,
+                                                       spec_list = spec_list)
+    if len(log["error"].keys()) >= 1:
+        return jsonify(log = log), 400
 
-		project = Project.get(session, project_string_id)
+    with sessionMaker.session_scope() as session:
 
-		directory = WorkingDir.get_with_fallback(
-			session = session,
-			project = project,
-			directory_id = input['directory_id'])
+        project = Project.get(session, project_string_id)
 
-		if directory is False or directory is None:
-			print("Invalid directory")
-			return jsonify("Invalid directory"), 400
+        directory = WorkingDir.get_with_fallback(
+            session = session,
+            project = project,
+            directory_id = input['directory_id'])
 
-		video_file = File.get_by_id_untrusted(
-			session = session,
-			user_id = None, 
-			project_string_id = project_string_id,
-			file_id = video_file_id,
-			directory_id = directory.id)
+        if directory is False or directory is None:
+            print("Invalid directory")
+            return jsonify("Invalid directory"), 400
 
-		return interpolate_api_shared(
-			session, log, project, video_file)
+        try:
+            video_file = File.get_by_id_untrusted(
+                session = session,
+                user_id = None,
+                project_string_id = project_string_id,
+                file_id = video_file_id,
+                directory_id = directory.id,
+                with_for_update = True,
+                nowait = True)
+        except Exception as e:
+            trace = traceback.format_exc()
+            logger.error('File {} is Locked'.format(video_file_id))
+            logger.error(trace)
+            log['error']['file_locked'] = 'File is being saved by another process, please try again later.'
+            return jsonify(log), 400
+
+        return interpolate_api_shared(session, log, project, video_file)
 
 
 def interpolate_api_shared(
-		session, log, project, video_file):
+    session, log, project, video_file):
+    interpolate_diffgram = Interpolate(
+        session = session,
+        log = log,
+        project = project,
+        video_file = video_file)
 
-	interpolate_diffgram = Interpolate(		
-		session = session,
-		log = log,
-		project = project,
-		video_file = video_file)
+    interpolate_diffgram.interpolate_all_sequences_in_video()
 
-	interpolate_diffgram.interpolate_all_sequences_in_video()
-
-	return jsonify(log = interpolate_diffgram.log), 200
-
-
-
-
-	
+    return jsonify(log = interpolate_diffgram.log), 200


### PR DESCRIPTION
To reduce cache errors occurrences:

1. Added the with_for_update() to instance list
2. Await the save method on frame changes instead of a sleep() time as sometimes the sleep can be less than the time the update takes, specially on slow connections.