### PR TITLE
Fix Frame Changes Bug

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -2885,7 +2885,7 @@ mplate_has_keypoints_type: function (instance_template) {
       }
 
       let new_frame = direction + this.current_frame;
-      this.$store.commit("go_to_keyframe_via_store", new_frame);
+      this.$refs.video_controllers.move_frame(direction)
     },
 
     hide_context_menu: function () {

--- a/frontend/src/components/main_menu/menu.vue
+++ b/frontend/src/components/main_menu/menu.vue
@@ -401,7 +401,7 @@
 
         }
         else{
-          window.open(`http://localhost:8085/order/premium?install_fingerprint=${this.$store.state.user.current.install_fingerprint}&email=${this.$store.state.user.current.email}`, '_blank')
+          window.open(`https://diffgram.com/order/premium?install_fingerprint=${this.$store.state.user.current.install_fingerprint}&email=${this.$store.state.user.current.email}`, '_blank')
 
         }
       },

--- a/frontend/src/components/video/video.vue
+++ b/frontend/src/components/video/video.vue
@@ -262,7 +262,7 @@
             ref="slider"
             data-cy="video_player_slider"
             class="pl-4 pr-4 pt-0"
-            @input="update_from_slider(parseInt($event))"
+
             @end="slider_end(parseInt($event))"
             @change="slide_change(parseInt($event))"
             :disabled="loading
@@ -749,7 +749,6 @@ export default Vue.extend( {
 
 
     go_to_keyframe: async function (frame) {
-
       if (this.go_to_keyframe_loading == true) { // swallow spamming
         return
       }
@@ -782,7 +781,6 @@ export default Vue.extend( {
         this.video_current_frame_guess = frame
         // TODO how we want to push this back to annotations component?
         //this.show_annotations = false
-
         this.$emit('go_to_keyframe');
 
         this.detect_end_from_keyframe()
@@ -790,7 +788,6 @@ export default Vue.extend( {
         this.push_key_frame()
 
         await this.get_video_single_image(this.video_current_frame_guess)
-
       }
       this.updateFrameUrl(frame);
       this.go_to_keyframe_loading = false;
@@ -865,7 +862,6 @@ export default Vue.extend( {
     move_frame: function(direction) {
       // direction is an int where:
       // -1 to go back, 1 go forward
-
       let new_frame = this.video_current_frame_guess + direction
       this.go_to_keyframe(new_frame)
       // Better reuse of existing go to keyframe function.


### PR DESCRIPTION
Removing the @input event from slider since it was causing frame changes problems with hotkeys. It seems that this event handler is executed only when the frame_number value changes so I think it's not necessary to have it at all.