### PR TITLE
fix: handle Forbidden exceptions correctly

### DIFF
--- a/default/main.py
+++ b/default/main.py
@@ -31,19 +31,6 @@ app = Flask('Diffgram',
 app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024    # 50 Mb limit
 sslify = SSLify(app, subdomains=True)  
 
-@app.errorhandler(500)
-def server_error(e):
-	logging.exception('An error occurred during a request.')
-
-	if app.debug == False:
-		return "Please try again later", 500
-
-	if app.debug == True:
-		return """
-		An internal error occurred: <pre>{}</pre>
-		See logs for full stacktrace.
-		""".format(e), 500
-
 from routes_init import do_routes_importing
 
 do_routes_importing()

--- a/shared/error_handlers/error_handlers.py
+++ b/shared/error_handlers/error_handlers.py
@@ -3,8 +3,10 @@ from flask import jsonify
 from shared.settings import settings
 import traceback
 from shared.shared_logger import get_shared_logger
+from werkzeug.exceptions import Forbidden
 
 logger = get_shared_logger()
+
 
 @current_app.errorhandler(Exception)
 def handle_exception(e):
@@ -14,3 +16,13 @@ def handle_exception(e):
         payload['trace'] = exc_traceback
     logger.error(exc_traceback)
     return jsonify(payload), 500
+
+
+@current_app.errorhandler(Forbidden)
+def handle_forbidden(e):
+    payload = {'error': str(e)}
+    exc_traceback = traceback.format_exc()
+    if settings.DIFFGRAM_ERROR_SEND_TRACES_IN_RESPONSE:
+        payload['trace'] = exc_traceback
+    logger.error(exc_traceback)
+    return jsonify(payload), 403

--- a/walrus/main.py
+++ b/walrus/main.py
@@ -17,21 +17,6 @@ app.app_context()
 sslify = SSLify(app, subdomains=True)
 
 
-
-@app.errorhandler(500)
-def server_error(e):
-    logging.exception('An error occurred during a request.')
-
-    if app.debug == False:
-        return "Please try again later", 500
-
-    if app.debug == True:
-        return """
-		An internal error occurred: <pre>{}</pre>
-		See logs for full stacktrace.
-		""".format(e), 500
-
-
 # This is so all the ORM can map the shared modules
 # Appears to be needed even if not directly using them
 # Maybe a setting we can look into


### PR DESCRIPTION
The exception handle we added was catching all types of exceptions. But we need to make a special case for the Forbidden exception since it's a different status code. 

From inspecting the code the are no other types of exceptions other than IOError, but that one should be handled as a 500. I think the general route should be to default to 500 and handle special types of exceptions with other handlers in this file.