### PR TITLE
DAD-43 fix: misplaced rotate point after drawing

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -36,7 +36,6 @@
             :label_file_colour_map="label_file_colour_map"
             :full_file_loading="full_file_loading"
             :instance_template_selected="instance_template_selected"
-            :instance_type="instance_type"
             :loading_instance_templates="loading_instance_templates"
             :instance_type_list="filtered_instance_type_list"
             :view_issue_mode="view_issue_mode"

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -1025,7 +1025,7 @@ export default Vue.extend({
     full_file_loading: {},
     annotations_loading: {},
     instance_template_selected: {},
-    instance_type: {},
+
     loading_instance_templates: {},
     instance_type_list: {},
     view_issue_mode: {},
@@ -1044,6 +1044,7 @@ export default Vue.extend({
         canvas_scale_global_is_automatic: true,
       },
       draw_mode_local: true,
+      instance_type: "box",
       numberValue: 1,
       duration_labels: ["1", "2", "3", "4", "5"],
     };

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -112,7 +112,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       this.nodes[node_index].occluded = true
     }
   }
-  public set_new_xy_to_scaled_values(): void{
+  public  set_new_xy_to_scaled_values(): void{
     for(let node of this.nodes){
       if (node.x < 300) {
         node.left_or_right = 'left'
@@ -122,6 +122,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       node.x = this.get_scaled_x(node);
       node.y = this.get_scaled_y(node);
     }
+    this.calculate_min_max_points();
     this.scale_height = undefined;
     this.scale_width = undefined;
     this.translate_y = undefined;
@@ -172,6 +173,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       this.add_node_to_instance();
     }
     else {
+
       if(this.is_moving){
         this.stop_moving();
       }
@@ -469,7 +471,33 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
 
   }
+  private draw_node(node, ctx, i){
+    if (this.label_settings &&
+      this.label_settings.show_occluded_keypoints == false &&
+      node.occluded == true) {
+      return
+    }
 
+    if (node.occluded == true) {
+      ctx.fillStyle = 'gray'
+    } else {
+      ctx.strokeStyle = this.strokeColor;
+      ctx.fillStyle = this.fillColor;
+    }
+
+    let x = node.x
+    let y = node.y
+
+    x = this.get_scaled_x(node)
+    y = this.get_scaled_y(node)
+
+    this.draw_point_and_set_node_hover_index(x, y, i, ctx)
+
+    this.draw_node_label(ctx, node);
+
+    this.draw_left_right_arrows(ctx, node, x, y)
+
+  }
   public draw(ctx): void {
     this.ctx = ctx;
 
@@ -493,34 +521,10 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
     for (let node of this.nodes) {
       // order of operations
-
-      if (this.label_settings &&
-          this.label_settings.show_occluded_keypoints == false &&
-          node.occluded == true) {
-        continue
-      }
-
-      if (node.occluded == true) {
-        ctx.fillStyle = 'gray'
-      } else {
-        ctx.strokeStyle = this.strokeColor;
-        ctx.fillStyle = this.fillColor;
-      }
-
-      let x = node.x
-      let y = node.y
-
-      x = this.get_scaled_x(node)
-      y = this.get_scaled_y(node)
-
-      this.draw_point_and_set_node_hover_index(x, y, i, ctx)
-
-      this.draw_node_label(ctx, node);
-
-      this.draw_left_right_arrows(ctx, node, x, y)
-
-      i += 1
+      this.draw_node(node, ctx, i);
+      i+=1
     }
+
     this.draw_rotate_point(ctx)
     this.determine_and_set_nearest_node_hovered(ctx)
 
@@ -691,7 +695,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     let min_max_obj = this.get_rotated_min_max();
     let width = Math.abs(min_max_obj.max_x - min_max_obj.min_x);
     let height = Math.abs(min_max_obj.max_y - min_max_obj.min_y);
-
     ctx.globalAlpha = 0.4;
     ctx.lineWidth = this.label_settings.spatial_line_size / this.zoom_value
     ctx.beginPath();
@@ -703,7 +706,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
 
 
-    if(this.is_mouse_in_path(ctx)){
+    if(this.is_mouse_in_path(ctx) && !this.instance_context.draw_mode){
       this.is_bounding_box_hovered = true;
       this.is_hovered = true;
       // Draw helper bounding box


### PR DESCRIPTION
Now rotate point is placed correctly on the keypoint instance

Fixes: https://github.com/diffgram/diffgram/issues/560