### PR TITLE
Snap to Instance and Keypoints improvements

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6595,7 +6595,7 @@
         },
 
         may_toggle_show_hide_occlusion: function (event) {
-          if (event.key === "o") {
+          if (event.key === "o" || event.key === "O") {
             this.label_settings.show_occluded_keypoints = !this.label_settings.show_occluded_keypoints
             this.refresh = new Date();
           }

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6574,6 +6574,26 @@
           }
         },
 
+        may_toggle_file_change_left: function (event) {
+          if (event.keyCode === 37 || event.key === "a") { // left arrow or A
+            if (this.shift_key) {
+              this.change_file("previous");
+            } else {
+              this.shift_frame_via_store(-1)
+            }
+          }
+        },
+
+        may_toggle_file_change_right: function (event) {
+          if (event.keyCode === 39 || event.key === "d") { // right arrow
+            if (this.shift_key) {
+              this.change_file("next");
+            } else {
+              this.shift_frame_via_store(1)
+            }
+          }
+        },
+
         keyboard_events_global_down: function (event) {
           var ctrlKey = 17,
             cmdKey = 91,
@@ -6595,23 +6615,10 @@
             return
           }
 
-          if (event.keyCode === 37 || event.key === "a") { // left arrow or A
-            if (this.shift_key) {
-              this.change_file("previous");
-            } else {
-              this.shift_frame_via_store(-1)
-            }
-          }
+          this.may_toggle_file_change_left(event)
+          this.may_toggle_file_change_right(event)
 
           this.may_toggle_instance_transparency(event)
-
-          if (event.keyCode === 39 || event.key === "d") { // right arrow
-            if (this.shift_key) {
-              this.change_file("next");
-            } else {
-              this.shift_frame_via_store(1)
-            }
-          }
 
           if (event.key === "N") { // shift + n
             if (this.shift_key) {

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6594,6 +6594,18 @@
           }
         },
 
+        may_toggle_escape_key: function (event) {
+          if (event.keyCode === 27) { // Esc
+            if (this.$props.view_only_mode == true) { return }
+            if(this.instance_select_for_issue || this.view_issue_mode){return}
+            if(this.instance_select_for_merge){return}
+
+            this.draw_mode = !this.draw_mode
+            this.edit_mode_toggle( this.draw_mode)
+            this.is_actively_drawing = false
+          }
+        },
+
         keyboard_events_global_down: function (event) {
           var ctrlKey = 17,
             cmdKey = 91,
@@ -6637,17 +6649,7 @@
             this.save(true);  // and_complete == true
           }
 
-          if (event.keyCode === 27) { // Esc
-            if (this.$props.view_only_mode == true) { return }
-            if(this.instance_select_for_issue || this.view_issue_mode){return}
-            if(this.instance_select_for_merge){return}
-
-            this.draw_mode = !this.draw_mode
-            this.edit_mode_toggle( this.draw_mode)
-            this.is_actively_drawing = false
-            // careful, can't include this direclty in edit_mode_toggle
-            // since veutify switch does this behaviour too
-          }
+          this.may_toggle_escape_key(event)
 
           if (event.keyCode === 32) { // space
 

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -986,12 +986,15 @@
 
           instance_rotate_control_mouse_hover: null,
 
+          snapped_to_instance: undefined,
+
           snackbar_paste_message: '',
           ghost_instance_hover_index: null,
           default_instance_opacity: 0.25,
           model_run_list: null,
           ghost_instance_hover_type: null,
           ghost_instance_list: [],
+          selected_instance_list: [],
 
           show_default_navigation: true,
           snackbar_merge_polygon: false,
@@ -1129,6 +1132,7 @@
           loading: false,
 
           label_settings: {
+            enable_snap_to_instance: true,
             show_ghost_instances: true,
             show_text: true,
             show_label_text: true,
@@ -1446,6 +1450,9 @@
         },
         selected_instance: function(){
           if(!this.instance_list){return}
+          if(this.selected_instance_list && this.selected_instance_list.length > 0) {
+            return this.selected_instance_list[0]
+          }
           for(let i=0; i < this.instance_list.length; i ++){
             if(this.instance_list[i].selected){
               return this.instance_list[i]
@@ -2645,10 +2652,14 @@
 
           // careful can't use id, since newly created instances won't have an ID!
           this.instance_focused_index = focus.index
+          this.selected_instance_list = [this.instance_list[this.instance_focused_index]]
+          this.snap_to_instance(this.selected_instance)
         },
 
         focus_instance_show_all() {
           this.instance_focused_index = null
+          this.selected_instance_list = []
+          this.reset_to_full()
         },
 
         instance_update: function (update) {
@@ -3345,6 +3356,85 @@
 
           this.canvas_translate = this.canvas_mouse_tools.zoom_wheel_canvas_translate(
             event, this.canvas_scale_local)
+        },
+
+        reset_to_full: function () {
+          this.canvas_translate.x = 0
+          this.canvas_translate.y = 0
+          this.canvas_scale_local = 1
+        },
+
+        get_center_point_of_instance:function (instance) {
+          let x = instance.x_max - (instance.width / 2)
+          let y = instance.y_max - (instance.height / 2)
+          return {'x' : x, 'y' : y}
+        },
+
+        get_focus_point_of_instance: function (instance){
+          let point = {'x': 0, 'y': 0}
+          let center_point = this.get_center_point_of_instance(instance)
+          let center_of_frame = {'x': this.canvas_width/2, 'y': this.canvas_height/2}
+
+          if (this.point_is_intersecting_circle(center_point, center_of_frame, 100)) {
+            return center_point
+          }
+
+          if (instance.x_max > (this.canvas_width / 2)) {
+            point.x = instance.x_max
+          }
+          else {
+            point.x = instance.x_min
+          }
+          if (instance.y_max > (this.canvas_height / 2)) {
+            point.y = instance.y_max
+          }
+          else {
+            point.y = instance.y_min
+          }
+          return point
+
+        },
+
+        clamp_values(val, min, max) {
+          return Math.min(Math.max(val, min), max)
+        },
+
+        auto_revert_snapped_to_instance_if_unchanged: function (instance) {
+          if (this.snapped_to_instance == instance) {
+            this.reset_to_full()
+            this.snapped_to_instance = undefined
+            return true
+          }
+          return false
+        },
+
+        get_zoom_region_of_instance: function (instance){
+          let max_zoom = 10
+          let max_x = this.clamp_values(max_zoom, 0, this.canvas_width / instance.width)
+          let max_y = this.clamp_values(max_zoom, 0, this.canvas_height / instance.height)
+          let max_zoom_to_show_all = this.clamp_values(3, max_x, max_y)
+          let padding = -0.5
+          return max_zoom_to_show_all + padding
+        },
+
+        snap_to_instance: function (instance){
+
+          if (this.label_settings.enable_snap_to_instance == false) {
+            return
+          }
+
+          if (this.auto_revert_snapped_to_instance_if_unchanged(instance) == true) {
+            return
+          }
+
+          this.snapped_to_instance = instance
+
+          let point = this.get_focus_point_of_instance(instance)
+
+          this.canvas_translate.x = point.x * this.canvas_scale_global
+          this.canvas_translate.y = point.y * this.canvas_scale_global
+
+          this.canvas_scale_local = this.get_zoom_region_of_instance(instance)
         },
 
         update_label_file_visible: function (label_file) {
@@ -5009,8 +5099,9 @@
       }
       */
           this.mouse_position = this.mouse_transform(event, this.mouse_position);
-          if (this.ctrl_key == true) {
+          if (this.ctrl_key === true) {
             this.move_position_based_on_mouse(event.movementX, event.movementY)
+            this.canvas_element.style.cursor = 'move'
             return
           }
           this.move_something(event)
@@ -6490,23 +6581,25 @@
 
         },
 
+        set_control_key: function (event){
+          // Caution used name commands here to that when multiple keys are pressed it still works
+          if (event.ctrlKey == false || event.metaKey == false) { // ctrlKey cmd key
+            this.ctrl_key = false
+          }
+          if (event.ctrlKey == true || event.metaKey == true) { // ctrlKey cmd key
+            this.ctrl_key = true
+          }
+        },
+
         // hotkey hotkeys
         keyboard_events_global_up: function (event) {
-          /*
-       *  So one thing to think about is having all annotation
-       *  hotkeys in one place
-       *  -> Things like the new label lock
-       *  -> ease of reference / **preventing overlap**
-       *  -> Event listeners are not great to have to setup and take down
-       *  in each component
-       *
-       *  BUT that's not for context relevant things I guess
-       *  Was thinking in context of where to add a hotkey for
-       *  sequences and at first thinking there and then realizing
-       *  maybe not.
-       *
-       */
-          var   ctrlKey = 17;
+
+          if (this.$store.state.user.is_typing_or_menu_open == true) {
+            return    // Caution must be near top to prevent when typing
+          }
+
+          this.set_control_key(event)
+
           if(this.show_context_menu){
             return
           }
@@ -6514,19 +6607,9 @@
             //
             this.shift_key = false
           }
-          if(event.keyCode === 91){ // cmd key
-            this.ctrl_key = false;
-          }
-          if (event.keyCode === ctrlKey) { // ctrlKey
-            this.ctrl_key = false
-          }
 
           if (event.keyCode === 72) { // h key
             this.show_annotations = !this.show_annotations;
-          }
-
-          if (this.$store.state.user.is_typing_or_menu_open == true) {
-            return
           }
 
           if (event.key === "f") {
@@ -6535,10 +6618,6 @@
 
           if (event.key === "g") {
             this.label_settings.show_ghost_instances = !this.label_settings.show_ghost_instances
-          }
-
-          if (event.keyCode === 83) { // save
-            this.save();
           }
 
           if (event.keyCode === 13) {  // enter
@@ -6558,8 +6637,6 @@
 
 
         },
-
-        // more hotkeys
 
         may_toggle_instance_transparency: function (event) {
           if (event.keyCode === 84) { // shift + t
@@ -6581,6 +6658,12 @@
             } else {
               this.shift_frame_via_store(-1)
             }
+          }
+        },
+        
+        may_snap_to_instance: function (event) {
+          if (this.shift_key == true && event.key === "F") {
+            this.snap_to_instance(this.selected_instance)
           }
         },
 
@@ -6613,26 +6696,34 @@
           }
         },
 
+        may_save: function (event) {
+          if (event.key === "s" && this.shift_key == false) { // save
+            this.save();
+          }
+        },
+
         keyboard_events_global_down: function (event) {
           var ctrlKey = 17,
             cmdKey = 91,
             shiftKey = 16,
             vKey = 86,
             cKey = 67;
-          if (event.keyCode == ctrlKey || event.keyCode == cmdKey) {this.ctrl_key = true;}
+
+          this.set_control_key(event)
+
+          if (this.$store.state.user.is_typing_or_menu_open == true) {
+            return    // this guard should be at highest level
+          }
+
           if (event.keyCode === shiftKey) { // shift
             //
             this.shift_key = true
           }
-          if(event.keyCode === 17){
-            this.ctrl_key = true;
-            this.canvas_element.style.cursor = 'move'
-          }
 
-          if (this.$store.state.user.is_typing_or_menu_open == true) {
-            //console.debug("Blocked by is_typing_or_menu_open")
-            return
-          }
+          this.may_save(event)
+
+          this.may_snap_to_instance(event)
+
 
           this.may_toggle_file_change_left(event)
           this.may_toggle_file_change_right(event)

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -1134,6 +1134,7 @@
             show_label_text: true,
             show_attribute_text: true,
             show_list: true,
+            show_occluded_keypoints: true,
             allow_multiple_instance_select: false,
             font_size: 20,
             spatial_line_size: 2,
@@ -6559,6 +6560,20 @@
         },
 
         // more hotkeys
+
+        may_toggle_instance_transparency: function (event) {
+          if (event.keyCode === 84) { // shift + t
+            if (this.shift_key) {
+              if(this.default_instance_opacity === 1){
+                this.default_instance_opacity = 0.25;
+              }
+              else{
+                this.default_instance_opacity = 1;
+              }
+            }
+          }
+        },
+
         keyboard_events_global_down: function (event) {
           var ctrlKey = 17,
             cmdKey = 91,
@@ -6588,16 +6603,7 @@
             }
           }
 
-          if (event.keyCode === 84) { // shift + t
-            if (this.shift_key) {
-              if(this.default_instance_opacity === 1){
-                this.default_instance_opacity = 0.25;
-              }
-              else{
-                this.default_instance_opacity = 1;
-              }
-            }
-          }
+          this.may_toggle_instance_transparency(event)
 
           if (event.keyCode === 39 || event.key === "d") { // right arrow
             if (this.shift_key) {
@@ -6712,7 +6718,8 @@
               this.trigger_instance_changed,
               this.instance_selected,
               this.instance_deselected,
-              this.mouse_down_delta_event
+              this.mouse_down_delta_event,
+              this.label_settings
             );
             initialized_instance.populate_from_instance_obj(instance);
             return initialized_instance

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6594,6 +6594,13 @@
           }
         },
 
+        may_toggle_show_hide_occlusion: function (event) {
+          if (event.key === "o") {
+            this.label_settings.show_occluded_keypoints = !this.label_settings.show_occluded_keypoints
+            this.refresh = new Date();
+          }
+        },
+
         may_toggle_escape_key: function (event) {
           if (event.keyCode === 27) { // Esc
             if (this.$props.view_only_mode == true) { return }
@@ -6631,6 +6638,7 @@
           this.may_toggle_file_change_right(event)
 
           this.may_toggle_instance_transparency(event)
+          this.may_toggle_show_hide_occlusion(event)
 
           if (event.key === "N") { // shift + n
             if (this.shift_key) {

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -2692,7 +2692,11 @@
           }
 
           if (update.mode == 'on_click_update_point_attribute'){
-            instance.nodes[update.node_hover_index].occluded = true
+            if (instance.nodes[update.node_hover_index].occluded == true) {
+              instance.nodes[update.node_hover_index].occluded = false
+            } else {
+              instance.nodes[update.node_hover_index].occluded = true
+            }
           }
 
           // instance update

--- a/frontend/src/components/annotation/annotation_ui_factory.vue
+++ b/frontend/src/components/annotation/annotation_ui_factory.vue
@@ -4,6 +4,7 @@
     <div id="annotation_ui_factory" tabindex="0">
       <div v-if="show_annotation_core == true">
         <v_annotation_core
+          class="pt-1 pl-1"
           :project_string_id="computed_project_string_id"
           :model_run_id_list="model_run_id_list"
           :model_run_color_list="model_run_color_list"

--- a/frontend/src/components/annotation/hotkeys.vue
+++ b/frontend/src/components/annotation/hotkeys.vue
@@ -18,6 +18,9 @@
   <p> <kbd>1 - 9</kbd> Change label </p>
 
   <p> <kbd>Shift</kbd> + <kbd>←</kbd>,<kbd>→</kbd> Previous or Next File </p>
+
+  <h2> Instance </h2>
+  <p> <kbd>Shift</kbd> + <kbd>f</kbd> Snap to Selected Instance / Unsnap </p>
   <p> <kbd>Ctrl</kbd> + <kbd>c</kbd> Copy Selected Instance </p>
   <p> <kbd>Ctrl</kbd> + <kbd>v</kbd> Paste Selected Instance </p>
 

--- a/frontend/src/components/annotation/hotkeys.vue
+++ b/frontend/src/components/annotation/hotkeys.vue
@@ -13,6 +13,7 @@
   <p> <kbd>W</kbd> Toggle Label Menu </p>
   <p> <kbd>H</kbd> Hide/Show All Instances in File. </p>
   <p> <kbd>Shift + T</kbd>Remove/Add Instance Transparency </p>
+  <p> <kbd>O</kbd> Hide/Show Occluded KeyPoints </p>
   <p> <kbd>G</kbd> Toggle Ghost Instances </p>
   <p> <kbd>1 - 9</kbd> Change label </p>
 

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -652,6 +652,11 @@
                           data-cy="show_allow_multiple_select_checkbox"
                           v-model="label_settings_local.allow_multiple_instance_select">
               </v-checkbox>
+              
+              <v-checkbox label="Show Occluded Keypoints"
+                          data-cy="show_occluded_keypoints"
+                          v-model="label_settings_local.show_occluded_keypoints">
+              </v-checkbox>
 
               <v-slider label="Text Font Size"
                         min=10

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -649,6 +649,11 @@
                           v-model="label_settings_local.show_occluded_keypoints">
               </v-checkbox>
 
+              <v-checkbox label="Enable Snap to Instance"
+                          data-cy="enable_snap_to_instance"
+                          v-model="label_settings_local.enable_snap_to_instance">
+              </v-checkbox>
+
               <v-slider label="Text Font Size"
                         min=10
                         max=30

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -385,16 +385,7 @@
     </template>
 
   </button_with_menu>
-  <tooltip_button
-    tooltip_message="Copy All Instances"
-    @click="$emit('copy_all_instances')"
-    :disabled="loading || annotations_loading"
-    color="primary"
-    icon="mdi-content-duplicate"
-    :icon_style="true"
-    :bottom="true"
-  >
-  </tooltip_button>
+
   <button_with_menu
     tooltip_message="Hotkeys"
     v-if="view_only_mode != true"
@@ -756,6 +747,19 @@
               :icon_style="true"
               :bottom="true"
               color="primary">
+          </tooltip_button>
+        </v-layout>
+
+        <v-layout>
+          <tooltip_button
+            tooltip_message="Copy All Instances"
+            @click="$emit('copy_all_instances')"
+            :disabled="loading || annotations_loading"
+            color="primary"
+            icon="mdi-content-duplicate"
+            :icon_style="true"
+            :bottom="true"
+          >
           </tooltip_button>
         </v-layout>
 

--- a/frontend/src/components/context_menu/context_menu.vue
+++ b/frontend/src/components/context_menu/context_menu.vue
@@ -640,15 +640,14 @@
 
         <v-list-item-icon>
           <tooltip_icon
-
-            tooltip_message="Update"
+            tooltip_message="Mark Occluded"
             icon="mdi-vector-polyline-minus"
             color="primary"
           />
         </v-list-item-icon>
         <v-list-item-content>
           <v-list-item-title class="pr-4">
-            Mark Ocluded
+            Mark Occluded
           </v-list-item-title>
         </v-list-item-content>
       </v-list-item>

--- a/frontend/src/components/vue_canvas/CanvasMouseTools.ts
+++ b/frontend/src/components/vue_canvas/CanvasMouseTools.ts
@@ -10,8 +10,8 @@ export class CanvasMouseTools {
 
   public zoom_in(canvas_transform): number {
     canvas_transform.canvas_scale_local += 0.1;
-    if (canvas_transform.canvas_scale_local >= 9) {
-      canvas_transform.canvas_scale_local = 9
+    if (canvas_transform.canvas_scale_local >= 30) {
+      canvas_transform.canvas_scale_local = 30
     }
     return canvas_transform.canvas_scale_local
   }
@@ -67,8 +67,8 @@ export class CanvasMouseTools {
     }
 
     // TODO abstract this
-    if (canvas_scale_local >= 9) {
-      canvas_scale_local = 9
+    if (canvas_scale_local >= 30) {
+      canvas_scale_local = 30
     }
     return canvas_scale_local
   }

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -31,7 +31,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   public current_node_connection: any = [];
   private instance_rotate_control_mouse_hover: boolean = undefined
   public angle: number = 0
-  public label_settings: any = {} 
+  public label_settings: any = undefined 
 
 
   public get_instance_data(): object {
@@ -411,7 +411,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       // order of operations
       ctx.lineWidth = 2;
 
-      if (this.label_settings.show_occluded_keypoints == false &&
+      if (this.label_settings &&
+          this.label_settings.show_occluded_keypoints == false &&
           node.occluded == true) {
         continue
       }
@@ -609,7 +610,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       let node1 = this.nodes.filter(n => n.id === edge.from)[0];
       let node2 = this.nodes.filter(n => n.id === edge.to)[0];
 
-      if (this.label_settings.show_occluded_keypoints == false &&
+      if (this.label_settings &&
+          this.label_settings.show_occluded_keypoints == false &&
           node2.occluded == true) {
         continue
       }

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -31,6 +31,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   public current_node_connection: any = [];
   private instance_rotate_control_mouse_hover: boolean = undefined
   public angle: number = 0
+  public label_settings: any = {} 
 
 
   public get_instance_data(): object {
@@ -43,7 +44,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
               on_instance_updated = undefined,
               on_instance_selected = undefined,
               on_instance_deselected = undefined,
-              mouse_down_delta_event = undefined) {
+              mouse_down_delta_event = undefined,
+              label_settings = undefined) {
 
     super();
     this.nodes = [];
@@ -57,6 +59,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     this.mouse_position = mouse_position;
     this.initialized = true;
     this.ctx = ctx;
+    this.label_settings = label_settings;
   }
 
   public duplicate_for_undo(){
@@ -407,12 +410,19 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     for (let node of this.nodes) {
       // order of operations
       ctx.lineWidth = 2;
+
+      if (this.label_settings.show_occluded_keypoints == false &&
+          node.occluded == true) {
+        continue
+      }
+
       if (node.occluded == true) {
         ctx.fillStyle = 'gray'
       } else {
         ctx.strokeStyle = this.strokeColor;
         ctx.fillStyle = this.fillColor;
       }
+
 
       let x = node.x
       let y = node.y
@@ -598,6 +608,11 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
       let node1 = this.nodes.filter(n => n.id === edge.from)[0];
       let node2 = this.nodes.filter(n => n.id === edge.to)[0];
+
+      if (this.label_settings.show_occluded_keypoints == false &&
+          node2.occluded == true) {
+        continue
+      }
 
       if (node2.occluded == true) {
         ctx.strokeStyle = 'gray'

--- a/walrus/methods/data_mocking/generate_data.py
+++ b/walrus/methods/data_mocking/generate_data.py
@@ -88,6 +88,7 @@ class DiffgramDataMocker:
                                             session=self.session,
                                             media_url='https://picsum.photos/1000',
                                             media_type='image',
+                                            original_filename="example.jpg",
                                             directory_id=dataset.id,
                                             commit_input=True,
                                             task_id=None,

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -1872,6 +1872,13 @@ class Process_Media():
             return
         self.input.original_filename, self.input.extension = get_file_name_and_extension(
                 self.input.url, input_original_filename = self.input.original_filename)
+
+        if self.input.extension is None:
+            self.input.status = "failed"
+            self.input.status_text = "Invalid extension, check filename"
+            self.log['error']['status_text'] = self.input.status_text
+            return
+
         # Add extension to name: ffmpeg requires the filename with the extension.
         # check the split() function in video_preprocess.py
         if self.input.original_filename and not self.input.original_filename.endswith(self.input.extension):


### PR DESCRIPTION

Main work is an addition of this snap to instance feature described here:
https://diffgram.readme.io/docs/snap-to-annotation
There's a couple of rough edges but in general it appears to be working as expected.
![snap to another](https://user-images.githubusercontent.com/18080164/135357716-b71d4c8f-359b-47fb-a042-98baf37cb948.PNG)

Other items
1. Fixed generate samples -> was just missing filename for some reason
2. Increase zoom max -> user request, no clear reason we had it at number before
3. For Keypoints, option to have occluded keypoints hidden completely from view. This essentially makes them "deleted". and still leaves option to "undelete" them.
4. For Keypoints, enable mark point as _not_ occluded
5. Debugged that control key sticking issue a bit. Essentially the left control key seems to "stick", eg the keyup event never gets trigged. This seems to be some kind of odd ongoing issue.
http://jsfiddle.net/vor0nwe/mkHsU/   - easy way to show that the "up" event never fires
https://stackoverflow.com/questions/62683548/why-does-shiftleft-not-trigger-a-keyup-event-while-shiftright-is-held-and-vi    
We may want to think about using shift key instead or see if there's some more general work around. This started to feel like a time sink so left it for now.

Also:
1. refactored some of the hotkey stuff to try and make it a little more clear
2. started a concept of a `selected_instance_list`. a start to try to unify the various "selected" concepts.

