### PR TITLE
Improve sequence list

### DIFF
--- a/default/main.py
+++ b/default/main.py
@@ -53,6 +53,8 @@ def log_request_info():
 	try:
 		if request.path in do_not_log_these_routes:		# sensitive routes
 			return
+		if request.path.endswith("annotation/update"):
+			return
 		out = request.get_json(force=True)
 		out['path'] = request.path	# Because may not log in line with normal path printing.
 		logger.info(out)

--- a/default/tests/shared/test_annotation.py
+++ b/default/tests/shared/test_annotation.py
@@ -1196,7 +1196,7 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         )
         result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
         print('ann_update.log', ann_update.log)
-        self.assertFalse(result)
+        self.assertTrue(result)
         self.assertTrue(len(ann_update.log['warning'].keys()) > 0)
         self.assertTrue('new_instance_list_missing_ids' in ann_update.log['warning'])
         self.assertTrue('information' in ann_update.log['warning'])
@@ -1219,7 +1219,7 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         )
         result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
 
-        self.assertFalse(result)
+        self.assertTrue(result)
         self.assertTrue(len(ann_update.log['warning'].keys()) > 0)
         self.assertTrue('new_instance_list_missing_ids' in ann_update.log['warning'])
         self.assertTrue('information' in ann_update.log['warning'])

--- a/default/tests/shared/test_annotation.py
+++ b/default/tests/shared/test_annotation.py
@@ -1196,7 +1196,7 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         )
         result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
         print('ann_update.log', ann_update.log)
-        self.assertTrue(result)
+        self.assertFalse(result)
         self.assertTrue(len(ann_update.log['warning'].keys()) > 0)
         self.assertTrue('new_instance_list_missing_ids' in ann_update.log['warning'])
         self.assertTrue('information' in ann_update.log['warning'])
@@ -1219,7 +1219,7 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         )
         result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
 
-        self.assertTrue(result)
+        self.assertFalse(result)
         self.assertTrue(len(ann_update.log['warning'].keys()) > 0)
         self.assertTrue('new_instance_list_missing_ids' in ann_update.log['warning'])
         self.assertTrue('information' in ann_update.log['warning'])

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -8111,6 +8111,7 @@ mplate_has_keypoints_type: function (instance_template) {
           if (this.video_mode) {
 
             for (var instance of response.data.added_instances) {
+
               this.add_keyframe_to_sequence(instance)
 
               if (instance.action_type == "deleted") {

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -8112,12 +8112,12 @@ mplate_has_keypoints_type: function (instance_template) {
 
             for (var instance of response.data.added_instances) {
 
-              this.add_keyframe_to_sequence(instance)
+              this.add_keyframe_to_sequence(instance, current_frame_cache)
 
               if (instance.action_type == "deleted") {
                 this.$refs.sequence_list.remove_frame_number_from_sequence(
                   instance.sequence_id,
-                  this.current_frame)
+                  current_frame_cache)
               }
             }
           }
@@ -8162,14 +8162,14 @@ mplate_has_keypoints_type: function (instance_template) {
         return false;
       }
     },
-    add_keyframe_to_sequence(instance) {
+    add_keyframe_to_sequence(instance, current_frame_cache) {
       if (instance.action_type == "created" ||
           instance.action_type == "new_instance" ||
           instance.action_type == "undeleted")      // not 'edited'
       {
         this.$refs.sequence_list.add_frame_number_to_sequence(
           instance.sequence_id,
-          this.current_frame
+          current_frame_cache
         );   
       }     
     },

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -7915,15 +7915,6 @@ mplate_has_keypoints_type: function (instance_template) {
       this.update_draw_mode_on_instances(draw_mode);
       this.is_actively_drawing = false; // QUESTION do we want this as a toggle or just set to false to clear
     },
-
-    refresh_sequence_frame_list: function (instance_list, frame_number) {
-      for (const instance of instance_list) {
-        this.$refs.sequence_list.add_frame_number_to_sequence(
-          instance.sequence_id,
-          frame_number
-        );
-      }
-    },
     save: async function (
       and_complete = false,
       frame_number_param = undefined,
@@ -8118,10 +8109,16 @@ mplate_has_keypoints_type: function (instance_template) {
             }
           }
           if (this.video_mode) {
-            this.refresh_sequence_frame_list(
-              instance_list_request_frame,
-              video_data.current_frame
-            );
+
+            for (var instance of response.data.added_instances) {
+              this.add_keyframe_to_sequence(instance)
+
+              if (instance.action_type == "deleted") {
+                this.$refs.sequence_list.remove_frame_number_from_sequence(
+                  instance.sequence_id,
+                  this.current_frame)
+              }
+            }
           }
         }
 
@@ -8163,6 +8160,17 @@ mplate_has_keypoints_type: function (instance_template) {
         //this.logout()
         return false;
       }
+    },
+    add_keyframe_to_sequence(instance) {
+      if (instance.action_type == "created" ||
+          instance.action_type == "new_instance" ||
+          instance.action_type == "undeleted")      // not 'edited'
+      {
+        this.$refs.sequence_list.add_frame_number_to_sequence(
+          instance.sequence_id,
+          this.current_frame
+        );   
+      }     
     },
     complete_task() {
       if (!this.task) {

--- a/frontend/src/components/annotation/utils/AnnotationSavePrechecks.ts
+++ b/frontend/src/components/annotation/utils/AnnotationSavePrechecks.ts
@@ -103,7 +103,7 @@ export let add_ids_to_new_instances_and_delete_old = function (response,
   }
   for (let i = 0; i < instance_list.length; i++) {
     const current_instance = instance_list[i]
-    console.log('CURRENT INSTANCE', current_instance)
+    //console.log('CURRENT INSTANCE', current_instance)
     if (!current_instance.id) {
       // Case of a new instance added
       const new_instance = new_added_instances.filter(x => x.creation_ref_id === current_instance.creation_ref_id)

--- a/frontend/src/components/free_tier_limits/free_tier_limit_dialog.vue
+++ b/frontend/src/components/free_tier_limits/free_tier_limit_dialog.vue
@@ -27,8 +27,8 @@
           x-large
           class="mt-4"
           color="success">
-          <v-icon>mdi-star-shooting</v-icon>
-          Upgrade to Premium
+          <v-icon left>mdi-star-shooting</v-icon>
+          Upgrade
         </v-btn>
 
       </v-card-text>

--- a/frontend/src/components/main_menu/menu.vue
+++ b/frontend/src/components/main_menu/menu.vue
@@ -283,12 +283,13 @@
               </v-btn>
             </ahref_seo_optimal>
             <v-btn
-              v-if="$store.state.user.logged_in == true"
+              v-if="$store.state.user.logged_in == true
+                   && $store.state.org && !$store.state.org.current.id"
               @click="go_to_order_page"
               outlined
               color="success">
-              <v-icon>mdi-star-shooting</v-icon>
-              Upgrade to Premium
+              <v-icon left>mdi-star-shooting</v-icon>
+              Upgrade
             </v-btn>
 
             <v_profile_in_menu class="hidden-xs-only">

--- a/frontend/src/components/video/sequence_list.vue
+++ b/frontend/src/components/video/sequence_list.vue
@@ -643,6 +643,7 @@ export default Vue.extend( {
   },
   methods: {
     add_frame_number_to_sequence(sequence_id, frame_number){
+
       if(frame_number == undefined){
         return
       }
@@ -654,6 +655,19 @@ export default Vue.extend( {
           existing_frames.sort(function(a, b) {
             return a - b;
           });
+        }
+      }
+    },
+    remove_frame_number_from_sequence(sequence_id, frame_number){
+      if(frame_number == undefined){
+        return
+      }
+      let sequence = this.sequence_list.find(seq => seq.id === sequence_id);
+      if(sequence){
+        let existing_frames = sequence.keyframe_list.frame_number_list;
+        let index = existing_frames.indexOf(frame_number)
+        if (index !== -1) {
+         existing_frames.splice(index, 1)
         }
       }
     },

--- a/shared/alembic/versions_opencore/alembic_2021_12_15_11_15_e25f886d921a_add_member_created_id_to_input_table.py
+++ b/shared/alembic/versions_opencore/alembic_2021_12_15_11_15_e25f886d921a_add_member_created_id_to_input_table.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'e25f886d921a'
-down_revision = 'b7921392b4c3'
+down_revision = 'efd1cf42073a'
 branch_labels = None
 depends_on = None
 

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -420,7 +420,7 @@ class Annotation_Update():
                 ids_not_included
             )
             self.log['warning'][
-                'information'] = 'Error: outdated instance list sent. This can happen when 2 users are working on the same file at the same time.' \
+                'information'] = 'Error: outdated instance list sent.' \
                                  'Please try reloading page, clicking the refresh file data button or check your network connection. ' \
                                  'Please contact use if this persists.'
             self.log['warning']['missing_ids'] = ids_not_included
@@ -437,8 +437,7 @@ class Annotation_Update():
                 member_id = self.member.id if self.member else None,
                 error_log = self.log,
                 success = False)
-            # Do not return an error state for now, we are recording the event.
-            # return False
+            return False
         return True
 
     def append_new_instance_list_hash(self, instance):

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -1897,7 +1897,6 @@ class Annotation_Update():
             update_existing_only = True)
 
         if sequence:
-            print(sequence.id, self.added_sequence_ids)
             if sequence.id not in self.added_sequence_ids:
                 sequence.remove_keyframe_to_cache(self.session, instance)
                 self.session.add(sequence)

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -1382,7 +1382,6 @@ class Annotation_Update():
         """
         # Prevent from adding the same instances with ID None (cases where list has the same instance twice)
         # And both instances have the same hash and no ID.
-        print('SERALIZED INSTANCE', self.instance   )
         if self.instance.id is None:
             return
 

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -420,7 +420,7 @@ class Annotation_Update():
                 ids_not_included
             )
             self.log['warning'][
-                'information'] = 'Error: outdated instance list sent.' \
+                'information'] = 'Error: outdated instance list sent. This can happen when 2 users are working on the same file at the same time.' \
                                  'Please try reloading page, clicking the refresh file data button or check your network connection. ' \
                                  'Please contact use if this persists.'
             self.log['warning']['missing_ids'] = ids_not_included
@@ -437,7 +437,8 @@ class Annotation_Update():
                 member_id = self.member.id if self.member else None,
                 error_log = self.log,
                 success = False)
-            return False
+            # Do not return an error state for now, we are recording the event.
+            # return False
         return True
 
     def append_new_instance_list_hash(self, instance):

--- a/shared/database/source_control/file.py
+++ b/shared/database/source_control/file.py
@@ -367,10 +367,7 @@ class File(Base, Caching):
 
         file = self.serialize_base_file()
 
-        # WIP... Things like complete status from video
-        # if self.video_parent_file_id:
-        #	file['video_file_parent'] = self.video_parent_file(session)
-        print('serialize with type', self.type)
+        #print('serialize with type', self.type)
         if self.type == "image":
             if self.image:
                 file['image'] = self.image.serialize_for_source_control(session)

--- a/shared/database/video/sequence.py
+++ b/shared/database/video/sequence.py
@@ -477,7 +477,6 @@ class Sequence(Base):
             limit = None)
 
         frame_number_list = self.regenerate_keyframes_for_whole_series(instance_list)
-        print("Running")
         self.keyframe_list['frame_number_list'] = frame_number_list
 
 
@@ -490,7 +489,7 @@ class Sequence(Base):
         return frame_number_list
 
 
-    def is_keyframe_missing_from_list(instance, frame_number_list):
+    def is_keyframe_missing_from_list(self, instance, frame_number_list):
         if instance.soft_delete is False or instance.soft_delete is None:
             if instance.frame_number is not None:
                 if instance.frame_number not in frame_number_list:

--- a/shared/database/video/sequence.py
+++ b/shared/database/video/sequence.py
@@ -199,7 +199,7 @@ class Sequence(Base):
                 instance = self.get_preview_instance(session = session)
 
                 if instance:
-                    logger.info("Rebuilding Instance {} Preview".format(instance.id))
+                    logger.debug("Rebuilding Instance {} Preview".format(instance.id))
 
                     self.instance_preview_cache = instance.serialize_for_sequence_preview(
                         session = session)
@@ -229,7 +229,7 @@ class Sequence(Base):
             the instance we are getting has a thumbnail.
         """
         if instance:
-            logger.info('Regenerating instance thumb for {}'.format(instance.id))
+            logger.debug('Regenerating instance thumb for {}'.format(instance.id))
             self.regenerate_instance_thumb(
                 session = session,
                 instance = instance)
@@ -369,7 +369,7 @@ class Sequence(Base):
         if label_file:
             sequence.label_file_id = label_file.id
         else:
-            logger.info(
+            logger.debug(
                 "label_file is None, this is unusual. video_file_id was: " + str(video_file_id) + " number was " + str(
                     number))
 
@@ -473,6 +473,7 @@ class Sequence(Base):
 
     def add_keyframe_to_cache(self, session, instance):
         # Assumes from a single instance to avoid computation
+        # Assumes will ignore duplicates
 
         frame_number_list = self.keyframe_list['frame_number_list']       
         if self.is_keyframe_alive(instance) is True:
@@ -485,6 +486,6 @@ class Sequence(Base):
                 return
             try:
                 bisect.insort(frame_number_list, instance.frame_number)
-            except:
-                pass
+            except Exception as e:
+                print(e)
         self.keyframe_list['frame_number_list'] = frame_number_list

--- a/shared/database/video/sequence.py
+++ b/shared/database/video/sequence.py
@@ -463,11 +463,15 @@ class Sequence(Base):
 
         frame_number_list = self.keyframe_list['frame_number_list']
         index = bisect.bisect_left(frame_number_list, instance.frame_number)
-        if instance.frame_number == 0 and index == 0:
-            del frame_number_list[index]
+        if frame_number_list:
+            try:
+                if instance.frame_number == 0 and index == 0:
+                    del frame_number_list[index]
 
-        if index != 0 and index < len(frame_number_list):
-            del frame_number_list[index]
+                if index != 0 and index < len(frame_number_list):
+                    del frame_number_list[index]
+            except Exception as e:
+                logger.error(e)
         self.keyframe_list['frame_number_list'] = frame_number_list
 
 
@@ -487,5 +491,5 @@ class Sequence(Base):
             try:
                 bisect.insort(frame_number_list, instance.frame_number)
             except Exception as e:
-                print(e)
+                logger.error(e)
         self.keyframe_list['frame_number_list'] = frame_number_list

--- a/shared/database/video/sequence.py
+++ b/shared/database/video/sequence.py
@@ -443,6 +443,7 @@ class Sequence(Base):
 
     def regenerate_keyframes_for_whole_series(self, instance_list):
         # Assumes entire list is provided and just want to recreate the list.
+        logger.debug("regenerate_keyframes_for_whole_series")
         frame_number_list = []
         for instance in instance_list:
             if self.is_keyframe_alive(instance) is True:
@@ -462,6 +463,7 @@ class Sequence(Base):
     def remove_keyframe_to_cache(self, session, instance):
 
         frame_number_list = self.keyframe_list['frame_number_list']
+        logger.debug(frame_number_list)
         index = bisect.bisect_left(frame_number_list, instance.frame_number)
         if frame_number_list:
             try:
@@ -472,6 +474,7 @@ class Sequence(Base):
                     del frame_number_list[index]
             except Exception as e:
                 logger.error(e)
+        logger.debug(frame_number_list)
         self.keyframe_list['frame_number_list'] = frame_number_list
 
 
@@ -479,17 +482,20 @@ class Sequence(Base):
         # Assumes from a single instance to avoid computation
         # Assumes will ignore duplicates
 
-        frame_number_list = self.keyframe_list['frame_number_list']       
+        frame_number_list = self.keyframe_list['frame_number_list']
+        logger.debug(frame_number_list)
+        logger.debug(instance.number)
         if self.is_keyframe_alive(instance) is True:
 
             # prevent duplicates by checking if it exists
             index = bisect.bisect_left(frame_number_list, instance.frame_number)
             if index < len(frame_number_list):
                 return
-            if index == 0 and instance.frame_number != 0:
+            if len(frame_number_list) != 0 and index == 0 and instance.frame_number != 0:
                 return
             try:
                 bisect.insort(frame_number_list, instance.frame_number)
             except Exception as e:
                 logger.error(e)
+        logger.debug(frame_number_list)
         self.keyframe_list['frame_number_list'] = frame_number_list

--- a/shared/feature_flags/feature_checker.py
+++ b/shared/feature_flags/feature_checker.py
@@ -67,7 +67,7 @@ class FeatureChecker:
             is_annual_pricing = False,
             calculated_charge = -1,
             per_user_final = -1,
-            marketing_promo_code = '',
+            marketing_promo_code = None,
             marketing_promo_rate_found = -1,
             marketing_plan_rate = -1,
             marketing_savings = -1,


### PR DESCRIPTION
### Main items
1. **Backend**: Extract keyframe cache to be more composable. This splits the old and confusing thing hidden in the `update` calls into much more clear stuff ->

![image](https://user-images.githubusercontent.com/18080164/148002852-a4a4be2e-3f45-4db2-8a79-e7d383f388b6.png)

The main concept here is to make it easier to understand when keyframes are getting added or removed from the cache

![image](https://user-images.githubusercontent.com/18080164/148002862-17165811-23de-41e1-a548-2e01966c0788.png)
https://github.com/diffgram/diffgram/commit/83b635759511c9ab3d1541b65f3175db88093d5b  (plus some little updates after)

**Timing bug**
There was a timing bug here too - depending on the order of it it was possible that the deletion would overwrite the addition.
eg ->  added instance adds frame number 29 then the removed version of it goes and deletes it. it's correct if the order is inverted. but order is hard to setup here. 

Solution was to just tracking which sequences we already added to, and then using that as an ignore list.

I think overall this will still need more iterations over time, but at least now it's pulled closer to the decision point and should be a lot more workable.

**little fixes and performance boost**
Also fixed a variety of little cases with the inserts, eg before repeated calls could have resulted in more deletions etc.
AND performance boost, was able to get rid of the `in list` check by adding a bisect plus some conditions. hat should mean that for large keyframe lists it's binary search time instead of checking each element.
https://github.com/diffgram/diffgram/blob/61e34c951209e97ac10537f101d279616a2173cb/shared/database/video/sequence.py#L491  


2. **Frontend**: 
  a) Better conditions on when to add keyframes on front end. bug fix that sometimes it was adding all.
  b) Added a proactive removal method
https://github.com/diffgram/diffgram/commit/73f958ef1991b68e72b9d8636c7c8fea2758a33
![adding 55s to all](https://user-images.githubusercontent.com/18080164/148002744-410e7def-782c-4a71-8425-44e4fe4ba3a6.PNG)

The benefit of leaning on backend here is that it helps ensure alignment, but the downside is that it's a little clunky. 

I think it would be better to do this before save.

It seemed like it would break the pattern too much do that change now but something to keep in mind for v2 of the sequence browser. Really trying to move away from this dependency on the backend for stuff we already know on frontend. Rather have backend act more like a saving mechanism in this case then a blocker

## Related bug observation - question for Pablo 
The only state I was able to get into that would break this on backend was when the frontend failed to send instance list. eg by moving quickly in UI - some edge case of mashing buttons we haven't covered yet.

![not having all the instances available can still cause keyframe issues](https://user-images.githubusercontent.com/18080164/148003692-030ae512-6e40-4773-af95-6479b6c15466.png)

I'm suggesting we go back to hard block on this for now, since it also breaks the keyframe thing other stuff.
https://github.com/diffgram/diffgram/blob/61e34c951209e97ac10537f101d279616a2173cb/shared/annotation.py#L440

Happy to revert quickly if we get too many hits on it, but perhaps when we do we can try to button up the front end, maybe block moving around in certain saving, or just make it more robust to allow navigation while saving (I think we took some steps there but maybe not 100% yet?)

Please let me know thoughts on this especially


### Relying on the added/deleted and action_type
This stuff is starting to depend more on some of those flags and states. We may need some more iterations on that too.

### Other items and side notes
1. Identified regen as totally different case which is regen all from a fresh instance_list() pull. updated new function for that case -> https://github.com/diffgram/diffgram/commit/5b4677bb16798eae5be2dbe1c26b7ba5717c29c7
2. noting this tiny logging change here just in case I'm missing a reason we needed it https://github.com/diffgram/diffgram/commit/f007bbe716e8c2ecf132e6b6caf95f419abb65dd 



Edit:
The tests were passing but the new False thing broke them, I tried updating here
https://github.com/diffgram/diffgram/pull/489/commits/99fbb01d2d52e4fe7e41b9c9f0e9f35b3278664c
