### PR TITLE
Fix Video: animation was not stopping even though video ended

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -3432,7 +3432,6 @@ mplate_has_keypoints_type: function (instance_template) {
 
       this.html_image = image;
       //this.trigger_refresh_with_delay()
-      // todo getting buffer should be in Video component
       // also this could be a lot smarter ie getting instances
       // while still some buffer left etc.
       if (this.current_frame in this.instance_buffer_dict) {

--- a/frontend/src/components/video/video.vue
+++ b/frontend/src/components/video/video.vue
@@ -1051,7 +1051,6 @@ export default Vue.extend( {
     },
 
     video_animation_unit_of_work: function (time_from_animation) {
-
       this.$emit('video_animation_unit_of_work', this.primary_video)
 
       this.update_current_frame_guess()
@@ -1064,7 +1063,10 @@ export default Vue.extend( {
       // integer codes for state...
 
       // must be at end?
-      this.video_animation_start()
+      if(this.playing){
+        this.animation_request = window.requestAnimationFrame(this.video_animation_unit_of_work)
+      }
+
     },
 
 	/**
@@ -1093,9 +1095,10 @@ export default Vue.extend( {
 
       if (typeof this.video_current_frame_guess != "undefined") {
         this.get_video_single_image(this.video_current_frame_guess)
+        this.updateFrameUrl(this.video_current_frame_guess);
       }
 
-      this.updateFrameUrl(this.video_current_frame_guess);
+
     },
 
     detect_early_end: function (early_end_time) {

--- a/frontend/src/components/video/video.vue
+++ b/frontend/src/components/video/video.vue
@@ -1036,7 +1036,9 @@ export default Vue.extend( {
       window.cancelAnimationFrame(this.animation_request)
 
     },
-
+    video_animation_start: function(){
+      this.animation_request = window.requestAnimationFrame(this.video_animation_unit_of_work)
+    },
     video_animation_unit_of_work: function (time_from_animation) {
       this.$emit('video_animation_unit_of_work', this.primary_video)
 

--- a/frontend/src/components/video/video.vue
+++ b/frontend/src/components/video/video.vue
@@ -1031,19 +1031,6 @@ export default Vue.extend( {
 
     },
 
-    // udacity intro on it https://www.youtube.com/watch?v=YGR8rVT6xJ8
-    // https://stackoverflow.com/questions/10735922/how-to-stop-a-requestanimationframe-recursion-loop
-    // https://stackoverflow.com/questions/38709923/why-is-requestanimationframe-better-than-setinterval-or-settimeout
-
-    video_animation_start: function () {
-      https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame
-      this.animation_request = window.requestAnimationFrame(this.video_animation_unit_of_work)
-      // returns a type long, a request id value
-      // we can pass that to cancel to cancel animation
-      // TODO clarify it's ok we reuse this.animation_request in this way
-
-    },
-
     video_animation_stop: function () {
 
       window.cancelAnimationFrame(this.animation_request)


### PR DESCRIPTION
This only happened when video reached the end, causing an infinite loop and browser crashing