### PR TITLE
Keypoint label names DRAFT 

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -33,7 +33,7 @@
                    :instance_type_list="instance_type_list"
                    :view_issue_mode="view_issue_mode"
                    :is_keypoint_template="is_keypoint_template"
-                   @label_settings_change="label_settings = $event, refresh = Date.now()"
+                   @label_settings_change="update_label_settings($event)"
                    @change_label_file="change_current_label_file_template($event)"
                    @update_label_file_visibility="update_label_file_visible($event)"
                    @change_instance_type="change_instance_type($event)"
@@ -1132,6 +1132,7 @@
           loading: false,
 
           label_settings: {
+            font_background_opacity: .75,
             enable_snap_to_instance: true,
             show_ghost_instances: true,
             show_text: true,
@@ -1857,6 +1858,10 @@
       },
 
       methods: {
+        update_label_settings: function (event) {
+          this.label_settings = event
+          this.refresh = Date.now()
+        },
         cancel_merge: function(){
           this.$store.commit('set_instance_select_for_merge', false);
         },

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -1140,6 +1140,7 @@
             show_attribute_text: true,
             show_list: true,
             show_occluded_keypoints: true,
+            show_left_right_arrows: true,
             allow_multiple_instance_select: false,
             font_size: 20,
             spatial_line_size: 2,

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -649,6 +649,11 @@
                           v-model="label_settings_local.show_occluded_keypoints">
               </v-checkbox>
 
+              <v-checkbox label="Show Left Right Icons Keypoints"
+                          data-cy="show_left_right_arrows"
+                          v-model="label_settings_local.show_left_right_arrows">
+              </v-checkbox>
+
               <v-checkbox label="Enable Snap to Instance"
                           data-cy="enable_snap_to_instance"
                           v-model="label_settings_local.enable_snap_to_instance">

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -654,12 +654,25 @@
                           v-model="label_settings_local.enable_snap_to_instance">
               </v-checkbox>
 
-              <v-slider label="Text Font Size"
-                        min=10
-                        max=30
-                        thumb-label
-                        ticks
-                        v-model="label_settings_local.font_size">
+              <v-slider
+                  label="Text Font Size"
+                  min=10
+                  max=30
+                  thumb-label
+                  ticks
+                  v-model="label_settings_local.font_size"
+                  prepend-icon="mdi-format-size">
+              </v-slider>
+
+              <v-slider
+                  label="Text Background Opacity"
+                  v-model="label_settings_local.font_background_opacity"
+                  prepend-icon="brightness_4"
+                  thumb-label
+                  ticks
+                  min=0.0
+                  step=.05
+                  max=1.0>
               </v-slider>
 
               <v-slider label="Target Reticle Size"
@@ -877,8 +890,11 @@ export default Vue.extend( {
     }
   },
   watch: {
-    label_settings_local(event) {
-      this.$emit('label_settings_change', event)
+    'label_settings_local': {
+        deep: true,
+        handler: function (event) {
+          this.$emit('label_settings_change', event)
+        }
     },
     label_settings(event){
       this.label_settings_local = event

--- a/frontend/src/components/vue_canvas/instance_list.vue
+++ b/frontend/src/components/vue_canvas/instance_list.vue
@@ -1339,6 +1339,32 @@
 
           ctx.fillStyle = this.$get_sequence_color(instance.sequence_id)
 
+          this.draw_text(ctx, message, x, y, ctx.font,
+            '255, 255, 255,',
+            this.$props.label_settings.font_background_opacity);
+        },
+
+        draw_text(ctx, message, x, y, font, background_color, background_opacity) {
+
+          ctx.textBaseline = 'bottom'
+          ctx.font = font
+
+          let text_width = ctx.measureText(message).width;
+
+          let previous_style = ctx.fillStyle
+          ctx.fillStyle = "rgba(" + background_color + background_opacity + ")";
+
+          let text_height = parseInt(font, 10)
+          // the `y - text_height` assumes textBaseline = 'bottom', it's not needed if textBaseline = 'top'
+          let padding = 2
+          ctx.fillRect(
+            x - 1,
+            y - text_height - padding,
+            text_width + padding,
+            text_height + padding)
+
+          ctx.fillStyle = previous_style
+
           ctx.fillText(message, x, y);
 
         },

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -169,7 +169,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     var pi = Math.PI;
     let degrees = this.angle  * (180/pi);
 
-    console.log('ANGLEEE', this.angle, degrees)
+    //console.log('ANGLEEE', this.angle, degrees)
     //console.log(this.angle)
   }
 
@@ -428,18 +428,13 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       let x = node.x
       let y = node.y
 
-      if(node.left_or_right == 'left') {
-        let apples = this.draw_icon(ctx, x, y, 'alert')
-      }
-      //if(node.left_or_right=='right') {
-      //  this.draw_icon(ctx, x, y, 'alert')
-      //}
-
       x = this.get_scaled_x(node)
-      y = this.get_scaled_y(node)
-      //console.log(this)
+      y = this.get_scaled_y(node)     
 
       this.draw_point_and_set_node_hover_index(x, y, i, ctx)
+
+      this.draw_left_right_arrows(ctx, node, x, y)
+
       i += 1
     }
     if (this.num_hovered_paths === 0) {
@@ -457,6 +452,15 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
     if(this.instance_rotate_control_mouse_hover){
       this.ctx.canvas.style.cursor = 'all-scroll'
+    }
+  }
+
+  private draw_left_right_arrows(ctx, node, x, y){
+    if(node.left_or_right == 'left') {
+      this.draw_icon(ctx, x - 5, y, 'arrow_left', 24, 'rgb(255,0,0)')
+    }
+    if(node.left_or_right=='right') {
+      this.draw_icon(ctx, x + 5, y, 'arrow_right', 24, 'rgb(0,255,0)')
     }
   }
 
@@ -506,22 +510,45 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
   }
 
-  private draw_icon(ctx, x, y, icon){
+  private draw_icon(
+        ctx, x, y, icon='arrow_left',
+        font_size=24, fillStyle='rgb(255,175,0)'){
+    // CAUTION if icon is invalid it won't render anything
+    // use `arrow_left` as an example that works
     if(!ctx.material_icons_loaded){
       return
     }
     const old_color = ctx.fillStyle;
     const old_font = ctx.font
-    ctx.beginPath();
-    ctx.font = '24px material-icons';
-    ctx.fillStyle = 'rgb(255,175,0)';
+    const old_textAlign = ctx.textAlign
+    const old_baseLine = ctx.textBaseline
+
+    ctx.font = font_size + 'px material-icons'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
     const text_icon = icon;
-    const text = ctx.fillText(text_icon,
-      x - 20,
-      y + 20);
+    //outline
+    ctx.font = font_size + 'px material-icons'
+    ctx.fillStyle = 'rgb(255,255,255)'
+    const text = ctx.fillText(
+      text_icon,
+      x,
+      y);
+
+    // inset main
+    let border_width = 10
+    ctx.fillStyle = fillStyle
+    ctx.font = font_size - border_width + 'px material-icons'
+    ctx.fillText(
+      text_icon,
+      x,
+      y);
+
     ctx.fillStyle = old_color;
     ctx.font = old_font;
-    const measures = ctx.measureText(text_icon);
+    ctx.textAlign = old_textAlign
+    ctx.textBaseline = old_baseLine
+    //const measures = ctx.measureText(text_icon);
     // Create an invisible box for click events.
     //const region = {x: x - 24 , y: y - 24 , w: measures.width, h: 100};
     //this.is_mouse_in_path_issue(ctx, region, i, issue)

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -456,11 +456,15 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   }
 
   private draw_left_right_arrows(ctx, node, x, y){
+    if (this.label_settings.show_left_right_arrows == false) {
+      return
+    }
+    let size = this.vertex_size * 8
     if(node.left_or_right == 'left') {
-      this.draw_icon(ctx, x - 5, y, 'arrow_left', 24, 'rgb(255,0,0)')
+      this.draw_icon(ctx, x - 5, y, 'arrow_left', size, 'rgb(255,0,0)')
     }
     if(node.left_or_right=='right') {
-      this.draw_icon(ctx, x + 5, y, 'arrow_right', 24, 'rgb(0,255,0)')
+      this.draw_icon(ctx, x + 5, y, 'arrow_right', size, 'rgb(0,255,0)')
     }
   }
 
@@ -536,7 +540,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       y);
 
     // inset main
-    let border_width = 10
+    let border_width = Math.round(font_size / 3)
     ctx.fillStyle = fillStyle
     ctx.font = font_size - border_width + 'px material-icons'
     ctx.fillText(


### PR DESCRIPTION
## Left Right Arrows

Now optional arrows show the left/right ness of a keypoint figure.

1. Arrows show left right even if moved - based on original template definition
2. Arrows smoothly rotate with rotation, eg a right point still shows as right even if rotated, and arrow stays correctly orientated. 
3. Dynamically adjust size

![left right arrows all](https://user-images.githubusercontent.com/18080164/135695307-bc5d8ba4-dab8-45ab-ba77-8d3ef557e4e3.PNG)


Label names (strings) will come later