### PR TITLE
Change file path from original file to the actual thumbnail file

### DIFF
--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -1835,7 +1835,7 @@ class Process_Media():
         self.new_image.url_signed_thumb = url_signed_thumb
 
         data_tools.upload_to_cloud_storage(
-            temp_local_path = self.input.temp_dir_path_and_filename,
+            temp_local_path = new_temp_filename,
             blob_path = self.new_image.url_signed_thumb_blob_path,
             content_type = "image/jpg",
         )


### PR DESCRIPTION
I think the original file got uploaded instead of the thumbnail. Result is shown below (file 14 + thumb is old code, file 15 + thumb is the new code)

![image](https://user-images.githubusercontent.com/1612886/153731639-626c5c90-3fe0-49c1-8b33-a9ceba5f0326.png)


This will fix #592