### PR TITLE
Display new statuses on job page

### DIFF
--- a/frontend/src/components/regular_concrete/task_status_icons.vue
+++ b/frontend/src/components/regular_concrete/task_status_icons.vue
@@ -38,6 +38,15 @@
   </tooltip_icon>
 
   <tooltip_icon
+    v-if="status == 'requires_changes'"
+    tooltip_message="Requires changes"
+    icon="mdi-clipboard-alert-outline"
+    color="red"
+    :large="large"
+  >
+  </tooltip_icon>
+
+  <tooltip_icon
       v-if="status == 'deferred'"
       tooltip_message = "Deferred"
       icon="mdi-debug-step-over"

--- a/frontend/src/components/regular_concrete/task_status_icons.vue
+++ b/frontend/src/components/regular_concrete/task_status_icons.vue
@@ -29,6 +29,15 @@
   </tooltip_icon>
 
   <tooltip_icon
+    v-if="status == 'review_requested'"
+    tooltip_message="In review"
+    icon="mdi-archive-eye-outline"
+    color="primary"
+    :large="large"
+  >
+  </tooltip_icon>
+
+  <tooltip_icon
       v-if="status == 'deferred'"
       tooltip_message = "Deferred"
       icon="mdi-debug-step-over"

--- a/frontend/src/components/stats/stats_panel.vue
+++ b/frontend/src/components/stats/stats_panel.vue
@@ -128,20 +128,21 @@ export default Vue.extend({
     },
     async update_user_chart() {
       const { job_id } = this.$route.params;
-      const userStats = await getJobStatsForUser(job_id, this.show_member_stat);
-      this.user_stats.chartData.datasets[0].data = [
-        userStats.completed,
-        userStats.total - userStats.completed,
-      ];
+      const { completed, total, in_progress, in_review, requires_changes, instaces_created } = await getJobStatsForUser(job_id, this.show_member_stat);
+      const pending = total - completed - in_progress - in_review - requires_changes
+      this.user_stats.chartData.datasets[0].data = [completed, in_progress, in_review, requires_changes, pending];
       this.user_stats.chartData.labels = [
-        `Completed ${userStats.completed}`,
-        `Pending ${userStats.total - userStats.completed}`,
+        `Completed ${completed}`,
+        `In progress ${in_progress}`,
+        `In review ${in_review}`,
+        `Require changes ${requires_changes}`,
+        `Pending ${pending}`,
       ];
       if (!this.job_data_fetched) {
         this.current_user_performance = {
-          instances: userStats.instaces_created,
-          total: userStats.total,
-          completed: userStats.completed,
+          instances: instaces_created,
+          total: total,
+          completed: completed,
         };
       }
       this.update_user_cart = false;
@@ -164,11 +165,15 @@ export default Vue.extend({
     this.member_list = [...this.$store.state.project.current.member_list];
     this.show_member_stat = user_id;
 
-    const { completed, total } = await getJobStats(job_id);
-    this.job_chart.chartData.datasets[0].data = [completed, total - completed];
+    const { completed, total, in_progress, in_review, requires_changes } = await getJobStats(job_id);
+    const pending = total - completed - in_progress - in_review - requires_changes
+    this.job_chart.chartData.datasets[0].data = [completed, in_progress, in_review, requires_changes, pending];
     this.job_chart.chartData.labels = [
       `Completed ${completed}`,
-      `Pending ${total - completed}`,
+      `In progress ${in_progress}`,
+      `In review ${in_review}`,
+      `Require changes ${requires_changes}`,
+      `Pending ${pending}`,
     ];
 
     await this.update_user_chart();
@@ -200,7 +205,7 @@ export default Vue.extend({
           labels: ["Completed", "Pending"],
           datasets: [
             {
-              backgroundColor: ["#41B883", "#00D8FF"],
+              backgroundColor: ["#6ab04c", "#ffbe76", '#7ed6df', '#eb4d4b', '#95afc0'],
               data: [],
             },
           ],
@@ -220,7 +225,7 @@ export default Vue.extend({
           datasets: [
             {
               label: "Data One",
-              backgroundColor: ["#41B883", "#E46651"],
+              backgroundColor: ["#6ab04c", "#ffbe76", '#7ed6df', '#eb4d4b', '#95afc0'],
               data: [],
             },
           ],

--- a/frontend/tests/unit/regular_concrete/task_status_icons.spec.js
+++ b/frontend/tests/unit/regular_concrete/task_status_icons.spec.js
@@ -1,0 +1,59 @@
+import { shallowMount } from "@vue/test-utils";
+import task_status_icons from "@/components/regular_concrete/task_status_icons.vue";
+
+describe("task_status_icons.vue", () => {
+  it("Renders complete icons when the status is complete", () => {
+    const wrapper = shallowMount(task_status_icons, {
+      propsData: {
+        status: "complete"
+      }
+    });
+    expect(wrapper.html()).toContain('tooltip_message="Complete"');
+    expect(wrapper.html()).toContain('icon="mdi-check"');
+    expect(wrapper.html()).toContain('color="green"');
+  });
+
+  it("Renders available icons when the status is available", () => {
+    const wrapper = shallowMount(task_status_icons, {
+      propsData: {
+        status: "available"
+      }
+    });
+    expect(wrapper.html()).toContain('tooltip_message="Available"');
+    expect(wrapper.html()).toContain('icon="mdi-inbox"');
+    expect(wrapper.html()).toContain('color="primary"');
+  });
+
+  it("Renders in progress icons when the status is in_progress", () => {
+    const wrapper = shallowMount(task_status_icons, {
+      propsData: {
+        status: "in_progress"
+      }
+    });
+    expect(wrapper.html()).toContain('tooltip_message="In Progress"');
+    expect(wrapper.html()).toContain('icon="mdi-account-clock-outline"');
+    expect(wrapper.html()).toContain('color="primary"');
+  });
+
+  it("Renders in review icons when the status is review_requested", () => {
+    const wrapper = shallowMount(task_status_icons, {
+      propsData: {
+        status: "review_requested"
+      }
+    });
+    expect(wrapper.html()).toContain('tooltip_message="In review"');
+    expect(wrapper.html()).toContain('icon="mdi-archive-eye-outline"');
+    expect(wrapper.html()).toContain('color="primary"');
+  });
+
+  it("Renders require changes icons when the status is requires_changes", () => {
+    const wrapper = shallowMount(task_status_icons, {
+      propsData: {
+        status: "requires_changes"
+      }
+    });
+    expect(wrapper.html()).toContain('tooltip_message="Requires changes"');
+    expect(wrapper.html()).toContain('icon="mdi-clipboard-alert-outline"');
+    expect(wrapper.html()).toContain('color="red"');
+  });
+});

--- a/shared/database/task/task.py
+++ b/shared/database/task/task.py
@@ -633,6 +633,12 @@ class Task(Base):
         total = query.filter(Task.job_id == job_id).count()
         completed = query.filter(Task.job_id == job_id,
                                  Task.status == 'complete').count()
+        in_review = query.filter(Task.job_id == job_id,
+                                 Task.status == 'review_requested').count()
+        requires_changes = query.filter(Task.job_id == job_id,
+                                 Task.status == 'requires_changes').count()
+        in_progress = query.filter(Task.job_id == job_id,
+                                 Task.status == 'in_progress').count()
 
         task_id_list = [task.id for task in all_the_tasks_in_job]
         if user_id is None:
@@ -653,6 +659,9 @@ class Task(Base):
         tasks_stats = {
             "total": total,
             "completed": completed,
+            "in_review": in_review,
+            "requires_changes": requires_changes,
+            "in_progress": in_progress,
             "instaces_created": instances_created
         }
         return tasks_stats


### PR DESCRIPTION
In this PR:
- Display new icons for new statuses on the task list
- Display new statuses on the stats