### PR TITLE
Add task complete API endpoint

### DIFF
--- a/default/methods/task/task/task_complete.py
+++ b/default/methods/task/task/task_complete.py
@@ -1,0 +1,49 @@
+from methods.regular.regular_api import *
+from shared.database.task.task import Task, TASK_STATUSES
+from shared.utils.task import task_complete as shared_task_complete
+
+
+@routes.route('/api/v1/task/<int:task_id>/complete', methods = ['POST'])
+@Permission_Task.by_task_id(apis_user_list = ["builder_or_trainer"])
+def api_task_complete(task_id):
+    """
+
+    """
+    spec_list = []
+
+    log, input, untrusted_input = regular_input.master(request = request,
+                                                       spec_list = spec_list)
+    if len(log["error"].keys()) >= 1:
+        return jsonify(log = log), 400
+
+    with sessionMaker.session_scope() as session:
+        member = get_member(session = session)
+
+        task_serialized = task_complete_core(session = session,
+                                             task_id = task_id,
+                                             member = member)
+
+        if task_serialized is False:
+            log['info']['task'] = "No Task Found"
+            return jsonify(log = log), 200
+
+        log['success'] = True
+        return jsonify(log = log,
+                       task = task_serialized), 200
+
+
+def task_complete_core(session,
+                       task_id: int,
+                       member: 'Member'):
+    task = Task.get_by_id(session, task_id = task_id)
+
+    shared_task_complete.task_complete(
+        session = session,
+        task = task,
+        new_file = task.file,
+        project = task.project,
+        member = member,
+        post_review = False
+    )
+
+    return task.serialize_builder_view_by_id(session)

--- a/default/routes_init.py
+++ b/default/routes_init.py
@@ -22,6 +22,7 @@ def do_routes_importing():
     from methods.task.task.task_next import task_next
     from methods.task.task.task_next_issue import task_next_issue
     from methods.task.task.task_review import task_review_api
+    from methods.task.task.task_complete import api_task_complete
 
     from methods.task.file.file_attach import add_files_to_job_api
     from methods.task.file.dir_attach import update_dirs_to_job_api
@@ -131,3 +132,6 @@ def do_routes_importing():
     from methods.task.credential.credential_list import credential_list_api
     from methods.task.credential.credential_type_attach_to_job import credential_type_attach_to_job_api
     from methods.task.credential.credential_type_update import update_credential_type_image_api
+
+
+

--- a/default/tests/methods/task/task/test_task_complete.py
+++ b/default/tests/methods/task/task/test_task_complete.py
@@ -1,0 +1,116 @@
+from shared.utils.task import task_complete
+from methods.task.task.task_complete import task_complete_core
+from methods.regular.regular_api import *
+from default.tests.test_utils import testing_setup
+from shared.tests.test_utils import common_actions, data_mocking
+from base64 import b64encode
+from unittest.mock import patch
+from shared.database.task.task import TASK_STATUSES
+from shared.database.hashing_functions import make_secure_val
+
+
+class TestTaskComplete(testing_setup.DiffgramBaseTestCase):
+    """
+        
+        
+        
+    """
+
+    def setUp(self):
+        # TODO: this test is assuming the 'my-sandbox-project' exists and some object have been previously created.
+        # For future tests a mechanism of setting up and tearing down the database should be created.
+        super(TestTaskComplete, self).setUp()
+        project_data = data_mocking.create_project_with_context(
+            {
+                'users': [
+                    {'username': 'Test',
+                     'email': 'test@test.com',
+                     'password': 'diffgram123',
+                     }
+                ]
+            },
+            self.session
+
+        )
+        self.project = project_data['project']
+        self.auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
+        self.member = self.auth_api.member
+        self.member.user = data_mocking.register_user({
+            'username': 'test_user',
+            'email': 'test@test.com',
+            'password': 'diffgram123',
+            'project_string_id': self.project.project_string_id,
+            'member_id': self.member.id
+        }, self.session)
+        job = data_mocking.create_job({
+            'name': 'my-test-job-{}'.format(1),
+            'project': self.project,
+            'allow_reviews': False
+        }, self.session)
+        file = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        self.task = data_mocking.create_task({'name': 'test task', 'file': file, 'job': job, 'status': 'available'},
+                                             self.session)
+        self.task.add_reviewer(session = self.session, user = self.auth_api.member.user)
+        self.task.add_reviewer(session = self.session, user = self.member.user)
+        self.session.commit()
+
+    def test_api_task_complete(self):
+        request_data = {
+            'action': 'approve'
+        }
+        endpoint = "/api/v1/task/{}/complete".format(self.task.id)
+        auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
+        auth_api.member.user = data_mocking.register_user({
+            'username': 'test_user',
+            'email': 'test@test.com',
+            'password': 'diffgram123',
+            'project_string_id': self.project.project_string_id,
+            'member_id': self.member.id
+        }, self.session)
+        with self.client.session_transaction() as session:
+            session['user_id'] = make_secure_val(auth_api.member.user.id)
+            credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        self.task.add_assignee(self.session, auth_api.member.user)
+        self.session.commit()
+        response = self.client.post(
+            endpoint,
+            data = json.dumps(request_data),
+            headers = {
+                'directory_id': str(self.project.directory_default_id),
+                'Authorization': 'Basic {}'.format(credentials)
+            }
+        )
+        data = response.json
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['task']['status'], 'complete')
+
+    def test_task_complete_core(self):
+        job = data_mocking.create_job({
+            'name': 'my-test-job-{}'.format(1),
+            'project': self.project,
+            'allow_reviews': False
+        }, self.session)
+        file = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        task = data_mocking.create_task({'name': 'test task', 'file': file, 'job': job, 'status': 'available'},
+                                        self.session)
+        result = task_complete_core(
+            session = self.session,
+            task_id = task.id,
+            member = self.member
+
+        )
+        self.assertEqual(result['status'], TASK_STATUSES['complete'])
+        with patch.object(task_complete, 'task_complete') as mock:
+            task_complete_core(
+                session = self.session,
+                task_id = task.id,
+                member = self.member
+
+            )
+            mock.assert_called_once_with(session = self.session,
+                                         task = task,
+                                         new_file = task.file,
+                                         project = task.project,
+                                         member = self.member,
+                                         post_review = False
+                                         )

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -6,7 +6,7 @@ except:
 
 try:
     # The walrus service doesn't have task_complete
-    from default.methods.task.task import task_complete
+    from shared.methods.task.task import task_complete
 except:
     pass
 


### PR DESCRIPTION
Adds the endpoint:

`/api/v1/task/<int:task_id>/complete`

For more explicit and semantic URL when completing task on frontend.