### PR TITLE
Change project automatically when going to a task ID (for admins and super admins)

### DIFF
--- a/shared/database/task/task.py
+++ b/shared/database/task/task.py
@@ -312,6 +312,7 @@ class Task(Base):
         return {
             'id': self.id,
             'job_id': self.job_id,
+            'project_id' : self.project_id,
             'task_type': self.task_type,
             'job_type': self.job_type,
             'status': self.job_type,
@@ -339,6 +340,7 @@ class Task(Base):
         return {
             'id': self.id,
             'job_id': self.job_id,
+            'project_string_id' : self.project.project_string_id,
             'task_type': self.task_type,
             'job_type': self.job_type,
             'file': self.file.serialize_with_type(session=session),


### PR DESCRIPTION
Now going to a task ID automatically changes the project.

There's potential issues with this in the Org context but that should be a corner case.
This still follows normal permissions thing, it's mostly just a UI convenience.

Main context is that now we only need to visit a task ID, without having to know what project the task is in. And without having to include the string ID in the url.

![loading change project by task](https://user-images.githubusercontent.com/18080164/136302159-bbd8e775-6b3b-4367-b1fd-7cff80f62d27.PNG)


