### PR TITLE
Upgrade export task context and general export fixes

### DIFF
--- a/default/methods/source_control/file/file_browser.py
+++ b/default/methods/source_control/file/file_browser.py
@@ -625,7 +625,7 @@ class File_Browser():
                 limit = self.metadata["limit"],
                 offset = self.metadata["start_index"],
             )
-            if not working_dir_file_list or len(log['error'].keys()) > 1:
+            if not working_dir_file_list or regular_log.log_has_error(log):
                 return False
             file_count += count
         else:

--- a/default/methods/task/task_template/job_new_or_update.py
+++ b/default/methods/task/task_template/job_new_or_update.py
@@ -254,7 +254,7 @@ def job_update_api(project_string_id):
             project=project)
 
         job, log = job_update_core(session, job, project, input, log)
-        if len(log['error'].keys()) > 1:
+        if regular_log.log_has_error(log):
             return jsonify(log=log), 400
         log['success'] = True
         out = jsonify(job=job.serialize_new(),
@@ -313,7 +313,7 @@ def job_output_dir_update(project_string_id):
 
         job, log = update_output_dir_actions(session, job, project, input, log)
 
-        if len(log['error'].keys()) > 1:
+        if regular_log.log_has_error(log):
             return jsonify(log=log), 400
         log['success'] = True
         out = jsonify(job=job.serialize_new(),

--- a/shared/regular/regular_log.py
+++ b/shared/regular/regular_log.py
@@ -17,5 +17,7 @@ def result_has_error(result):
 
 
 def log_has_error(log):
-    print(log)
-    return log and log.get('error') and len(log.get('error').keys()) >= 1
+    if log.get('error'):
+        if len(log.get('error').keys()) >= 1:
+            return True
+    return False

--- a/shared/utils/job_dir_sync_utils.py
+++ b/shared/utils/job_dir_sync_utils.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from shared.utils.sync_events_manager import SyncEventManager
 from shared.shared_logger import get_shared_logger
 from shared.database.task.job.job_working_dir import JobWorkingDir
+from shared.regular import regular_log
 
 logger = get_shared_logger()
 
@@ -80,7 +81,7 @@ class JobDirectorySyncManager:
         if result is not True:
             log['error']['create_file_links'] = 'Error creating links for file id: {}'.format(file.id)
             return False, log
-        if len(log['error'].keys()) > 1:
+        if regular_log.log_has_error(log):
             return False, log
 
         return True, log
@@ -338,7 +339,7 @@ class JobDirectorySyncManager:
                     )
                     if result is not True:
                         log['error']['sync_file_dirs'] = 'Error syncing dirs for file id: {}'.format(file.id)
-                    if len(log['error'].keys()) > 1:
+                    if regular_log.log_has_error(log):
                         return False, log
         else:
             logger.debug(
@@ -370,7 +371,7 @@ class JobDirectorySyncManager:
             )
             if result is not True:
                 log['error']['sync_file_dirs'] = 'Error syncing dirs for file id: {}'.format(file_to_link.id)
-            if len(log['error'].keys()) > 1:
+            if regular_log.log_has_error(log):
                 return False, log
         self.job.update_file_count_statistic(session = self.session)
         return True, self.log

--- a/shared/utils/job_dir_sync_utils.py
+++ b/shared/utils/job_dir_sync_utils.py
@@ -152,7 +152,7 @@ class JobDirectorySyncManager:
                 create_tasks = create_tasks,
                 sync_event_manager = sync_event_manager)
 
-            if len(self.log['error'].keys()) > 1:
+            if regular_log.log_has_error(self.log):
                 return False, self.log
             job.update_file_count_statistic(session = self.session)
         return True, self.log

--- a/walrus/methods/connectors/azure_connector.py
+++ b/walrus/methods/connectors/azure_connector.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from methods.export.export_view import export_view_core
 from shared.database.export import Export
 from methods.export.export_utils import generate_file_name_from_export, check_export_permissions_and_status
-
+from shared.regular import regular_log
 
 images_allowed_file_names = [".jpg", ".jpeg", ".png"]
 videos_allowed_file_names = [".mp4", ".mov", ".avi", ".m4v", ".quicktime"]
@@ -350,7 +350,7 @@ class AzureConnector(Connector):
             export_check_result = check_export_permissions_and_status(export,
                                                                       self.config_data['project_string_id'],
                                                                       session)
-            if len(export_check_result['error'].keys()) > 1:
+            if regular_log.log_has_error(export_check_result):
                 return export_check_result
 
             result = export_view_core(

--- a/walrus/methods/connectors/google_cloud_storage_connector.py
+++ b/walrus/methods/connectors/google_cloud_storage_connector.py
@@ -389,7 +389,7 @@ class GoogleCloudStorageConnector(Connector):
             export_check_result = check_export_permissions_and_status(export,
                                                                       self.config_data['project_string_id'],
                                                                       session)
-            if len(export_check_result['error'].keys()) > 1:
+            if regular_log.log_has_error(export_check_result):
                 log = regular_log.default()
                 log['error'] = export_check_result['error']
                 log['error']['file_name'] = opts['path']

--- a/walrus/methods/connectors/s3_connector.py
+++ b/walrus/methods/connectors/s3_connector.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from methods.export.export_view import export_view_core
 from shared.database.export import Export
 from methods.export.export_utils import generate_file_name_from_export, check_export_permissions_and_status
+from shared.regular import regular_log
 
 images_allowed_file_names = [".jpg", ".jpeg", ".png"]
 videos_allowed_file_names = [".mp4", ".mov", ".avi", ".m4v", ".quicktime"]
@@ -334,7 +335,7 @@ class S3Connector(Connector):
             export_check_result = check_export_permissions_and_status(export,
                                                                       self.config_data['project_string_id'],
                                                                       session)
-            if len(export_check_result['error'].keys()) > 1:
+            if regular_log.log_has_error(export_check_result):
                 return export_check_result
 
             result = export_view_core(

--- a/walrus/methods/export/export_generation.py
+++ b/walrus/methods/export/export_generation.py
@@ -86,13 +86,21 @@ def new_external_export(
     # files not replaced in the directory yet.
     if export.source == "job":
 
-        file_list = WorkingDirFileLink.file_list(
-            session=session,
-            limit=None,
-            root_files_only=True,
-            job_id=export.job_id,
-            ann_is_complete=export.ann_is_complete
+        status = None
+        if export.ann_is_complete is True:
+            status = "complete"
+
+        task_list = Task.list(
+            session = session,
+            job_id = export.job_id,
+            status = status,
+            project_id = export.project_id,
+            limit_count=None
         )
+
+        file_list =[]
+        for task in task_list:
+            file_list.append(task.file)
 
     if export.source == "directory":
         # Question, why are we declaring this here?

--- a/walrus/methods/export/export_generation.py
+++ b/walrus/methods/export/export_generation.py
@@ -115,7 +115,7 @@ def new_external_export(
         file_list=file_list)
 
     if result is False or result is None:
-        return False
+        return False, None
 
     filename = generate_file_name_from_export(export, session)
 

--- a/walrus/methods/export/export_utils.py
+++ b/walrus/methods/export/export_utils.py
@@ -62,11 +62,11 @@ def is_export_completed(export):
 
 def check_export_permissions_and_status(export, project_string_id, session):
     project_perms = has_project_permissions_for_export(export, project_string_id, session)
-    if len(project_perms['error'].keys()) > 1:
+    if regular_log.log_has_error(project_perms):
         return project_perms
 
     export_completed_result = is_export_completed(export)
-    if len(export_completed_result['error'].keys()) > 1:
+    if regular_log.log_has_error(export_completed_result):
         return export_completed_result
 
     return regular_log.default()

--- a/walrus/methods/export/export_utils.py
+++ b/walrus/methods/export/export_utils.py
@@ -42,7 +42,7 @@ def has_project_permissions_for_export(export, project_string_id, session):
     project = Project.get(session, project_string_id)
     # Theory is that if a user has access to project
     # They have access to download from project
-    if export.project_id == project.id:
+    if export.project_id != project.id:
         log['error']['project_permissions'] = 'Permission error, invalid project export match'
 
     return log
@@ -54,7 +54,7 @@ def is_export_completed(export):
     # it failing if the export is not ready
     # note it's "complete" and not "success"
     if export.status != "complete":
-        log['error'] = "Export not ready yet."
+        log['error']['export'] = "Export not ready yet."
         log['export'] = export.serialize()
         return log
     return log

--- a/walrus/methods/export/export_view.py
+++ b/walrus/methods/export/export_view.py
@@ -92,6 +92,7 @@ def export_link(project_string_id):
         return jsonify(result), 200
 
 
+# CAUTION this is a private method - call check_export_permissions_and_status() in many cases
 def export_view_core(
         export,
         format="JSON",

--- a/walrus/methods/export/export_view.py
+++ b/walrus/methods/export/export_view.py
@@ -3,6 +3,8 @@ from methods.regular.regular_api import *
 from shared.data_tools_core import Data_tools
 from shared.database.export import Export
 from methods.export.export_utils import check_export_permissions_and_status
+from shared.regular import regular_log
+
 data_tools = Data_tools().data_tools
 
 
@@ -81,7 +83,7 @@ def export_link(project_string_id):
             Export.id == input['id']).first()
 
         export_check_result = check_export_permissions_and_status(export, project_string_id, session)
-        if len(export_check_result['error'].keys()) > 1:
+        if regular_log.log_has_error(export_check_result):
             return jsonify(export_check_result), 400
 
         result = export_view_core(

--- a/walrus/methods/export/export_web.py
+++ b/walrus/methods/export/export_web.py
@@ -6,6 +6,8 @@ from shared.data_tools_core import Data_tools
 from shared.database.export import Export
 from methods.export.export_view import export_view_core
 from shared.database.task.job.job import Job
+from methods.export.export_utils import check_export_permissions_and_status
+
 
 data_tools = Data_tools().data_tools
 
@@ -197,6 +199,12 @@ def web_export_to_file(project_string_id):
                 project_string_id = project_string_id,
                 export_id = export.id)
 
+            export_check_result = check_export_permissions_and_status(
+                export, project_string_id, session)
+
+            if regular_log.log_has_error(export_check_result):
+                return jsonify(export_check_result), 400
+
             result = export_view_core(
                 export = export,
                 format = "JSON",
@@ -263,5 +271,3 @@ def export_web_core(session,
             use_request_context = use_request_context
         )
 
-    project.generate_status = "complete"
-    session.add(project)

--- a/walrus/tests/methods/export/test_export_generation.py
+++ b/walrus/tests/methods/export/test_export_generation.py
@@ -93,7 +93,8 @@ class TestExportGeneration(testing_setup.DiffgramBaseTestCase):
         }, self.session)
 
         file = data_mocking.create_file(
-            {'project_id': self.project.id, 'type': 'image'}, self.session)
+            {'project_id': self.project.id, 
+             'type': 'image'}, self.session)
 
         task_1 = data_mocking.create_task({
             'name': 'task1',
@@ -105,9 +106,12 @@ class TestExportGeneration(testing_setup.DiffgramBaseTestCase):
         
         instance1 = data_mocking.create_instance(
             {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 
-             'file_id': file.id, 'label_file_id': label_file.id},
+             'file_id': file.id, 
+             'label_file_id': label_file.id},
             self.session
         )
+        self.session.commit()
+
         export = data_mocking.create_export({
             'description': 'test',
             'source': 'job',

--- a/walrus/tests/methods/export/test_export_generation.py
+++ b/walrus/tests/methods/export/test_export_generation.py
@@ -88,10 +88,12 @@ class TestExportGeneration(testing_setup.DiffgramBaseTestCase):
         """
 
         job = data_mocking.create_job({
-            'name': 'my-test-job'
+            'name': 'my-test-job',
+            'project': self.project
         }, self.session)
 
-        file = data_mocking.create_file({'project_id': self.project.id, 'type': 'image'}, self.session)
+        file = data_mocking.create_file(
+            {'project_id': self.project.id, 'type': 'image'}, self.session)
 
         task_1 = data_mocking.create_task({
             'name': 'task1',

--- a/walrus/tests/methods/export/test_export_generation.py
+++ b/walrus/tests/methods/export/test_export_generation.py
@@ -110,7 +110,6 @@ class TestExportGeneration(testing_setup.DiffgramBaseTestCase):
              'label_file_id': label_file.id},
             self.session
         )
-        self.session.commit()
 
         export = data_mocking.create_export({
             'description': 'test',
@@ -119,7 +118,6 @@ class TestExportGeneration(testing_setup.DiffgramBaseTestCase):
             'project_id': self.project.id,
             'job_id': job.id
         }, self.session)
-        self.session.commit()
 
         with patch.object(
             export_generation.data_tools, 'upload_from_string') as mock_1:

--- a/walrus/tests/methods/export/test_export_generation.py
+++ b/walrus/tests/methods/export/test_export_generation.py
@@ -111,12 +111,15 @@ class TestExportGeneration(testing_setup.DiffgramBaseTestCase):
             self.session
         )
 
+
         export = data_mocking.create_export({
             'description': 'test',
             'source': 'job',
             'kind': 'Annotations',
             'project_id': self.project.id,
-            'job_id': job.id
+            'job_id': job.id,
+            'ann_is_complete': False,
+            'file_comparison_mode': 'latest'
         }, self.session)
 
         with patch.object(
@@ -129,9 +132,9 @@ class TestExportGeneration(testing_setup.DiffgramBaseTestCase):
                 use_request_context = False
             )
 
-            mock_1.asser_called_once()
+            mock_1.assert_called_once()
 
-            print('result', export_data)
+            print('result', export_data[file.id]['instance_list'])
 
             self.assertTrue(result)
 


### PR DESCRIPTION
Summary

1. **Make export from tasks work as expected.** Meaning it pulls from tasks not files. This is becuase now that we have streaming, the concept of a file being associated with a singular job is ill-defined. Further it opens the ability to use task orientated filters!
2. It also happens to fix the one-off case of job_id not being populated unless annotation was completed, effectively meaning "ann_is_true" was forced on, but without actually using that flag, which is of course bad.
3. Fix a variety of > instead of >= and refactor to avoid in future. 
Note: It's possible this could have downstream effects, but unless there was some reason (I can't think of one) that we actually did want ">" for these, then this fix should still be correct, and we can do further fixes for downstream issues.
4. Small fixes on export conditions
5. Properly call `check_export_permissions_and_status()` in the immediate return case
6. Add a wip test case for this path since it's different from the existing working dir test case

A past hesitancy with moving to task abstraction was if we should actually export the task objects. But for now, by simply converting back to the same file list structure, it works. And we can explore exporting more task specific data later if needed.

Pablo, the test case mostly works but for some reason `instance_list` is not being populated. It's successfully getting the file though. https://github.com/diffgram/diffgram/runs/3680036283?check_suite_focus=true#step:17:109 
I'm not sure if I'm using the utility function correctly, maybe can I get your help there when you can please?

