### PR TITLE
Configure Selinux label

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,7 +104,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_DB=diffgram
     volumes:
-      - ${POSTGRES_DATA_DIR:-./postgres-data}:/var/lib/postgresql/data
+      - ${POSTGRES_DATA_DIR:-./postgres-data}:/var/lib/postgresql/data:Z
     ports:
       - 5432:5432
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,7 +104,8 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_DB=diffgram
     volumes:
-      - ${POSTGRES_DATA_DIR:-./postgres-data}:/var/lib/postgresql/data:Z
+      # Default INTERNAL_POSTGRES_DIR=/var/lib/postgresql/data:Z
+      - ${POSTGRES_DATA_DIR:-./postgres-data}:${INTERNAL_POSTGRES_DIR:-/var/lib/postgresql/data}
     ports:
       - 5432:5432
 

--- a/install.py
+++ b/install.py
@@ -69,6 +69,7 @@ class DiffgramInstallTool:
     mailgun = None
     mailgun_key = None
     email_domain = None
+    z_flag = None
 
     def set_static_storage_option(self, option_number):
         if option_number == 1:
@@ -420,6 +421,10 @@ class DiffgramInstallTool:
             env_file += 'MAILGUN_KEY={}\n'.format(self.mailgun_key)
             env_file += 'EMAIL_DOMAIN_NAME={}\n'.format(self.email_domain)
 
+        if self.z_flag:
+            env_file += 'INTERNAL_POSTGRES_DIR={}\n'.format('/var/lib/postgresql/data:Z')
+        else:
+            env_file += 'INTERNAL_POSTGRES_DIR={}\n'.format('/var/lib/postgresql/data')
         text_file = open(".env", "w")
         text_file.write(env_file)
         text_file.close()
@@ -474,6 +479,13 @@ class DiffgramInstallTool:
                         bcolors.FAIL)
                     bcolors.printcolor('Error data: {}'.format(str(e)), bcolors.FAIL)
                     valid = False
+
+        z_flag = bcolors.inputcolor('Do Add Z Flag to Postgres Mount? (Use only when using SELinux distros or similar) Y/N [Press Enter to Skip]: ')
+        z_flag = z_flag.lower()
+        if z_flag == 'y':
+            self.z_flag = True
+        else:
+            self.z_flag = False
 
     def mailgun_config(self):
         need_mailgun = bcolors.inputcolor(


### PR DESCRIPTION
Without this option the container doesn't work under Linux distros with Selinux
https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

Windows seems to be unaffected by adding the :Z option

This fixes #580 