### PR TITLE
Only show if available

### DIFF
--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -86,7 +86,9 @@
     <!-- Defer, In Task Context Only -->
     <div>
       <tooltip_button
-        v-if="task && task.id"
+        v-if="task
+              && task.id
+              && task.status == 'available'"
         @click="$emit('task_update_toggle_deferred')"
         :loading="save_loading"
         :disabled="save_loading || view_only_mode || (file == undefined && task == undefined)"


### PR DESCRIPTION
1. Context that deferring a completed task is undefined
2. check == available instead of != complete because we may add other statues in the future.