### PR TITLE
Improve visibility to frame update errors

### DIFF
--- a/frontend/src/components/input/input_view.vue
+++ b/frontend/src/components/input/input_view.vue
@@ -202,10 +202,13 @@
 
                     <template slot="content">
                       <v-layout column>
+                        <h4 >Description: </h4>
+                        <p class="text--error">
+                          {{ props.item.description}}
+                        </p>
+                        <h4>Log: </h4>
 
-                        <v-card-title> Log</v-card-title>
-
-                        <v_error_multiple :error="props.item.update_log['error']">
+                        <v_error_multiple :error="props.item.update_log">
                         </v_error_multiple>
 
                         <!-- Not showing info messages here yet -->
@@ -275,18 +278,19 @@
                     color="error">
                     <template slot="content">
                       <v-layout column>
-
-                        <v-card-title> Log</v-card-title>
-                        <p class="error--text">
-                          {{ props.item.status_text}}
+                        <h4>Description: </h4>
+                        <p>
+                          {{ props.item.description}}
                         </p>
-                        <v_error_multiple :error="props.item.update_log['error']">
+                        <h4>Log: </h4>
+
+                        <v_error_multiple :error="props.item.update_log">
                         </v_error_multiple>
 
                         <!-- Not showing info messages here yet -->
 
-
                       </v-layout>
+
                     </template>
                   </button_with_menu>
 

--- a/shared/database/input.py
+++ b/shared/database/input.py
@@ -272,6 +272,7 @@ class Input(Base):
             'total_time': str(total_time),
             'media_type': self.media_type,
             'original_filename': self.original_filename,
+            'description': self.description,
             'status': self.status,
             'status_text': self.status_text,
             'directory': directory,

--- a/shared/database/video/sequence.py
+++ b/shared/database/video/sequence.py
@@ -502,7 +502,7 @@ class Sequence(Base):
             # saving maybe? but it was suprisingly glaring bug
             # on front end
 
-            if instance.frame_number not in frame_number_list:
+            if instance.frame_number not in frame_number_list and instance.frame_number is not None:
                 # binary search based insertion
                 bisect.insort(frame_number_list, instance.frame_number)
         elif instance.soft_delete and not default_sequences_to_single_frame:

--- a/shared/model/model_manager.py
+++ b/shared/model/model_manager.py
@@ -24,6 +24,9 @@ class ModelManager:
         create_models = []
         created_runs = []
         for instance in self.instance_list:
+            if instance is None:
+                raise Exception('Instance cannot be None')
+
             if instance.get('model_ref') is None and instance.get('model_id') is None:
                 continue
 


### PR DESCRIPTION
When an update to a video failed on one frame, the error was not being propagated to the parent and resulted in the video on a processing state forever. We now capture that and set the parent file to failing state.

Also there was an exception being raised when trying to update a sequence with instance with instance.frame_number = None

Finally added some extra validations to prevent None type instances being processed by the walrus.