### PR TITLE
fix: cache error fixes duplicate hashes

### DIFF
--- a/default/methods/source_control/file/file_cache_regen.py
+++ b/default/methods/source_control/file/file_cache_regen.py
@@ -99,6 +99,14 @@ def cache_regeneration_core(session, project, file_id, frame_number, log):
             if not file:
                 log['error']['frame_number'] = 'Frame {} does not exists.'.format(frame_number)
                 return result, log
+
+    instance_list_existing = Instance.list(session = session,
+                                            file_id = file.id,
+                                            limit = None)
+    for instance in instance_list_existing:
+        instance.hash_instance()
+        session.add(instance)
+
     # Invalidate cache
     file.set_cache_key_dirty('instance_list')
     # Regenerate Cache
@@ -107,4 +115,5 @@ def cache_regeneration_core(session, project, file_id, frame_number, log):
         cache_miss_function = file.serialize_instance_list_only,
         session = session)
     result['regenerated'] = True
+
     return result, log

--- a/frontend/src/components/regular/error_multiple.vue
+++ b/frontend/src/components/regular/error_multiple.vue
@@ -4,7 +4,7 @@
 
     <v-alert v-if="Object.keys(error).length"
              v-model="show"
-             type="error"
+             :type="type"
              :width="width"
              :height="height"
              :dense="dense"
@@ -76,6 +76,9 @@ import Vue from "vue"; export default Vue.extend( {
     'dense': {
       default: false
     },
+    'type':{
+      default: 'error'
+    }
   },
   data() {
     return {

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -568,10 +568,9 @@ class Annotation_Update():
     def detect_and_remove_collisions(self, instance_list):
         result = []
         hashes_dict = {}
-        new_instance_list = []
         for inst in instance_list:
             if inst.soft_delete is True:
-                new_instance_list.append(inst)
+                result.append(inst)
                 continue
 
             if hashes_dict.get(inst.hash):

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -577,7 +577,7 @@ class Annotation_Update():
             if hashes_dict.get(inst.hash):
                 # Collision detected, we keep the newest instance by created time.
                 hashes_dict.get(inst.hash).soft_delete = True
-                self.session.add(inst)
+                self.session.add(hashes_dict.get(inst.hash))
                 hashes_dict[inst.hash] = inst
             else:
                 hashes_dict[inst.hash] = inst

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -568,6 +568,7 @@ class Annotation_Update():
     def detect_and_remove_collisions(self, instance_list):
         result = []
         hashes_dict = {}
+        instance_list.sort(key = lambda item: (item.created_time is not None, item.created_time), reverse = True)
         for inst in instance_list:
             if inst.soft_delete is True:
                 result.append(inst)
@@ -575,21 +576,16 @@ class Annotation_Update():
 
             if hashes_dict.get(inst.hash):
                 # Collision detected, we keep the newest instance by created time.
-                if hashes_dict.get(inst.hash).created_time < inst.created_time:
-                    hashes_dict.get(inst.hash).soft_delete = True
-                    self.session.add(hashes_dict.get(inst.hash))
-                    hashes_dict[inst.hash] = inst
-                else:
-                    inst.soft_delete = True
-                    self.session.add(inst)
-
+                hashes_dict.get(inst.hash).soft_delete = True
+                self.session.add(inst)
+                hashes_dict[inst.hash] = inst
             else:
                 hashes_dict[inst.hash] = inst
 
         for hash, inst in hashes_dict.items():
             result.append(inst)
 
-        result.sort(key = lambda item: (item.created_time is not None, item.created_time), reverse = True)
+            result.sort(key = lambda item: (item.created_time is not None, item.created_time), reverse = True)
         return result
 
     def init_existing_instances(self):

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -584,6 +584,7 @@ class Annotation_Update():
                 # So this one is just to be deleted and not added to results.
                 logger.warning('Collision detected on {} instance id: {}'.format(inst.hash, inst.id))
                 inst.soft_delete = True
+                inst.action_type = "from_collision"
                 self.session.add(inst)
 
         return result

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -577,7 +577,13 @@ class Annotation_Update():
             if hashes_dict.get(inst.hash):
                 # Collision detected, we keep the newest instance by created time.
                 if hashes_dict.get(inst.hash).created_time < inst.created_time:
+                    hashes_dict.get(inst.hash).soft_delete = True
+                    self.session.add(hashes_dict.get(inst.hash))
                     hashes_dict[inst.hash] = inst
+                else:
+                    inst.soft_delete = True
+                    self.session.add(inst)
+
             else:
                 hashes_dict[inst.hash] = inst
 

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -570,12 +570,16 @@ class Annotation_Update():
         hashes_dict = {}
         instance_list.sort(key = lambda item: (item.created_time is not None, item.created_time), reverse = True)
         for inst in instance_list:
+            # Rehash instances in case of hash mismatching current state.
+            inst.hash_instance()
+            self.session.add(inst)
             if inst.soft_delete is True:
                 result.append(inst)
                 continue
 
             if hashes_dict.get(inst.hash):
                 # Collision detected, we keep the newest instance by created time.
+                logger.warning('Collision detected on {} instance id: {}'.format(inst.hash, inst.id))
                 hashes_dict.get(inst.hash).soft_delete = True
                 self.session.add(hashes_dict.get(inst.hash))
                 hashes_dict[inst.hash] = inst

--- a/shared/database/annotation/instance.py
+++ b/shared/database/annotation/instance.py
@@ -206,7 +206,8 @@ class Instance(Base):
         date_to = None,
         date_from = None,
         frame_number = None,
-        with_for_update = False
+        with_for_update = False,
+        sort_by = None
     ):
         """
 
@@ -257,6 +258,9 @@ class Instance(Base):
         if limit:
             query = query.limit(limit)
 
+        if sort_by is not None:
+            if sort_by == 'created_time':
+                query = query.order_by(Instance.created_time.desc())
         if return_kind == "query":
             return query
 

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -1540,10 +1540,7 @@ class Process_Media():
         allowed_model_id_list = self.__get_allowed_model_ids()
         allowed_model_runs_id_list = self.__get_allowed_model_run_ids()
         try:
-            file = File.get_by_id(self.session,
-                                  file_id,
-                                  with_for_update = True,
-                                  nowait = True)  # For video, expects it to be parent video file, not a frame
+            file = File.get_by_id(self.session, file_id)  # For video, expects it to be parent video file, not a frame
 
             annotation_update = Annotation_Update(
                 session=self.session,


### PR DESCRIPTION
Fixes 4 things:

1. Remove with_for_update on process_media to allow parallel processing.
2. Add remove collisions function to instance list existing
3. Soft delete existing colliding hashes on frontend instance list.
4. Add duplicate validation on frontend