### PR TITLE
Add Per Frame Save Loading Flags

### DIFF
--- a/frontend/cypress/integration/diffgram/annotate_files/annotate_files_video_annotation_tools_spec.js
+++ b/frontend/cypress/integration/diffgram/annotate_files/annotate_files_video_annotation_tools_spec.js
@@ -170,6 +170,7 @@ describe('Annotate Files Tests', () => {
                     .get('[data-cy=save_warning]').should('be.visible')
 
               })
+                .wait(7000)
 
           })
 


### PR DESCRIPTION
Before, when users changed frames fast and the save operation took longer than the frame change. They could end up with frames not being saved, this because we only had one global `save_loading` flag per video.

Now we have added the `save_loading_frame` dict to control which frames are saving and not block other frames from saving if a save operation is occuring in another frame

Another bug that in the `add_ids_to_new_instances_and_delete_old` function were were using the reference to this.instance_list instead for the `frame_buffer_dict[request.video_data.current_frame]`. This could cause problems because this.instance_list can change while the annotations are saving. 

Please let me now what you think of these changes and if there's any issue/concern that stands out.