### PR TITLE
Make Issues Concept more Visible & Fix global attribute label file permission

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -358,6 +358,7 @@
             <v-expansion-panel-content>
 
               <tooltip_button
+                  v-if="show_modify_an_issue != true"
                   tooltip_message="New Issue"
                   datacy="new_issue_in_side_panel"
                   @click="show_modify_an_issue=true"

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -274,42 +274,7 @@
             :instance="selected_instance_for_history"
           >
           </instance_history_sidepanel>
-          <create_issue_panel
-            :project_string_id="
-              project_string_id
-                ? project_string_id
-                : this.$store.state.project.current.project_string_id
-            "
-            v-show="show_issue_panel == true && !current_issue"
-            :instance_list="instance_list"
-            :task="task"
-            :file="file"
-            :frame_number="this.video_mode ? this.current_frame : undefined"
-            :mouse_position="issue_mouse_position"
-            @new_issue_created="refresh_issues_sidepanel"
-            @open_side_panel="open_issue_panel"
-            @close_issue_panel="close_issue_panel"
-          ></create_issue_panel>
-          <view_edit_issue_panel
-            v-if="!loading"
-            v-show="show_issue_panel == true && current_issue"
-            :project_string_id="
-              project_string_id
-                ? project_string_id
-                : this.$store.state.project.current.project_string_id
-            "
-            :task="task"
-            :instance_list="instance_list"
-            :current_issue_id="current_issue ? current_issue.id : undefined"
-            :file="file"
-            @close_view_edit_panel="close_view_edit_issue_panel"
-            @start_attach_instance_edition="start_attach_instance_edition"
-            @update_issues_list="update_issues_list"
-            @stop_attach_instance_edition="stop_attach_instance_edition"
-            @update_canvas="update_canvas"
-            ref="view_edit_issue_panel"
-          ></view_edit_issue_panel>
-
+          
           <v-divider></v-divider>
 
         <v-expansion-panels
@@ -333,7 +298,7 @@
                 mdi-language-javascript
               </v-icon>
 
-              <h4>Interactive Automations</h4>
+              <h4>Scripts</h4>
 
               <v-spacer></v-spacer>
 
@@ -359,22 +324,107 @@
           </v-expansion-panel>
         </v-expansion-panels>
 
+        <v-expansion-panels
+          v-model="issues_expansion_panel"
+          :accordion="true"
+          :inset="false"
+          :multiple="false"
+          :focusable="true"
+          :disabled="false"
+          :flat="true"
+          :hover="false"
+          :tile="true"
+        >
+          <v-expansion-panel>
 
-          <issues_sidepanel
-            :minimized="minimize_issues_sidepanel"
-            :project_string_id="
-              project_string_id
-                ? project_string_id
-                : this.$store.state.project.current.project_string_id
-            "
-            :task="task"
-            :file="file"
-            @view_issue_detail="open_view_edit_panel"
-            @issues_fetched="issues_fetched"
-            @minimize_issues_panel="minimize_issues_sidepanel = true"
-            @maximize_issues_panel="minimize_issues_sidepanel = false"
-            ref="issues_sidepanel"
-          ></issues_sidepanel>
+            <v-expansion-panel-header
+              data-cy="show_issues_panel_button"
+              class="d-flex justify-start pa-0 sidebar-accordeon-header align-center">
+
+              <v-icon left class="ml-5 flex-grow-0" color="primary" size="18">
+                mdi-comment-multiple
+              </v-icon>
+
+              <h4>Issues</h4>
+
+              <v-spacer></v-spacer>
+
+              <v-chip x-small class="d-flex justify-center flex-grow-0">
+                  {{ issues_list.length }}
+              </v-chip>
+
+            </v-expansion-panel-header>
+
+            <v-expansion-panel-content>
+
+              <tooltip_button
+                  tooltip_message="New Issue"
+                  datacy="new_issue_in_side_panel"
+                  @click="show_modify_an_issue=true"
+                  icon="add"
+                  :icon_style="true"
+                  color="primary"
+                              >
+              </tooltip_button>
+
+             <create_issue_panel
+              :project_string_id="
+                project_string_id
+                  ? project_string_id
+                  : this.$store.state.project.current.project_string_id
+              "
+              v-show="show_modify_an_issue == true && !current_issue"
+              :instance_list="instance_list"
+              :task="task"
+              :file="file"
+              :frame_number="this.video_mode ? this.current_frame : undefined"
+              :mouse_position="issue_mouse_position"
+              @new_issue_created="refresh_issues_sidepanel"
+              @open_side_panel="open_issue_panel"
+              @close_issue_panel="close_issue_panel"
+            ></create_issue_panel>
+
+            <view_edit_issue_panel
+              v-if="!loading"
+              v-show="show_modify_an_issue == true && current_issue"
+              :project_string_id="
+                project_string_id
+                  ? project_string_id
+                  : this.$store.state.project.current.project_string_id
+              "
+              :task="task"
+              :instance_list="instance_list"
+              :current_issue_id="current_issue ? current_issue.id : undefined"
+              :file="file"
+              @close_view_edit_panel="close_view_edit_issue_panel"
+              @start_attach_instance_edition="start_attach_instance_edition"
+              @update_issues_list="update_issues_list"
+              @stop_attach_instance_edition="stop_attach_instance_edition"
+              @update_canvas="update_canvas"
+              ref="view_edit_issue_panel"
+            ></view_edit_issue_panel>
+
+            <!-- List -->
+            <issues_sidepanel
+              :project_string_id="
+                project_string_id
+                  ? project_string_id
+                  : this.$store.state.project.current.project_string_id
+              "
+              :task="task"
+              :file="file"
+              @view_issue_detail="open_view_edit_panel"
+              @issues_fetched="issues_fetched"
+              ref="issues_sidepanel"
+            ></issues_sidepanel>
+
+
+
+            </v-expansion-panel-content>
+
+          </v-expansion-panel>
+        </v-expansion-panels>
+
         </v-navigation-drawer>
 
         <!-- TODO would want to think a bit about how to block scrolling
@@ -1089,8 +1139,8 @@ export default Vue.extend({
 
       this.clear_selected();
     },
-    show_issue_panel: function () {
-      if (this.show_issue_panel == true) {
+    show_modify_an_issue: function () {
+      if (this.show_modify_an_issue == true) {
         this.label_settings.show_ghost_instances = false;
         this.label_settings.ghost_instances_closed_by_open_view_edit_panel =
           true;
@@ -1153,7 +1203,7 @@ export default Vue.extend({
       instance_context: new InstanceContext(),
       instance_template_draw_started: false,
       mouse_down_delta_event: { x: 0, y: 0 },
-      issues_list: undefined,
+      issues_list: [],
       canvas_alert_x: undefined,
       canvas_alert_y: undefined,
       original_edit_instance: undefined,
@@ -1170,7 +1220,7 @@ export default Vue.extend({
       request_change_current_instance: null,
       current_issue: undefined,
       share_dialog_open: false,
-      show_issue_panel: false,
+      show_modify_an_issue: false,
       snackbar_issues: false, // Controls the display of snackbar with info message when selecting instance on issues.
       trigger_refresh_current_instance: null,
       ellipse_hovered_corner: undefined,
@@ -1297,7 +1347,7 @@ export default Vue.extend({
       annotations_loading: false,
       save_loading_image: false,
 
-      minimize_issues_sidepanel: false,
+      issues_expansion_panel: false,
 
       source_control_menu: false,
 
@@ -2836,7 +2886,7 @@ export default Vue.extend({
     },
     open_view_edit_panel(issue) {
       // This boolean controls if issues create/edit panel is shown or hidden.
-      this.show_issue_panel = true;
+      this.show_modify_an_issue = true;
 
       // Case for edit/view mode.
       this.current_issue = issue;
@@ -2891,7 +2941,8 @@ export default Vue.extend({
     },
     open_issue_panel(mouse_position) {
       // This boolean controls if issues create/edit panel is shown or hidden.
-      this.show_issue_panel = true;
+      this.show_modify_an_issue = true
+      this.issues_expansion_panel = 0
       // Close context menu and set select instance mode
       this.show_context_menu = false;
       this.issue_mouse_position = mouse_position;
@@ -2915,13 +2966,13 @@ export default Vue.extend({
     },
     close_view_edit_issue_panel() {
       this.current_issue = undefined;
-      this.show_issue_panel = false;
+      this.show_modify_an_issue = false;
       this.label_settings.allow_multiple_instance_select = false;
       this.$store.commit("set_view_issue_mode", false);
       this.$store.commit("set_instance_select_for_issue", false);
     },
     close_issue_panel() {
-      this.show_issue_panel = false;
+      this.show_modify_an_issue = false;
       this.$store.commit("set_instance_select_for_issue", false);
       this.snackbar_issues = false;
       this.issue_mouse_position = undefined;

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -313,7 +313,6 @@
           <v-divider></v-divider>
 
         <v-expansion-panels
-          v-model="userscript_minimized"
           :accordion="true"
           :inset="false"
           :multiple="false"
@@ -328,8 +327,6 @@
             <v-expansion-panel-header
               data-cy="show_userscript_panel_button"
               class="d-flex justify-start pa-0 pr-1 align-center"
-              @click="userscript_minimized = !userscript_minimized"
-              v-if="userscript_minimized"
               style="border-top: 1px solid #e0e0e0;border-bottom: 1px solid #e0e0e0">
 
               <v-icon left class="ml-4 flex-grow-0" color="primary" size="18">
@@ -345,7 +342,6 @@
             <v-expansion-panel-content>
 
               <userscript
-                v-show="!userscript_minimized"
                 :project_string_id_prop="project_string_id"
                 :create_instance="event_create_instance"
                 :current_userscript_prop="get_userscript()"
@@ -1141,8 +1137,6 @@ export default Vue.extend({
       hovered_figure_id: null,
       parent_merge_instance_index: null,
       instances_to_merge: [],
-
-      userscript_minimized: true,
 
       event_create_instance: undefined,
 

--- a/frontend/src/components/discussions/create_issue_panel.vue
+++ b/frontend/src/components/discussions/create_issue_panel.vue
@@ -1,146 +1,133 @@
 <template>
   <div id="create_issue_panel">
-  <v-container max-width="750px">
-    <v-card>
-      <v-card-title class="headline d-flex align-center">
-        <v-icon size="36" color="warning">mdi-alert</v-icon>
-        Create Issue
-      </v-card-title>
+    <v-card
+            elevation=0
+            max-width="750px"
+            >
+
       <v-card-text>
-        <v-container class="d-flex flex-column">
-
-          <v-text-field
-                v-model="current_issue.title"
-                label="Issue Name"
-                @focus="$store.commit('set_user_is_typing_or_menu_open', true)"
-                @blur="$store.commit('set_user_is_typing_or_menu_open', false)"
-                        >
-          </v-text-field>
-
-          <p class="ma-0"><strong>Attached Instances</strong></p>
-          <v-container class="d-flex flex-wrap">
-            <v-chip color="primary" small v-for="instance in selected_instances">
-              <template>
-                <span style="font-size: 10px">
-                    ID: {{instance.id}}
-                </span>
-              </template>
-            </v-chip>
-          </v-container>
-        </v-container>
-        <v-container>
-          <v-container  class="d-flex justify-end pb-0 pr-4">
-
-            <editor-menu-bar :editor="editor" v-slot="{ commands, isActive }">
-
-              <div class="menubar d-flex justify-end flex-wrap">
-
-                <v-btn
-                  class="menubar__button pa-0"
-                  style="width: 20px"
-                  icon
-                  :class="{ 'is-active': isActive.bold() }"
-                  @click="commands.bold"
-                >
-                  <v-icon size="18">mdi-format-bold</v-icon>
-                </v-btn>
-
-                <v-btn
-                  class="menubar__button pa-0"
-                  style="width: 20px"
-                  icon
-                  :class="{ 'is-active': isActive.italic() }"
-                  @click="commands.italic"
-                >
-                  <v-icon size="18">mdi-format-italic</v-icon>
-                </v-btn>
-                <v-btn
-                  class="menubar__button pa-0"
-                  style="width: 20px"
-                  icon
-                  :class="{ 'is-active': isActive.underline() }"
-                  @click="commands.underline"
-                >
-                  <v-icon size="18" name="underline" >mdi-format-underline</v-icon>
-                </v-btn>
-                <v-btn
-                  class="menubar__button pa-0"
-                  style="width: 20px"
-                  icon
-                  :class="{ 'is-active': isActive.bullet_list() }"
-                  @click="commands.bullet_list"
-                >
-                  <v-icon size="18" name="underline" >mdi-format-list-bulleted</v-icon>
-                </v-btn>
-
-                <v-btn
-                  class="menubar__button pa-0"
-                  style="width: 20px"
-                  icon
-                  :class="{ 'is-active': isActive.strike() }"
-                  @click="commands.strike"
-                >
-                  <v-icon size="18">mdi-format-strikethrough</v-icon>
-                </v-btn>
-                <v-btn
-                  class="menubar__button pa-0"
-                  style="width: 20px"
-                  icon
-                  :class="{ 'is-active': isActive.code_block() }"
-                  @click="commands.code_block"
-                >
-                  <v-icon size="18">mdi-xml</v-icon>
-                </v-btn>
-                <v-btn
-                  class="menubar__button pa-0"
-                  style="width: 20px"
-                  icon
-                  :class="{ 'is-active': isActive.paragraph() }"
-                  @click="commands.paragraph"
-                >
-                  <v-icon size="18">mdi-format-paragraph</v-icon>
-                </v-btn>
-                <v-btn
-                  class="menubar__button pa-0"
-                  style="width: 20px"
-                  icon
-                  :class="{ 'is-active': isActive.heading({ level: 1 }) }"
-                  @click="commands.heading({ level: 1 })"
-                >
-                  <v-icon size="18">mdi-format-header-1</v-icon>
-                </v-btn>
-
-                <v-btn
-                  class="menubar__button pa-0"
-                  style="width: 20px"
-                  icon
-                  :class="{ 'is-active': isActive.heading({ level: 2 }) }"
-                  @click="commands.heading({ level: 2 })"
-                >
-                  <v-icon size="18">mdi-format-header-2</v-icon>
-                </v-btn>
-
-                <v-btn
-                  class="menubar__button pa-0"
-                  style="width: 20px"
-                  icon
-                  :class="{ 'is-active': isActive.heading({ level: 3 }) }"
-                  @click="commands.heading({ level: 3 })"
-                >
-                  <v-icon size="18">mdi-format-header-3</v-icon>
-                </v-btn>
 
 
-              </div>
-            </editor-menu-bar>
+      <v-layout class="pt-0">
+        <v-text-field
+              v-model="current_issue.title"
+              label="Issue Name"
+              @focus="$store.commit('set_user_is_typing_or_menu_open', true)"
+              @blur="$store.commit('set_user_is_typing_or_menu_open', false)"
+                      >
+        </v-text-field>
+      </v-layout>
+
+      <v-layout>
+        <editor-menu-bar :editor="editor" v-slot="{ commands, isActive }">
+
+          <div class="menubar d-flex justify-end flex-wrap">
+
+            <v-btn
+              class="menubar__button pa-0"
+              style="width: 20px"
+              icon
+              :class="{ 'is-active': isActive.bold() }"
+              @click="commands.bold"
+            >
+              <v-icon size="18">mdi-format-bold</v-icon>
+            </v-btn>
+
+            <v-btn
+              class="menubar__button pa-0"
+              style="width: 20px"
+              icon
+              :class="{ 'is-active': isActive.italic() }"
+              @click="commands.italic"
+            >
+              <v-icon size="18">mdi-format-italic</v-icon>
+            </v-btn>
+            <v-btn
+              class="menubar__button pa-0"
+              style="width: 20px"
+              icon
+              :class="{ 'is-active': isActive.underline() }"
+              @click="commands.underline"
+            >
+              <v-icon size="18" name="underline" >mdi-format-underline</v-icon>
+            </v-btn>
+            <v-btn
+              class="menubar__button pa-0"
+              style="width: 20px"
+              icon
+              :class="{ 'is-active': isActive.bullet_list() }"
+              @click="commands.bullet_list"
+            >
+              <v-icon size="18" name="underline" >mdi-format-list-bulleted</v-icon>
+            </v-btn>
+
+            <v-btn
+              class="menubar__button pa-0"
+              style="width: 20px"
+              icon
+              :class="{ 'is-active': isActive.strike() }"
+              @click="commands.strike"
+            >
+              <v-icon size="18">mdi-format-strikethrough</v-icon>
+            </v-btn>
+            <v-btn
+              class="menubar__button pa-0"
+              style="width: 20px"
+              icon
+              :class="{ 'is-active': isActive.code_block() }"
+              @click="commands.code_block"
+            >
+              <v-icon size="18">mdi-xml</v-icon>
+            </v-btn>
+            <v-btn
+              class="menubar__button pa-0"
+              style="width: 20px"
+              icon
+              :class="{ 'is-active': isActive.paragraph() }"
+              @click="commands.paragraph"
+            >
+              <v-icon size="18">mdi-format-paragraph</v-icon>
+            </v-btn>
+            <v-btn
+              class="menubar__button pa-0"
+              style="width: 20px"
+              icon
+              :class="{ 'is-active': isActive.heading({ level: 1 }) }"
+              @click="commands.heading({ level: 1 })"
+            >
+              <v-icon size="18">mdi-format-header-1</v-icon>
+            </v-btn>
+
+            <v-btn
+              class="menubar__button pa-0"
+              style="width: 20px"
+              icon
+              :class="{ 'is-active': isActive.heading({ level: 2 }) }"
+              @click="commands.heading({ level: 2 })"
+            >
+              <v-icon size="18">mdi-format-header-2</v-icon>
+            </v-btn>
+
+            <v-btn
+              class="menubar__button pa-0"
+              style="width: 20px"
+              icon
+              :class="{ 'is-active': isActive.heading({ level: 3 }) }"
+              @click="commands.heading({ level: 3 })"
+            >
+              <v-icon size="18">mdi-format-header-3</v-icon>
+            </v-btn>
 
 
-          </v-container>
-          <editor-content :editor="editor"
-                          class="discussion-create">
+          </div>
+        </editor-menu-bar>
+      </v-layout>
+
+      <editor-content :editor="editor"
+                      class="discussion-create">
 
           </editor-content>
-        </v-container>
+
 
       </v-card-text>
 
@@ -172,8 +159,27 @@
         </v-btn
         >
       </v-card-actions>
+
+      <div v-if="selected_instances && selected_instances.length > 0">
+        <p class="ma-0"><strong>Attached Instances</strong></p>
+        <v-container class="d-flex flex-wrap">
+          <v-chip color="primary" small v-for="instance in selected_instances">
+            <template>
+              <span style="font-size: 10px">
+                  ID: {{instance.id}}
+              </span>
+            </template>
+          </v-chip>
+        </v-container>
+      </div>
+      <div v-else>
+        <p>
+          No Annotations Selected.
+        </p>
+      </div>
+
+
     </v-card>
-  </v-container>
   </div>
 </template>
 

--- a/frontend/src/components/discussions/issues_sidepanel.vue
+++ b/frontend/src/components/discussions/issues_sidepanel.vue
@@ -1,73 +1,66 @@
 <template>
-  <div v-cloak v-if="issues_list.length > 0">
+  <div v-cloak>
 
+    <v-container fluid style="border: 1px solid #ababab"
+                 v-if="!loading && issues_list.length == 0"
+                 class="d-flex flex-column align-center justify-center ma-0">
+      <h1>No Issues.</h1>
+      <v-icon size="250" color="green">mdi-check</v-icon>
+    </v-container>
 
+    <v-expand-transition>
+      <v-card-text class="pa-0" >
 
-        <v-card-title class="d-flex justify-start align-center">
+        <v-container  v-if="!loading && issues_list.length > 0" class="d-flex flex-column pa-1">
 
-          <v-icon left color="primary" size="28">mdi-comment-multiple</v-icon>
-          Discussions
+          <v-select :items="status_list"
+                    v-model="status_filter"
+                    label="Status"
+                    height="20"
+                    class="align-self-end pa-0"
+                    style="width: 30%; font-size: 12px; min-height: 30px !important; justify-self: flex-end; margin-bottom: auto"
+                    item-text="text"
+                    item-value="value">
+          </v-select>
+          <!--
+            Please note that this code is almost same as issues_table.vue. Decided to leave it duplicate since I have
+            the feeling that both table might grow in different directions in the future since one is on the studio
+            and the other is in the context of the job_detail or project context.
+          -->
+            <regular_table
+              style="max-height: 350px; overflow-y: auto"
+              :item_list="filtered_issues_list"
+              :column_list="columns_issues"
+              :items_per_page="5"
+              v-model="selected_cols"
+              :header_list="headers_issues">
 
-          <v-spacer></v-spacer>
+              <template slot="title" slot-scope="props">
+                <div class="d-flex align-center">
+                  <v-icon color="success" class="mr-4" v-if="props.item.status === 'closed'">mdi-lock-check</v-icon>
+                  <v-icon color="warning" class="mr-4" v-else>mdi-alert</v-icon>
+                  <div class="d-flex flex-column justify-end pt-4" style="height: 100%">
+                    <a class="font-weight-bold" @click="view_issue_detail(props.item)"> {{props.item.title}} </a>
+                    <p style="font-size: 9px; font-weight: bold; color: #323232">
+                      Opened: {{props.item.created_time| moment("ddd, MMMM Do YYYY")}} {{props.item.user ? `By: ${props.item.user.first_name} ${props.item.user.last_name}` : ''}}
+                    </p>
+                  </div>
+                </div>
+              </template>
 
-          <v-btn @click="maximize_panel" v-if="minimized" icon>
-            <v-icon>mdi-chevron-down</v-icon>
-          </v-btn>
-          <v-btn @click="minimize_panel" v-if="!minimized" icon>
-            <v-icon>mdi-chevron-up</v-icon>
-          </v-btn>
-        </v-card-title>
-        <v-expand-transition>
-          <v-card-text v-show="!minimized" class="pa-0" >
-            <v-container  v-if="!loading && issues_list" class="d-flex flex-column pa-1">
-              <v-select :items="status_list"
-                        v-model="status_filter"
-                        label="Status"
-                        height="20"
-                        class="align-self-end pa-0"
-                        style="width: 30%; font-size: 12px; min-height: 30px !important; justify-self: flex-end; margin-bottom: auto"
-                        item-text="text"
-                        item-value="value">
-              </v-select>
-              <!--
-                Please note that this code is almost same as issues_table.vue. Decided to leave it duplicate since I have
-                the feeling that both table might grow in different directions in the future since one is on the studio
-                and the other is in the context of the job_detail or project context.
-              -->
-                <regular_table
-                  style="max-height: 350px; overflow-y: auto"
-                  :item_list="filtered_issues_list"
-                  :column_list="columns_issues"
-                  :items_per_page="5"
-                  v-model="selected_cols"
-                  :header_list="headers_issues">
+            </regular_table>
 
-                  <template slot="title" slot-scope="props">
-                    <div class="d-flex align-center">
-                      <v-icon color="success" class="mr-4" v-if="props.item.status === 'closed'">mdi-lock-check</v-icon>
-                      <v-icon color="warning" class="mr-4" v-else>mdi-alert</v-icon>
-                      <div class="d-flex flex-column justify-end pt-4" style="height: 100%">
-                        <a class="font-weight-bold" @click="view_issue_detail(props.item)"> {{props.item.title}} </a>
-                        <p style="font-size: 9px; font-weight: bold; color: #323232">
-                          Opened: {{props.item.created_time| moment("ddd, MMMM Do YYYY")}} {{props.item.user ? `By: ${props.item.user.first_name} ${props.item.user.last_name}` : ''}}
-                        </p>
-                      </div>
-                    </div>
-                  </template>
+        </v-container>
+      </v-card-text>
+    </v-expand-transition>
 
-                </regular_table>
+    <!-- And minimized false because otherwise when saving it
+      "pushes" it down and is visually distracting. question if it's better
+      to have this in expand-transition then all game for that. -->
+    <v-skeleton-loader :loading="loading" type="table-row@3"
+          v-if="loading && minimized == false">
 
-            </v-container>
-          </v-card-text>
-        </v-expand-transition>
-
-        <!-- And minimized false because otherwise when saving it
-          "pushes" it down and is visually distracting. question if it's better
-          to have this in expand-transition then all game for that. -->
-        <v-skeleton-loader :loading="loading" type="table-row@3"
-              v-if="loading && minimized == false">
-
-        </v-skeleton-loader>
+    </v-skeleton-loader>
 
   </div>
 </template>

--- a/frontend/src/components/discussions/view_edit_issue_panel.vue
+++ b/frontend/src/components/discussions/view_edit_issue_panel.vue
@@ -1,5 +1,4 @@
 <template>
-  <v-container fluid>
     <v-card class="d-flex flex-column">
       <v_error_multiple :error="update_attachments_error">
       </v_error_multiple>
@@ -140,9 +139,6 @@
       </div>
 
     </v-card>
-
-
-  </v-container>
 </template>
 
 <script>

--- a/frontend/src/components/discussions/view_edit_issue_panel.vue
+++ b/frontend/src/components/discussions/view_edit_issue_panel.vue
@@ -1,5 +1,6 @@
 <template>
-    <v-card class="d-flex flex-column">
+    <v-card v-if="current_issue"
+            class="d-flex flex-column">
       <v_error_multiple :error="update_attachments_error">
       </v_error_multiple>
       <v-progress-circular v-if="loading_get_issue" :indeterminate="true" class="ma-8 align-self-center justify-self-center align-center"></v-progress-circular>
@@ -139,6 +140,7 @@
       </div>
 
     </v-card>
+
 </template>
 
 <script>

--- a/frontend/src/utils/instance_utils.js
+++ b/frontend/src/utils/instance_utils.js
@@ -40,7 +40,7 @@ export const initialize_instance_object = function(instance, component_ctx, scen
     return initialized_instance
   }
   else if (instance.type === 'global') {
-    let new_global_instance = this.new_global_instance();
+    let new_global_instance = component_ctx.new_global_instance();
     new_global_instance.populate_from_instance_obj(instance)
     return new_global_instance
   }

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -766,6 +766,11 @@ class Annotation_Update():
 
         if self.instance.label_file_id in self.allowed_label_file_id_list:
             return True
+
+        if self.instance.type == "global":
+            self.instance.label_file_id = None      # Ensure is None for Security
+            return True
+
         self.log['error']['valid_label_file'] = "Permission issue with " + \
                                                 str(self.instance.label_file_id) + " label_file_id."
         return False
@@ -1011,7 +1016,7 @@ class Annotation_Update():
                         elm['label_file_id']['required'] = False
 
             if self.instance_proposed.get('type') == 'global':
-                self.instance_proposed['label_file_id'] = -1  # to bypass check
+                self.instance_proposed['label_file_id'] = -1  # to bypass input type check
 
             self.log, input = regular_input.input_check_many(
                 spec_list = self.per_instance_spec_list,


### PR DESCRIPTION
### Fixes
1) Fix global attribute label file permission https://github.com/diffgram/diffgram/commit/05b7d1f09dfb1d3318c4f2f6ff049e6f71f29cd7
2) Fix undefined https://github.com/diffgram/diffgram/commit/37b756379b683e8bf5abb886543d4b66592b0f64
3) Fix bug with Scripts expansion panel https://github.com/diffgram/diffgram/commit/fef0fdf12697170dfa9e5fe8618c0c210abe2686

### Make issues more visible by default 
rest of commits starting with -> 
https://github.com/diffgram/diffgram/commit/35c8e8b614c1e05fccd955e9d6ee0f8e9d745117

To recap highlights of that:
1) Make issues according viewable by default. Before had to create an issue to see the existing issues (in this context).
2) Add a "new issue" button. This means a user does not have to know to right click on canvas. Also makes this accessible to other media types more easily
3) Add a "no issues" style art to visual. Fix v-cloack

#### Now visible as an expansion panel:
Key point -> it wasn't visible here at all before. To even get the left to come up, had to click on canvas and know about feature. 
![image](https://user-images.githubusercontent.com/18080164/154782795-cc5ceeef-b1e5-4c67-a2f6-ccb7ed49acd8.png)


#### Before and After
UI/UX wise now this should make it easier for the user to dive into describing the issue.
![image](https://user-images.githubusercontent.com/18080164/154782737-d92ef8a2-aa9a-4b65-8749-eabb88932630.png)


### Notes
1) Going through this discovered some various unexpected behavior. As far as I can tell it's not directly from this update, but just more visible now that the components themselves are more visible. (for example the `issues_list` does not seem to update very well.)
