### PR TITLE
Fix CSV Uploads

### DIFF
--- a/frontend/src/components/input/new_or_update_upload_screen.vue
+++ b/frontend/src/components/input/new_or_update_upload_screen.vue
@@ -355,7 +355,7 @@
           return {
             init: function () {
               this.on("addedfile", function (file) {
-                if (file.type === 'application/json' || file.type === 'text/csv') {
+                if (file.type === 'application/json' || (file.type === 'text/csv' && $vm.with_prelabeled)) {
                   file.data_type = 'Annotations';
                 } else {
                   file.data_type = 'Raw Media';


### PR DESCRIPTION
The upload wizard was always setting CSV as prelabeled data. Now if you select, that you will NOT add prelabeled data the CSV is considered as a list of URL's and uploaded correctly.

The CSV Provided was not working due to that page throwing 403 to anything that is not a web browser.

I added a new CSV where I removed 2 of the 3 rows to some other URL so you can re test the upload
[testcase - Dogs - testcase - Dogs.csv](https://github.com/diffgram/diffgram/files/7873488/testcase.-.Dogs.-.testcase.-.Dogs.csv)
