### PR TITLE
Allow Batched Prelabels Upload With S3 Connectors

### DIFF
--- a/default/methods/batch/append_to_batch.py
+++ b/default/methods/batch/append_to_batch.py
@@ -66,9 +66,7 @@ def save_pre_labeled_data_to_db(batch_id):
                 batch.download_status_pre_labeled_data = 'downloading'
                 session.add(batch)
                 session.commit()
-
                 json_str = data_tools.get_string_from_blob(batch.data_temp_dir)
-
                 json_data = json.loads(json_str)
                 batch.pre_labeled_data = json_data
                 batch.download_status_pre_labeled_data = 'success'
@@ -110,7 +108,8 @@ def append_to_batch_core(session, log, batch_id, member, project, request):
             url = data_tools.create_resumable_upload_session(
                 blob_path = temp_dir_path,
                 content_type = 'application/json',
-                input = None
+                input = None,
+                batch = batch
             )
             batch.data_temp_dir = url
             session.add(batch)

--- a/frontend/src/components/input/upload_summary.vue
+++ b/frontend/src/components/input/upload_summary.vue
@@ -264,7 +264,7 @@
         create_batch: async function (labels_payload) {
           try {
             this.loading_create_batch = true;
-            const chunk_size_bytes = 2 * 1024 * 1024; // 2 mb
+            const chunk_size_bytes = 6 * 1024 * 1024; // 6 mb
             // const chunk_size_bytes = 256 * 1024 // 256KB;
             const str = JSON.stringify(labels_payload);
             const bytes = new TextEncoder().encode(str);
@@ -272,7 +272,7 @@
               type: "application/json;charset=utf-8"
             });
             const total_size = blob.size;
-
+            console.log('total size', total_size, chunk_size_bytes)
             if (total_size < chunk_size_bytes){
               const response = await axios.post(`/api/v1/project/${this.$props.project_string_id}/input-batch/new`, {
                 pre_labeled_data: {...labels_payload}

--- a/shared/data_tools_core_azure.py
+++ b/shared/data_tools_core_azure.py
@@ -30,7 +30,8 @@ class DataToolsAzure:
         self,
         input: 'Input',
         blob_path: str,
-        content_type: str = None
+        content_type: str = None,
+        batch: 'InputBatch' = None
     ):
         """
           Azure has no concept of creating a resumable session, so for now this does nothing.

--- a/shared/data_tools_core_gcp.py
+++ b/shared/data_tools_core_gcp.py
@@ -42,6 +42,7 @@ class DataToolsGCP:
         input: 'Input',
         blob_path: str,
         content_type: str = None,
+        batch: 'InputBatch' = None
     ):
         """
         Create an upload session url where the user can upload a file to be stored

--- a/shared/data_tools_core_s3.py
+++ b/shared/data_tools_core_s3.py
@@ -34,7 +34,8 @@ class DataToolsS3:
         self,
         input: 'Input',
         blob_path: str,
-        content_type: str = None
+        content_type: str = None,
+        batch: 'InputBatch' = None
     ):
         """
             Creates an S3 Multipart upload session and attached the upload ID
@@ -53,7 +54,12 @@ class DataToolsS3:
             Key = blob_path,
             ContentType = content_type
         )
-        input.upload_aws_id = response['UploadId']
+        if input is not None:
+            input.upload_aws_id = response['UploadId']
+
+        if batch is not None:
+            batch.upload_aws_id = response['UploadId']
+        return response['UploadId']
 
     def transmit_chunk_of_resumable_upload(
         self,
@@ -96,31 +102,26 @@ class DataToolsS3:
         """
         # - 1 seems to be needed
         # it's "includsive" ?
+        parts_obj = None
+        if input:
+            parts_obj = input
+
+        if batch:
+            parts_obj = batch
 
         part = self.s3_client.upload_part(
             Body = stream,
             Bucket = self.s3_bucket_name,
             Key = blob_path,
-            UploadId = input.upload_aws_id,
+            UploadId = parts_obj.upload_aws_id,
             PartNumber = int(chunk_index) + 1)
-        if input:
-            if input.upload_aws_parts_list is None or \
-                input.upload_aws_parts_list.get('parts') is None:
-                input.upload_aws_parts_list = {
+        if parts_obj:
+            if parts_obj.upload_aws_parts_list is None or parts_obj.upload_aws_parts_list.get('parts') is None:
+                parts_obj.upload_aws_parts_list = {
                     'parts': [{"PartNumber": int(chunk_index) + 1, "ETag": part["ETag"]}]
                 }
             else:
-                input.upload_aws_parts_list['parts'].append(
-                    {"PartNumber": int(chunk_index) + 1, "ETag": part["ETag"]}
-                )
-        elif not input and batch:
-            if batch.upload_aws_parts_list is None or \
-                batch.upload_aws_parts_list.get('parts') is None:
-                batch.upload_aws_parts_list = {
-                    'parts': [{"PartNumber": int(chunk_index) + 1, "ETag": part["ETag"]}]
-                }
-            else:
-                batch.upload_aws_parts_list['parts'].append(
+                parts_obj.upload_aws_parts_list['parts'].append(
                     {"PartNumber": int(chunk_index) + 1, "ETag": part["ETag"]}
                 )
 
@@ -128,9 +129,8 @@ class DataToolsS3:
             result = self.s3_client.complete_multipart_upload(
                 Bucket = self.s3_bucket_name,
                 Key = blob_path,
-                UploadId = input.upload_aws_id if input else batch.upload_aws_id,
-                MultipartUpload = {
-                    "Parts": input.upload_aws_parts_list['parts'] if input else batch.upload_aws_parts_list['parts']}
+                UploadId = parts_obj.upload_aws_id,
+                MultipartUpload = {"Parts": parts_obj.upload_aws_parts_list['parts']}
             )
         return True
 
@@ -249,7 +249,11 @@ class DataToolsS3:
         :param blob_name: path to the blob on the cloud providers's bucket
         :return: string data of the downloaded blob
         """
-        raise NotImplementedError
+        bytes_buffer = BytesIO()
+        self.s3_client.download_fileobj(Bucket = self.s3_bucket_name, Key = blob_name, Fileobj = bytes_buffer)
+        byte_value = bytes_buffer.getvalue()
+        str_value = byte_value.decode()
+        return str_value
 
     def rebuild_secure_urls_image(self, session: 'Session', image: 'Image'):
         """


### PR DESCRIPTION
Batch object was missing the 

` batch.upload_aws_id = response['UploadId']`

for it to proceed with the batch upload of big prelabeled files.