### PR TITLE
fixes in task serialization and show error in process media.

### DIFF
--- a/shared/database/task/task.py
+++ b/shared/database/task/task.py
@@ -593,6 +593,7 @@ class Task(Base):
 
     def serialize_for_list_view_builder(self, session=None):
 
+        file = None
         if session:
             file = self.file.serialize_with_type(session=session)
 

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -526,6 +526,7 @@ class Process_Media():
             # log['error']['status_text']
             if len(self.log["error"].keys()) >= 1:
                 logger.error('Error downloading media: {}'.format(str(self.log['error'])))
+                self.input.update_log['error'] = self.log['error']
                 return False
 
         if self.input.media_type == "video":


### PR DESCRIPTION
Fixes 2 issues:

1. When there is an error on `download_media()` in `process_media.py` we were not attaching log to input, so it was not visible to user. This was just an unhandled case up until now. It should now display appropriately,
2. Task serialization could end up throwing a :

`error: local variable 'file' referenced before assignment`