### PR TITLE
Cancel Frames/Video requests on video drawable canvas on destroy

### DIFF
--- a/default/methods/report/report_runner.py
+++ b/default/methods/report/report_runner.py
@@ -484,7 +484,8 @@ class Report_Runner():
             self.query = self.query.order_by(self.date_func)
 
         elif self.report_template.group_by == 'label':
-            self.query = self.query.group_by(self.label_file_id)
+            if hasattr(self, 'label_file_id'):
+                self.query = self.query.group_by(self.label_file_id)
 
         elif self.report_template.group_by == 'user':
             self.query = self.query.group_by(self.member_id_normalized)
@@ -670,9 +671,13 @@ class Report_Runner():
         """
         label_file_id_list: List of ints ids
         """
+        if self.base_class_string == 'task':
+            self.query = self.query.filter(
+                self.base_class.file_id.in_(label_file_id_list))
 
-        self.query = self.query.filter(
-            self.base_class.label_file_id.in_(label_file_id_list))
+        else:
+            self.query = self.query.filter(
+                self.base_class.label_file_id.in_(label_file_id_list))
 
     def update_report_template(self, metadata: dict):
         """
@@ -955,7 +960,10 @@ class Report_Runner():
         WIP only really for Instance
         Yes this must use an id it look like for group by
         """
-        query = self.session.query(self.label_file_id, func.count(self.base_class.id))
+        if hasattr(self, 'label_file_id'):
+            query = self.session.query(self.label_file_id, func.count(self.base_class.id))
+        else:
+            query = self.session.query(self.base_class)
         return query
 
     def group_by_file(self):

--- a/frontend/src/components/video/video.vue
+++ b/frontend/src/components/video/video.vue
@@ -255,9 +255,7 @@
 
              Do NOT 2 way bind this component, we expect the events to update frame number
              We do want to send the current video frame number to this though so that
-             It can update as it plays.
-
-          --->
+             It can update as it plays. --->
           <v-slider
             ref="slider"
             data-cy="video_player_slider"

--- a/frontend/src/components/video/video.vue
+++ b/frontend/src/components/video/video.vue
@@ -607,7 +607,10 @@ export default Vue.extend( {
 
     this.keyframe_watcher()
     this.video_pause()    // in case video was still playing
-
+    if(this.$refs.video_source_ref){
+      this.$refs.video_source_ref.src = "";
+      this.$refs.video_source_ref.load();
+    }
   },
   methods: {
     reset_cache(){
@@ -1360,7 +1363,6 @@ export default Vue.extend( {
         ) {
         return
       }
-      console.log('get_video_single_image')
       this.get_video_single_image_last_fired = new Date().getTime()
 
       this.video_current_frame_guess_update()
@@ -1368,7 +1370,6 @@ export default Vue.extend( {
       const prev_frames = this.get_previous_n_frames(frame_number, this.MAX_NUM_URL_BUFFER)
       const all_new_frames = [...new Set(next_frames.concat(prev_frames))];
       if (frame_number != this.prior_frame_number) {
-        console.log('frame_number != this.prior_frame_number')
         if(!this.frame_url_buffer[frame_number]){
           this.error = {}
           try{

--- a/frontend/src/components/vue_canvas/video_drawable_canvas.vue
+++ b/frontend/src/components/vue_canvas/video_drawable_canvas.vue
@@ -130,6 +130,7 @@ import {KeypointInstance} from "./instances/KeypointInstance";
       show_video_nav_bar:{
         default: true
       },
+
       reticle_colour: {
         default: () => ({
           hex: '#ff0000',
@@ -147,6 +148,7 @@ import {KeypointInstance} from "./instances/KeypointInstance";
         loading: false,
         hovered: false,
         is_mounted: false,
+        loading_images: [],
         annotations_loading: false,
         get_instances_loading: false,
         refresh: new Date(),
@@ -172,6 +174,12 @@ import {KeypointInstance} from "./instances/KeypointInstance";
       //console.debug("Destroyed")
       document.removeEventListener('focusin', this.focus_in)
       document.removeEventListener('focusout', this.focus_out)
+      if(window.stop !== undefined) {
+        window.stop();
+      }
+      else if(document.execCommand !== undefined){
+        document.execCommand("Stop", false);
+      }
     },
     watch: {
       instance_list: function(){
@@ -396,11 +404,18 @@ import {KeypointInstance} from "./instances/KeypointInstance";
       addImageProcess: function (src) {
         return new Promise((resolve, reject) => {
           let image = new Image()
+          this.loading_images.push(image)
+
           image.src = src
           if(process.env.NODE_ENV === 'testing'){
             image.crossOrigin = "anonymous";
           }
-          image.onload = () => resolve(image)
+          image.onload = () => {
+            this.loading_images = this.loading_images.filter(function(elm){
+              return elm !== image;
+            });
+            resolve(image)
+          }
           image.onerror = reject
         })
       },
@@ -408,7 +423,9 @@ import {KeypointInstance} from "./instances/KeypointInstance";
         var self = this
         self.addImageProcess(url).then(image => {
           self.html_image = image
-          self.$refs.drawable_canvas.canvas_wrapper.style.display = ""
+          if(self.$refs.drawable_canvas){
+            self.$refs.drawable_canvas.canvas_wrapper.style.display = ""
+          }
           self.loading = false
           this.refresh = Date.now();
         })


### PR DESCRIPTION
Context is that user goes to the task list before annotation core.

If we don't cancel the requests, then the frames/video files of 15 tasks will be fetching while they open the annotation core video.

This was causing the requests from 15 videos to be queued, and when going to the video annotation this was consuming all the bandwith for the frames fetching

** Also includes small bugfixes to report runner