### PR TITLE
Hide reviewer columns from task list when job does not allow reviews

### DIFF
--- a/frontend/src/components/3d_annotation/sensor_fusion_editor.vue
+++ b/frontend/src/components/3d_annotation/sensor_fusion_editor.vue
@@ -34,6 +34,7 @@
             @next_issue_task="next_issue_task(task)"
             @complete_task="complete_task()"
             @new_tag_instance="insert_tag_type()"
+            @on_task_annotation_complete_and_save="on_task_annotation_complete_and_save()"
             @replace_file="$emit('replace_file', $event)"
             :full_file_loading="full_file_loading"
             :instance_type="instance_type"
@@ -247,7 +248,7 @@
   import * as THREE from "three";
   import {UpdateInstanceCommand} from "../annotation/commands/update_instance_command.ts";
   import {CommandManagerAnnotationCore} from "../annotation/annotation_core_command_manager";
-  import {trackTimeTask} from "../../services/tasksServices";
+  import {trackTimeTask, finishTaskAnnotation} from "../../services/tasksServices";
 
   export default Vue.extend({
     name: "sensor_fusion_editor_3d",
@@ -424,6 +425,19 @@
       }
     },
     methods: {
+      on_task_annotation_complete_and_save: async function () {
+        await this.save(false);
+        const response = await finishTaskAnnotation(this.task.id);
+        const new_status = response.data.task.status;
+        this.task.status = new_status;
+        if (new_status !== "complete") {
+          this.submitted_to_review = true;
+        }
+        if (this.$props.task && this.$props.task.id) {
+          this.save_loading_image = false;
+          this.trigger_task_change("next", this.$props.task, true);
+        }
+      },
       delete_instance: function () {
         if (this.$props.view_only_mode == true) {
           return

--- a/frontend/src/components/3d_annotation/toolbar_sensor_fusion.vue
+++ b/frontend/src/components/3d_annotation/toolbar_sensor_fusion.vue
@@ -208,6 +208,7 @@
         :task="task"
         @complete_task="$emit('complete_task')"
         @replace_file="$emit('replace_file', $event)"
+        @on_task_annotation_complete_and_save="$emit('on_task_annotation_complete_and_save')"
         :save_and_complete="true"
         :loading="save_loading"
         :disabled="save_loading || view_only_mode || (!file && !task)"

--- a/frontend/src/components/task/task/task_list.vue
+++ b/frontend/src/components/task/task/task_list.vue
@@ -219,7 +219,8 @@
                   tooltip_message="Reset"
                   @click="column_list = column_list_backup"
                   v-if="column_list != column_list_backup"
-                  icon="autorenew"
+                  icon="mdi-autorenew"
+                  :icon_style="true"
                   color="primary"
                 >
                 </tooltip_button>
@@ -772,7 +773,7 @@ export default Vue.extend({
         "LastUpdated",
         "Action",
       ],
-
+      column_list_backup: [],
       column_list_all: [
         "Select",
         "Status",
@@ -1145,7 +1146,6 @@ export default Vue.extend({
             limit_count: this.per_page_limit,
           }
         );
-
         if (response.data.log.success == true) {
           this.task_list = response.data.task_list;
           this.allow_reviews = response.data.allow_reviews
@@ -1170,6 +1170,9 @@ export default Vue.extend({
               { name: "Assign reviewers", value: 'assignReviewers'},
               { name: "Remove reviewers", value: 'removeReviewers'},
               ]
+          }
+          else{
+            this.column_list_all = this.column_list_all.filter(col => !["AssignedReviewer"].includes(col))
           }
 
           this.update_tasks_with_file_annotations(this.task_list);


### PR DESCRIPTION
Now review columns are only showed when the job allows reviews.
Also fixed a small issue on 3d interface when completing tasks.