### PR TITLE
Auto Assign Reviewer on Task Completion

### DIFF
--- a/default/methods/annotation/annotation.py
+++ b/default/methods/annotation/annotation.py
@@ -74,13 +74,7 @@ def task_annotation_update_api(task_id):
 
     # MAIN
     with sessionMaker.session_scope() as session:
-        user = User.get(session)
-        if user:
-            member = user.member
-        else:
-            client_id = request.authorization.get('username', None)
-            auth = Auth_api.get(session, client_id)
-            member = auth.member
+        member = get_member(session = session)
         new_file, annotation_update = task_annotation_update(
             session = session,
             task_id = task_id,

--- a/default/methods/task/task/task_review.py
+++ b/default/methods/task/task/task_review.py
@@ -28,13 +28,7 @@ def task_review_api(task_id):
         return jsonify(log = log), 400
 
     with sessionMaker.session_scope() as session:
-        user = User.get(session)
-        if user:
-            member = user.member
-        else:
-            client_id = request.authorization.get('username', None)
-            auth = Auth_api.get(session, client_id)
-            member = auth.member
+        member = get_member(session = session)
 
         task_serialized = task_review_core(session = session,
                                            task_id = task_id,

--- a/default/methods/task/task/task_update.py
+++ b/default/methods/task/task/task_update.py
@@ -42,13 +42,8 @@ def task_update_api():
 
     with sessionMaker.session_scope() as session:
         task_list = []
-        user = User.get(session)
-        if user:
-            member = user.member
-        else:
-            client_id = request.authorization.get('username', None)
-            auth = Auth_api.get(session, client_id)
-            member = auth.member
+        
+        member = get_member(session = session)
 
         if input['task_id']:
             task = Task.get_by_id(session = session,

--- a/default/methods/task/task_template/job_new_or_update.py
+++ b/default/methods/task/task_template/job_new_or_update.py
@@ -701,9 +701,7 @@ def new_or_update_core(session,
         log['error']['kind'] = "Invalid share_type, valid options are: ['market', 'org', 'project']"
         return False, log
 
-    # What about validation on other inputs???
-    # Look at actions or other part of system for options here...
-    print('IS log', log)
+
     job.launch_datetime = launch_datetime
     # We expect this to be a valid datetime object,
     # but otherwise don't validate, ie a date in the past
@@ -752,7 +750,6 @@ def new_or_update_core(session,
                 user = member.user)
         except:
             logger.info("Failed to email about new pro job")
-    print('IS log2', log)
     # Update sync dirs and completion directory ID
     if isinstance(attached_directories_dict, dict):
         job.update_attached_directories(session,
@@ -776,7 +773,6 @@ def new_or_update_core(session,
             member=member,
             success=True
         )
-    print('IS log final', log)
     return job, log
 
 

--- a/default/tests/methods/task/task_template/test_job_new_or_update.py
+++ b/default/tests/methods/task/task_template/test_job_new_or_update.py
@@ -59,7 +59,6 @@ class TestJobNewUpdate(testing_setup.DiffgramBaseTestCase):
         }
 
         endpoint = "/api/v1/project/" + job.project.project_string_id + "/job/update"
-        print('aaaa', job.project_id, self.project.id)
         credentials = b64encode("{}:{}".format(self.auth_api.client_id, self.auth_api.client_secret).encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
@@ -69,7 +68,6 @@ class TestJobNewUpdate(testing_setup.DiffgramBaseTestCase):
                 'Authorization': 'Basic {}'.format(credentials)
             }
         )
-        print('qweqweqwe', response.data)
         self.assertEqual(response.status_code, 200)
         new_session = sessionMaker.session_factory()
         updated_job = Job.get_by_id(new_session, job.id)

--- a/default/tests/shared/database/task/test_task_user.py
+++ b/default/tests/shared/database/task/test_task_user.py
@@ -80,3 +80,40 @@ class TestTaskUser(testing_setup.DiffgramBaseTestCase):
         self.assertEqual(result['task_id'], task1.id)
         self.assertEqual(result['user_id'], self.member.user.id)
         self.assertEqual(result['relation'], 'test')
+
+    def test_list(self):
+        job = data_mocking.create_job({
+            'name': 'my-test-job-{}'.format(1),
+            'project': self.project
+        }, self.session)
+        file = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        task1 = data_mocking.create_task({'name': 'test task', 'file': file, 'job': job, 'status': 'available'},
+                                         self.session)
+        task2 = data_mocking.create_task({'name': 'test task', 'file': file, 'job': job, 'status': 'available'},
+                                         self.session)
+
+        task_user = TaskUser.new(
+            session = self.session,
+            task_id = task1.id,
+            user_id = self.member.user.id,
+            relation = 'test'
+        )
+
+        task_user2 = TaskUser.new(
+            session = self.session,
+            task_id = task2.id,
+            user_id = self.member.user.id,
+            relation = 'test'
+        )
+
+        result = TaskUser.list(
+            session = self.session,
+            user_id = self.member.user.id
+        )
+
+        self.assertEqual(len(result), 2)
+
+        id_list = [elm.id for elm in result]
+
+        self.assertTrue(task_user.id in id_list)
+        self.assertTrue(task_user2.id in id_list)

--- a/default/tests/shared/utils/task/test_task_assign_reviewer.py
+++ b/default/tests/shared/utils/task/test_task_assign_reviewer.py
@@ -1,0 +1,128 @@
+from methods.regular.regular_api import *
+from default.tests.test_utils import testing_setup
+from shared.tests.test_utils import common_actions, data_mocking
+from shared.utils.task import task_complete
+from shared.database.task.task import TASK_STATUSES
+from shared.utils.task import task_assign_reviewer
+from unittest.mock import patch
+
+
+class TestTaskAssignReviewer(testing_setup.DiffgramBaseTestCase):
+    """
+        
+        
+        
+    """
+
+    def setUp(self):
+        # TODO: this test is assuming the 'my-sandbox-project' exists and some object have been previously created.
+        # For future tests a mechanism of setting up and tearing down the database should be created.
+        super(TestTaskAssignReviewer, self).setUp()
+        self.project_data = data_mocking.create_project_with_context(
+            {
+                'users': [
+                    {'username': 'Test',
+                     'email': 'test@test.com',
+                     'password': 'diffgram123',
+                     }
+                ]
+            },
+            self.session
+        )
+        self.project = self.project_data['project']
+        self.auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
+        self.member = self.auth_api.member
+        self.member.user = data_mocking.register_user({
+            'username': 'test_user',
+            'email': 'test@test.com',
+            'password': 'diffgram123',
+            'project_string_id': self.project.project_string_id,
+            'member_id': self.member.id
+        }, self.session)
+
+    def test_task_complete(self):
+        # Create mock tasks
+        job = data_mocking.create_job({
+            'name': 'my-test-job-{}'.format(1),
+            'project': self.project,
+            'allow_reviews': True
+        }, self.session)
+
+        file = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        task_list = []
+        user1 = data_mocking.register_user({
+            'username': 'test_user1',
+            'email': 'test1@test.com',
+            'password': 'diffgram123',
+            'project_string_id': self.project.project_string_id,
+            'member_id': common_actions.create_project_auth(project = self.project, session = self.session).member.id
+        }
+            , self.session)
+        user2 = data_mocking.register_user({
+            'username': 'test_user1',
+            'email': 'test1@test.com',
+            'password': 'diffgram123',
+            'project_string_id': self.project.project_string_id,
+            'member_id': common_actions.create_project_auth(project = self.project, session = self.session).member.id
+        }, self.session)
+        user3 = data_mocking.register_user({
+            'username': 'test_user1',
+            'email': 'test1@test.com',
+            'password': 'diffgram123',
+            'project_string_id': self.project.project_string_id,
+            'member_id': common_actions.create_project_auth(project = self.project, session = self.session).member.id
+        }, self.session)
+
+        job.update_reviewer_list(
+            session = self.session,
+            reviewer_list_ids = [user1.member_id, user2.member_id, user3.member_id],
+            log = regular_log.default()
+        )
+        for i in range(0, 25):
+            task = data_mocking.create_task({'name': 'test task', 'file': file, 'job': job}, self.session)
+            task_list.append(task)
+
+        task_list[0].add_reviewer(self.session, user1)
+        task_list[1].add_reviewer(self.session, user1)
+        task_list[2].add_reviewer(self.session, user1)
+
+        task_list[3].add_reviewer(self.session, user2)
+        task_list[4].add_reviewer(self.session, user2)
+        task_list[5].add_reviewer(self.session, user2)
+        task_list[6].add_reviewer(self.session, user2)
+        task_list[7].add_reviewer(self.session, user2)
+
+        task_list[8].add_reviewer(self.session, user3)
+        task_list[9].add_reviewer(self.session, user3)
+        task_list[10].add_reviewer(self.session, user3)
+        task_list[11].add_reviewer(self.session, user3)
+        task_list[12].add_reviewer(self.session, user3)
+
+        self.session.flush()
+        self.session.commit()
+        with patch.object(task_list[13], 'add_reviewer') as mock_add_reviewer:
+            task_assign_reviewer.auto_assign_reviewer_to_task(
+                session = self.session,
+                task = task_list[13]
+            )
+            mock_add_reviewer.assert_called_once_with(
+                session = self.session,
+                user = user1
+            )
+
+        result = task_assign_reviewer.auto_assign_reviewer_to_task(
+            session = self.session,
+            task = task_list[14]
+        )
+        self.assertEqual(result.id, user1.id)
+
+        task_list[15].add_reviewer(self.session, user1)
+        task_list[16].add_reviewer(self.session, user1)
+        task_list[17].add_reviewer(self.session, user2)
+        task_list[18].add_reviewer(self.session, user2)
+
+        result = task_assign_reviewer.auto_assign_reviewer_to_task(
+            session = self.session,
+            task = task_list[19]
+        )
+        self.assertEqual(result.id, user3.id)

--- a/shared/database/event/event.py
+++ b/shared/database/event/event.py
@@ -311,7 +311,7 @@ class Event(Base):
             Sends the current event to Diffgram's EventHub for anonymous data tracking.
         :return:
         """
-        if settings.DIFFGRAM_SYSTEM_MODE in ['sandbox']:
+        if settings.DIFFGRAM_SYSTEM_MODE in ['sandbox', 'testing', 'testing_e2e']:
             return
 
         try:

--- a/shared/database/task/job/job.py
+++ b/shared/database/task/job/job.py
@@ -410,6 +410,7 @@ class Job(Base, Caching):
 
         # Now create user_to_job relations.
         user_added_id_list = []
+        print('user_list', user_list)
         for user in user_list:
 
             user_added_id_list.append(user.id)

--- a/shared/database/task/task.py
+++ b/shared/database/task/task.py
@@ -267,7 +267,6 @@ class Task(Base):
             job=None):
 
         last_task = user.last_task
-        print('LASTTT', last_task)
         if last_task:
 
             if job:
@@ -294,7 +293,6 @@ class Task(Base):
             TaskUser.task_id == self.id
         ).all()
         user_id_list = [elm.user_id for elm in result]
-        print('user_id_list', user_id_list)
         return user.id in user_id_list
 
     def add_assignee(self, session, user):

--- a/shared/database/task/task_user.py
+++ b/shared/database/task/task_user.py
@@ -49,17 +49,26 @@ class TaskUser(Base, SerializerMixin):
         return task_event
 
     @staticmethod
-    def list(session: 'Session', task_id: int = None, user_id: int = None, relation: str = None):
+    def list(session: 'Session',
+             task_id: int = None,
+             user_id: int = None,
+             job_id: int = None,
+             relation: str = None):
 
         query = session.query(TaskUser)
-
         if task_id:
-            query.filter(TaskUser.task_id == task_id)
+            query = query.filter(TaskUser.task_id == task_id)
 
         if user_id:
-            query.filter(TaskUser.user_id == user_id)
+            query = query.filter(TaskUser.user_id == user_id)
 
         if relation:
-            query.filter(TaskUser.relation == relation)
+            query = query.filter(TaskUser.relation == relation)
+
+        if job_id:
+            from shared.database.task.task import Task
+            query = query.join(Task).filter(
+                Task.job_id == job_id
+            )
 
         return query.all()

--- a/shared/database/task/task_user.py
+++ b/shared/database/task/task_user.py
@@ -47,3 +47,19 @@ class TaskUser(Base, SerializerMixin):
         if flush_session:
             session.flush()
         return task_event
+
+    @staticmethod
+    def list(session: 'Session', task_id: int = None, user_id: int = None, relation: str = None):
+
+        query = session.query(TaskUser)
+
+        if task_id:
+            query.filter(TaskUser.task_id == task_id)
+
+        if user_id:
+            query.filter(TaskUser.user_id == user_id)
+
+        if relation:
+            query.filter(TaskUser.relation == relation)
+
+        return query.all()

--- a/shared/permissions/project_permissions.py
+++ b/shared/permissions/project_permissions.py
@@ -163,7 +163,7 @@ class Project_permissions():
         if project_string_id is None:
             # TODO merge None checks from other thing up top here.
             raise Forbidden(user_denied_message + "project_string_id is None")
-    
+
         if Project_permissions.check_if_project_is_public(project, Roles):
             return True
 

--- a/shared/regular/regular_member.py
+++ b/shared/regular/regular_member.py
@@ -4,29 +4,29 @@ from shared.database.auth.api import Auth_api
 
 
 def get_member(session):
-	"""
-	Private method. Assumes request already verified.
+    """
+    Private method. Assumes request already verified.
 
-	An issue of this being part of auth is that we may want the actual 
-	member object available in the session,
-	and at least our current process is to close / not pass the 
-	session used in auth. That perhaps is a good area to change
-	but either way core logic here is similar.
-	"""
-	member = None
+    An issue of this being part of auth is that we may want the actual
+    member object available in the session,
+    and at least our current process is to close / not pass the
+    session used in auth. That perhaps is a good area to change
+    but either way core logic here is similar.
+    """
+    member = None
 
-	# Potential to be outside of request context
-	if not request:
-		return member
+    # Potential to be outside of request context
+    if not request:
+        return member
 
-	user = User.get(session)
-	if user:
-		member = user.member
-	else:
-		if request.authorization:
-			client_id = request.authorization.get('username', None)
-			if client_id and client_id != 'None':
-				auth = Auth_api.get(session, client_id)
-				member = auth.member
+    user = User.get(session)
+    if user:
+        member = user.member
+    else:
+        if request.authorization:
+            client_id = request.authorization.get('username', None)
+            if client_id and client_id != 'None':
+                auth = Auth_api.get(session, client_id)
+                member = auth.member
 
-	return member
+    return member

--- a/shared/utils/task/task_assign_reviewer.py
+++ b/shared/utils/task/task_assign_reviewer.py
@@ -1,0 +1,32 @@
+from shared.database.task.task import Task
+from shared.database.task.task_user import TaskUser
+
+
+def assign_reviewer_to_task(session: 'Session', task: Task):
+    """
+        Assigns a reviewer to the given task based on the reviewer
+        who has less tasks assigned on that job.
+    :param session:
+    :param task:
+    :return:
+    """
+    # Get job avaialable reviewers
+    job_reviewers = task.job.get_reviewers(session = session)
+
+    reviewer_count = {}
+    for reviewer in job_reviewers:
+        relations = TaskUser.list(
+            user_id = reviewer.id
+        )
+        task_ids = [elm.task_id for elm in relations]
+        task_ids = set(task_ids)
+        reviewer_count[reviewer.id] = {
+            'task_count': len(task_ids),
+            'obj': reviewer
+        }
+
+    min = 99999999
+    reviewer_to_assign = None
+    for user_id, count_data in reviewer_count.items():
+        if reviewer_count[user_id]['task_count'] < min:
+            min = reviewer_count[user_id]['task_count']

--- a/shared/utils/task/task_assign_reviewer.py
+++ b/shared/utils/task/task_assign_reviewer.py
@@ -1,32 +1,54 @@
-from shared.database.task.task import Task
+from shared.database.task.task import Task, TASK_STATUSES
 from shared.database.task.task_user import TaskUser
+from shared.utils.task.task_update_manager import Task_Update
 
 
-def assign_reviewer_to_task(session: 'Session', task: Task):
+def auto_assign_reviewer_to_task(session: 'Session', task: Task):
     """
         Assigns a reviewer to the given task based on the reviewer
         who has less tasks assigned on that job.
+
+        If the task already has a reviewer, we will not do anything.
+        To add an additional reviewer manually, please use task.add_reviewer()
+
     :param session:
     :param task:
-    :return:
+    :return: user object with representing the reviewer assigned to task.
     """
-    # Get job avaialable reviewers
+    # Get job available reviewers
     job_reviewers = task.job.get_reviewers(session = session)
 
     reviewer_count = {}
     for reviewer in job_reviewers:
         relations = TaskUser.list(
-            user_id = reviewer.id
+            session = session,
+            user_id = reviewer.id,
+            job_id = task.job_id,
+            relation = 'reviewer'
         )
         task_ids = [elm.task_id for elm in relations]
         task_ids = set(task_ids)
+
         reviewer_count[reviewer.id] = {
             'task_count': len(task_ids),
             'obj': reviewer
         }
 
+    # Find the user with less tasks assigned.
     min = 99999999
     reviewer_to_assign = None
     for user_id, count_data in reviewer_count.items():
         if reviewer_count[user_id]['task_count'] < min:
             min = reviewer_count[user_id]['task_count']
+            reviewer_to_assign = reviewer_count[user_id]['obj']
+
+    if reviewer_to_assign:
+        task.add_reviewer(session = session, user = reviewer_to_assign)
+        task_update_mngr = Task_Update(
+            session = session,
+            task = task,
+            status = TASK_STATUSES['in_review']
+        )
+        task_update_mngr.main()
+
+    return reviewer_to_assign

--- a/shared/utils/task/task_complete.py
+++ b/shared/utils/task/task_complete.py
@@ -93,6 +93,7 @@ def task_complete(session,
             else:
                 trigger_sync_event = False  # In review Mode no sync event (unless post_review=True)
                 task_update_manager.status = TASK_STATUSES['review_requested']
+
                 task_update_manager.main()
 
         else:

--- a/shared/utils/task/task_complete.py
+++ b/shared/utils/task/task_complete.py
@@ -10,7 +10,7 @@ from shared.utils.sync_events_manager import SyncEventManager
 from shared.database.task.task_event import TaskEvent
 from shared.utils.task.task_update_manager import Task_Update
 from shared.database.task.task import TASK_STATUSES
-
+from shared.utils.task import task_assign_reviewer
 
 def trigger_task_complete_sync_event(session, task, job, log):
     sync_event_manager = SyncEventManager.create_sync_event_and_manager(
@@ -93,8 +93,11 @@ def task_complete(session,
             else:
                 trigger_sync_event = False  # In review Mode no sync event (unless post_review=True)
                 task_update_manager.status = TASK_STATUSES['review_requested']
-
                 task_update_manager.main()
+                task_assign_reviewer.auto_assign_reviewer_to_task(
+                    session = session,
+                    task = task
+                )
 
         else:
             task_update_manager.status = 'complete'


### PR DESCRIPTION
Adds the reviewer with the least amounts of tasks automatically as a reviewer when a user completes a task and the job supports reviews.