### PR TITLE
Annotation improvements

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -33,7 +33,7 @@
                    :instance_type_list="instance_type_list"
                    :view_issue_mode="view_issue_mode"
                    :is_keypoint_template="is_keypoint_template"
-                   @label_settings_change="label_settings = $event, refresh = Date.now()"
+                   @label_settings_change="update_label_settings($event)"
                    @change_label_file="change_current_label_file_template($event)"
                    @update_label_file_visibility="update_label_file_visible($event)"
                    @change_instance_type="change_instance_type($event)"
@@ -1132,6 +1132,7 @@
           loading: false,
 
           label_settings: {
+            font_background_opacity: .75,
             enable_snap_to_instance: true,
             show_ghost_instances: true,
             show_text: true,
@@ -1857,6 +1858,10 @@
       },
 
       methods: {
+        update_label_settings: function (event) {
+          this.label_settings = event
+          this.refresh = Date.now()
+        },
         cancel_merge: function(){
           this.$store.commit('set_instance_select_for_merge', false);
         },

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -654,12 +654,25 @@
                           v-model="label_settings_local.enable_snap_to_instance">
               </v-checkbox>
 
-              <v-slider label="Text Font Size"
-                        min=10
-                        max=30
-                        thumb-label
-                        ticks
-                        v-model="label_settings_local.font_size">
+              <v-slider
+                  label="Text Font Size"
+                  min=10
+                  max=30
+                  thumb-label
+                  ticks
+                  v-model="label_settings_local.font_size"
+                  prepend-icon="mdi-format-size">
+              </v-slider>
+
+              <v-slider
+                  label="Text Background Opacity"
+                  v-model="label_settings_local.font_background_opacity"
+                  prepend-icon="brightness_4"
+                  thumb-label
+                  ticks
+                  min=0.0
+                  step=.05
+                  max=1.0>
               </v-slider>
 
               <v-slider label="Target Reticle Size"
@@ -877,8 +890,11 @@ export default Vue.extend( {
     }
   },
   watch: {
-    label_settings_local(event) {
-      this.$emit('label_settings_change', event)
+    'label_settings_local': {
+        deep: true,
+        handler: function (event) {
+          this.$emit('label_settings_change', event)
+        }
     },
     label_settings(event){
       this.label_settings_local = event

--- a/frontend/src/components/vue_canvas/instance_list.vue
+++ b/frontend/src/components/vue_canvas/instance_list.vue
@@ -1339,6 +1339,32 @@
 
           ctx.fillStyle = this.$get_sequence_color(instance.sequence_id)
 
+          this.draw_text(ctx, message, x, y, ctx.font,
+            '255, 255, 255,',
+            this.$props.label_settings.font_background_opacity);
+        },
+
+        draw_text(ctx, message, x, y, font, background_color, background_opacity) {
+
+          ctx.textBaseline = 'bottom'
+          ctx.font = font
+
+          let text_width = ctx.measureText(message).width;
+
+          let previous_style = ctx.fillStyle
+          ctx.fillStyle = "rgba(" + background_color + background_opacity + ")";
+
+          let text_height = parseInt(font, 10)
+          // the `y - text_height` assumes textBaseline = 'bottom', it's not needed if textBaseline = 'top'
+          let padding = 2
+          ctx.fillRect(
+            x - 1,
+            y - text_height - padding,
+            text_width + padding,
+            text_height + padding)
+
+          ctx.fillStyle = previous_style
+
           ctx.fillText(message, x, y);
 
         },


### PR DESCRIPTION
add draw_text() concept for font_background_opacity
Now we have a font background, and it's user selectable from 0 to 1

bugfix label_settings_local. this was a regression from refactor to component.
now updates in real time as user drags slider for all label settings



![exmaple 3](https://user-images.githubusercontent.com/18080164/135691987-79201ce8-c746-4627-b0f5-ce1e114ea503.PNG)
![example 1](https://user-images.githubusercontent.com/18080164/135691983-e907607b-e907-4f0d-9e9f-75ffcdd1ee1d.PNG)
![example 2](https://user-images.githubusercontent.com/18080164/135691989-4586fca0-455c-4cd1-88c6-849136e30e10.PNG)

