### PR TITLE
Add support for BMP, TIF and TIFF files

### DIFF
--- a/.github/workflows/diffgram_testing.yaml
+++ b/.github/workflows/diffgram_testing.yaml
@@ -6,7 +6,7 @@ on:
       - 'releases/**'
       - '**'
   pull_request_target:
-    types: [review_requested]
+    types: [review_requested, synchronize, ready_for_review, opened]
     branches:
       - '**'
       - '!DAD**'

--- a/.github/workflows/diffgram_testing.yaml
+++ b/.github/workflows/diffgram_testing.yaml
@@ -8,7 +8,7 @@ on:
   pull_request_target:
     types: [review_requested]
     branches:
-      - 'releases/**'
+      - '**'
       - '!DAD**'
 jobs:
   Default-Service-Unit-Tests:

--- a/frontend/src/components/input/new_or_update_upload_screen.vue
+++ b/frontend/src/components/input/new_or_update_upload_screen.vue
@@ -291,7 +291,7 @@
           loading_annotations: false,
           upload_source: null,
           accepted_annotation_file_types: ['json', 'csv'],
-          accepted_files: ".jpg, .jpeg, .png, .mp4, .m4v, .mov, .avi, .csv, .txt, .json",
+          accepted_files: ".jpg, .jpeg, .png, .bmp, .tif, .tiff, .mp4, .m4v, .mov, .avi, .csv, .txt, .json",
           file_table_headers: [
             {
               text: 'File Name',

--- a/shared/tests/test_utils/data_mocking.py
+++ b/shared/tests/test_utils/data_mocking.py
@@ -31,6 +31,8 @@ from shared.database.image import Image
 from shared.database.export import Export
 from shared.database.video.sequence import Sequence
 from shared.database.task.job.user_to_job import User_To_Job
+from shared.database.input import Input
+
 # This line is to prevent developers to run test in other databases or enviroments. We should rethink how to handle
 # configuration data for the different deployment phases (local, testing, staging, production)
 if settings.DIFFGRAM_SYSTEM_MODE != 'testing':
@@ -112,6 +114,21 @@ def register_user(user_data: dict, session):
                                                                           user_data['project_string_id'])
     return new_user
 
+
+def create_image(image_data, session):
+    im_obj = Image(**image_data)
+    session.add(im_obj)
+    session.commit()
+    return im_obj
+
+
+def create_input(input_data, session):
+    input_obj = Input(
+        **input_data
+    )
+    session.add(input_obj)
+    session.commit()
+    return input_obj
 
 
 def create_event(event_data, session):

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -1760,7 +1760,8 @@ class Process_Media():
             new_temp_filename = self.input.temp_dir_path_and_filename
             with open(self.input.temp_dir_path_and_filename, 'rb') as f:
                 f.seek(63)
-                compress = (f.read(1) == b'\x01')
+                read_value = f.read(1)
+                compress = (read_value == b'\x01')
 
             # If compress_level 0 or 1 write file with compress_level=2 and point to new file instead
             if (compress):
@@ -1773,6 +1774,7 @@ class Process_Media():
                                     '.png'
             imwrite(new_temp_filename, np.asarray(self.raw_numpy_image), compress_level=3)
         else:
+            raise NotImplementedError(f'Extension: {self.input.extension} not supported yet.')
             pass
 
         data_tools.upload_to_cloud_storage(
@@ -1783,6 +1785,7 @@ class Process_Media():
 
         self.new_image.url_signed = data_tools.build_secure_url(self.new_image.url_signed_blob_path,
                                                                 self.new_image.url_signed_expiry)
+        return new_temp_filename
 
     def save_text_tokens(self, raw_text: str, file: File) -> None:
         # By Default, file has NLTK tokenizer.

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -1842,9 +1842,9 @@ class Process_Media():
 
         thumbnail_image = imresize(self.raw_numpy_image, (160, 160))
 
-        new_temp_filename = self.input.temp_dir + "/resized" + ".png"
+        new_temp_filename = self.input.temp_dir + "/resized" + ".jpg"
 
-        imwrite(new_temp_filename, thumbnail_image, compress_level=6)
+        imwrite(new_temp_filename, thumbnail_image, quality=95)
 
         # Build URL
         url_signed_thumb = data_tools.build_secure_url(self.new_image.url_signed_thumb_blob_path,

--- a/walrus/tests/methods/input/test_process_media.py
+++ b/walrus/tests/methods/input/test_process_media.py
@@ -1,8 +1,12 @@
+import tempfile
 from walrus.tests.test_utils import testing_setup
 from shared.tests.test_utils import common_actions, data_mocking
 from methods.input import process_media
+from methods.input.process_media import imwrite
 from unittest.mock import patch
 from shared.regular import regular_log
+import numpy as np
+from shared.settings import settings
 
 
 class TestProcessMedia(testing_setup.DiffgramBaseTestCase):
@@ -99,3 +103,103 @@ class TestProcessMedia(testing_setup.DiffgramBaseTestCase):
                 allow_csv = allow_csv
             )
             self.assertEqual(result, 'existing_instances')
+
+    def test_save_raw_image_file(self):
+        log = regular_log.default()
+        # Test PNG Files
+        temp = tempfile.NamedTemporaryFile(suffix = '.png')
+        with open(temp.name, 'wb') as f:
+            f.seek(63)
+            f.write(b'\x01')
+        input_obj = data_mocking.create_input(
+            {
+                'project_id': self.project.id,
+                'extension': '.png',
+                'temp_dir_path_and_filename': temp.name,
+                'temp_dir': '/tmp'
+            },
+            session = self.session)
+        pm = process_media.Process_Media(
+            input_id = input_obj.id,
+            input = input_obj,
+            project_id = self.project.id,
+            session = self.session,
+        )
+        pm.new_image = data_mocking.create_image({
+            'original_filename': 'test_img.png'
+        }, session = self.session)
+        with patch.object(process_media, 'imwrite') as mock1:
+            with patch.object(process_media.data_tools, 'upload_to_cloud_storage') as mock2:
+                new_temp_filename = pm.save_raw_image_file()
+                self.assertEqual(pm.new_image.url_signed_blob_path,
+                                 f'{settings.PROJECT_IMAGES_BASE_DIR}{str(self.project.id)}/{str(pm.new_image.id)}')
+                mock1.assert_called_with(new_temp_filename, np.asarray(pm.raw_numpy_image), compress_level = 2)
+                mock2.assert_called_with(temp_local_path = new_temp_filename,
+                                         blob_path = pm.new_image.url_signed_blob_path,
+                                         content_type = "image/jpg")
+
+        # Test JPG Files
+        temp = tempfile.NamedTemporaryFile(suffix = '.jpg')
+        with open(temp.name, 'wb') as f:
+            f.seek(63)
+            f.write(b'\x01')
+        input_obj = data_mocking.create_input(
+            {
+                'project_id': self.project.id,
+                'extension': '.jpg',
+                'temp_dir_path_and_filename': temp.name,
+                'temp_dir': '/tmp'
+            },
+            session = self.session)
+        pm = process_media.Process_Media(
+            input_id = input_obj.id,
+            input = input_obj,
+            project_id = self.project.id,
+            session = self.session,
+        )
+        pm.new_image = data_mocking.create_image({
+            'original_filename': 'test_img.jpg'
+        }, session = self.session)
+        with patch.object(process_media, 'imwrite') as mock1:
+            with patch.object(process_media.data_tools, 'upload_to_cloud_storage') as mock2:
+                new_temp_filename = pm.save_raw_image_file()
+                self.assertEqual(pm.new_image.url_signed_blob_path,
+                                 f'{settings.PROJECT_IMAGES_BASE_DIR}{str(self.project.id)}/{str(pm.new_image.id)}')
+                self.assertEqual(mock1.call_count, 0)
+                mock2.assert_called_with(temp_local_path = new_temp_filename,
+                                         blob_path = pm.new_image.url_signed_blob_path,
+                                         content_type = "image/jpg")
+
+
+        # Test BMP, TIF, TTF
+        for file_extension in ['.bmp', '.tif', '.tiff']:
+            temp = tempfile.NamedTemporaryFile(suffix = file_extension)
+            with open(temp.name, 'wb') as f:
+                f.seek(63)
+                f.write(b'\x01')
+            input_obj = data_mocking.create_input(
+                {
+                    'project_id': self.project.id,
+                    'extension': file_extension,
+                    'temp_dir_path_and_filename': temp.name,
+                    'temp_dir': '/tmp'
+                },
+                session = self.session)
+            pm = process_media.Process_Media(
+                input_id = input_obj.id,
+                input = input_obj,
+                project_id = self.project.id,
+                session = self.session,
+            )
+            pm.new_image = data_mocking.create_image({
+                'original_filename': f'test_img{file_extension}'
+            }, session = self.session)
+            with patch.object(process_media, 'imwrite') as mock1:
+                with patch.object(process_media.data_tools, 'upload_to_cloud_storage') as mock2:
+                    new_temp_filename = pm.save_raw_image_file()
+                    self.assertEqual(pm.new_image.url_signed_blob_path,
+                                     f'{settings.PROJECT_IMAGES_BASE_DIR}{str(self.project.id)}/{str(pm.new_image.id)}')
+                    mock1.assert_called_with(new_temp_filename, np.asarray(pm.raw_numpy_image), compress_level = 3)
+                    mock2.assert_called_with(temp_local_path = new_temp_filename,
+                                             blob_path = pm.new_image.url_signed_blob_path,
+                                             content_type = "image/jpg")


### PR DESCRIPTION
This PR will close #240  I think.

.bmp, .tif and .tiff files will be supported. Original file will go to raw files and a PNG with compress_level=4 is generated because it feels like a good tradeoff between the required processing power and the space saved. Feel free to adjust this as needed. 

Because thumbnail would be generated with the native file extension this approach didn't work. All thumbnails will be generated as JPG with quality=95.

If a new extension gets requested it can be added to the same list as .bmp, .tif and .tiff as long as imageio can read and write it the same way as the other extensions.

@PJEstrada I changed the thumbnail extension to JPG because it is a thumbnail and you don't really see the difference with PNG. It is slightly smaller and blazing fast. It is in a separate commit, so you can also get the thumbnails as .PNG.

Here is a small comparison between a JPG and PNG thumbnail to visualize it
![image](https://user-images.githubusercontent.com/1612886/154782571-d5488271-174e-4cf5-882d-c24d7427fa0b.png)
