### PR TITLE
Login improvements - small

### DIFF
--- a/default/methods/user/account/auth_code.py
+++ b/default/methods/user/account/auth_code.py
@@ -40,10 +40,11 @@ def new(session,
 	# TODO not clear on use of this type of filer, ie if using a code to send to multiple
 	# orgs...
 
-	existing_code = session.query(Signup_code).filter( Signup_code.email_sent_to == email_sent_to, 
-													   Signup_code.type == auth_code_type,
-													   Signup_code.is_available != False,
-														).first()
+	existing_code = session.query(Signup_code).filter( 
+        Signup_code.email_sent_to == email_sent_to, 
+		Signup_code.type == auth_code_type,
+		Signup_code.is_available != False,
+		).first()
 	if existing_code:
 		if existing_code.type == "magic_login":
 

--- a/default/methods/user/account/magic_login.py
+++ b/default/methods/user/account/magic_login.py
@@ -46,10 +46,11 @@ def start_magic_login_api():
             return jsonify(log = log), 400
 
         ### MAIN
-        auth_result, message, auth = auth_code.new(session = session,
-                                                   user = user,
-                                                   email_sent_to = user.email,
-                                                   auth_code_type = "magic_login")
+        auth_result, message, auth = auth_code.new(
+            session = session,
+            user = user,
+            email_sent_to = user.email,
+            auth_code_type = "magic_login")
         ###
         # TODO use message var?
         if auth_result is False:

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -310,21 +310,25 @@ Cypress.Commands.add('loginByForm', function (email, password) {
   })
   cy.visit('http://localhost:8085/user/login')
   let LOCAL_STORAGE_MEMORY = {};
-  cy.wait(3000);
-  cy.get('[data-cy=email]')
-    .type(email)
-    .should('have.value', email)
-  cy.get('#show_pass').click();
-  cy.get('[data-cy=password]')
-    .type(password)
-    .should('have.value', password)
-  cy.get('[data-cy=login]').click();
-  cy.wait(3000);
-  Object.keys(LOCAL_STORAGE_MEMORY).forEach(key => {
-    localStorage.setItem(key, LOCAL_STORAGE_MEMORY[key]);
-  });
-  const getStore = () => cy.window().its('app.$store')
-  getStore().its('state.user.logged_in').should('eq', true);
+
+  const getInitialStore = () => cy.window().its('app.$store')
+  if (getInitialStore.its('state.user.logged_in') == false) {
+    cy.wait(3000);
+    cy.get('[data-cy=email]')
+      .type(email)
+      .should('have.value', email)
+    cy.get('#show_pass').click();
+    cy.get('[data-cy=password]')
+      .type(password)
+      .should('have.value', password)
+    cy.get('[data-cy=login]').click();
+    cy.wait(3000);
+    Object.keys(LOCAL_STORAGE_MEMORY).forEach(key => {
+      localStorage.setItem(key, LOCAL_STORAGE_MEMORY[key]);
+    });
+    const getStore = () => cy.window().its('app.$store')
+    getStore().its('state.user.logged_in').should('eq', true);
+  }
 });
 
 Cypress.Commands.add('gotToProject', function (project_string_id) {

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -312,23 +312,28 @@ Cypress.Commands.add('loginByForm', function (email, password) {
   let LOCAL_STORAGE_MEMORY = {};
 
   const getInitialStore = () => cy.window().its('app.$store')
-  if (getInitialStore.its('state.user.logged_in') == false) {
-    cy.wait(3000);
-    cy.get('[data-cy=email]')
-      .type(email)
-      .should('have.value', email)
-    cy.get('#show_pass').click();
-    cy.get('[data-cy=password]')
-      .type(password)
-      .should('have.value', password)
-    cy.get('[data-cy=login]').click();
-    cy.wait(3000);
-    Object.keys(LOCAL_STORAGE_MEMORY).forEach(key => {
-      localStorage.setItem(key, LOCAL_STORAGE_MEMORY[key]);
-    });
-    const getStore = () => cy.window().its('app.$store')
-    getStore().its('state.user.logged_in').should('eq', true);
-  }
+
+  getInitialStore().its('state.user.logged_in').then((user_logged_in) => {
+
+    if (user_logged_in == false) {
+      cy.wait(3000);
+      cy.get('[data-cy=email]')
+        .type(email)
+        .should('have.value', email)
+      cy.get('#show_pass').click();
+      cy.get('[data-cy=password]')
+        .type(password)
+        .should('have.value', password)
+      cy.get('[data-cy=login]').click();
+      cy.wait(3000);
+      Object.keys(LOCAL_STORAGE_MEMORY).forEach(key => {
+        localStorage.setItem(key, LOCAL_STORAGE_MEMORY[key]);
+      });
+      const getStore = () => cy.window().its('app.$store')
+      getStore().its('state.user.logged_in').should('eq', true);
+    }
+
+  })
 });
 
 Cypress.Commands.add('gotToProject', function (project_string_id) {

--- a/frontend/src/components/user/home/dashboard.vue
+++ b/frontend/src/components/user/home/dashboard.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="home" class="home-container">
 
-    <div v-if="$store.state.user.logged_in == true ">
+    <div v-if="$store.state.user.logged_in == true">
       <div v-if="!$store.state.builder_or_trainer.mode">
         <v-card>
 
@@ -123,7 +123,8 @@
         Project ID {{$store.state.project.current.id}}
       </div>
     </div>
-    <div v-else>
+
+    <div v-if="$store.state.user.logged_in != true">
       <v-container>
 
         <v-layout>

--- a/frontend/src/components/user/login.vue
+++ b/frontend/src/components/user/login.vue
@@ -2,7 +2,8 @@
 <template>
   <div v-cloak>
 
-    <v-flex xs6 center>
+    <v-flex xs6 center
+            v-if="$store.state.user.logged_in != true">
 
       <v-card>
 
@@ -172,6 +173,30 @@
 
     </v-flex>
 
+    <div v-if="$store.state.user.logged_in == true
+         && show_logging_in_messsage == false">
+      <v-alert type="info">
+        Already Logged In.
+      </v-alert>
+    </div>
+
+    <div v-if="$store.state.user.logged_in == true
+         && show_logging_in_messsage == true">
+
+      <v-progress-linear
+        height="10"
+        indeterminate
+        absolute
+        top
+        color="secondary accent-4">
+      </v-progress-linear>
+
+      <v-alert type="info">
+        Logging in...
+      </v-alert>
+
+    </div>
+
   </div>
 </template>
 
@@ -199,6 +224,7 @@ import Vue from "vue"; export default Vue.extend( {
     email: null,
 
     mode: "magic_auth",
+    show_logging_in_messsage: false,
 
     error: {
       email: null,
@@ -231,8 +257,10 @@ import Vue from "vue"; export default Vue.extend( {
     window.addEventListener('keyup', this.keyboard_events);
 
     if (this.magic_auth) {
-      this.mode = "magic_auth_redeem"
-      this.login()
+      if (this.$store.state.user.logged_in != true) {
+        this.mode = "magic_auth_redeem"
+        this.login()
+      }
     }
 
   },
@@ -392,6 +420,9 @@ import Vue from "vue"; export default Vue.extend( {
 
     },
     do_login: function (response) {
+
+      this.show_logging_in_messsage = true
+
       this.$store.commit('log_in');
       //this.$store.commit('set_user_name', this.email)
 


### PR DESCRIPTION
Context of debugging -> user not being able to use magic login.
I was unable to reproduce the error - even with an "empty" new user. However I did notice it was possible to get into odd UI states. That could be confusing.

For example if, as a user, I click the back button after doing the magic redeem, it would show this which was confusing.
![state of clicking back after magic login is a bit odd it shows login screen](https://user-images.githubusercontent.com/18080164/132605546-5ec1af46-3374-4f69-8241-16472b161a50.PNG)

1. Added a guard to prevent running auth if user is already logged in
2. Show state of already logged in

![already logged in state](https://user-images.githubusercontent.com/18080164/132604955-f7f0ce48-4043-43ce-a101-f3e31bc050ea.PNG)

I believe solution is ok. 
An alterative is a navigation guard to prevent entry to this page. Because we use `beforeEnter` , at a quick analysis it seemed like it would have required bigger scope of changes to capture the `back` context. https://stackoverflow.com/questions/50087164/vue-router-how-to-prevent-the-user-back-to-the-login-screen-pressing-the-back-b 
<br>

3. Took opportunity to add loading screen.
While in many cases login is instant, sometimes on first load etc it's possible for this screen to show for a few seconds so this looks better then showing a login screen - and also helps avoid user trying to hit login button again etc. Also avoids more work having to re-work disable flags to remain until next page loads etc.
![image](https://user-images.githubusercontent.com/18080164/132604980-695281f2-b509-46f4-b240-784fa5bc5231.png)

