### PR TITLE
fix: add unit testing DB url

### DIFF
--- a/.github/workflows/diffgram_testing.yaml
+++ b/.github/workflows/diffgram_testing.yaml
@@ -21,6 +21,7 @@ jobs:
       env:
         NODE_ENV: development
         DATABASE_URL: postgresql+psycopg2://postgres:postgres@postgres/diffgram_unit_tests?sslmode=disable
+        UNIT_TESTING_DATABASE_URL: postgresql+psycopg2://postgres:postgres@postgres/diffgram_unit_tests?sslmode=disable
         PYTHONPATH: /__w/diffgram/default
         DIFFGRAM_SYSTEM_MODE: testing
         GOOGLE_APPLICATION_CREDENTIALS: /gcp/gcloud-service-key.json
@@ -74,6 +75,7 @@ jobs:
       env:
         NODE_ENV: development
         DATABASE_URL: postgresql+psycopg2://postgres:postgres@postgres/diffgram_unit_tests?sslmode=disable
+        UNIT_TESTING_DATABASE_URL: postgresql+psycopg2://postgres:postgres@postgres/diffgram_unit_tests?sslmode=disable
         PYTHONPATH: /__w/diffgram/walrus
         DIFFGRAM_SYSTEM_MODE: testing
         GOOGLE_APPLICATION_CREDENTIALS: /gcp/gcloud-service-key.json

--- a/default/tests/conftest.py
+++ b/default/tests/conftest.py
@@ -13,6 +13,8 @@ os.chdir(init_config_path)
 if settings.DIFFGRAM_SYSTEM_MODE != 'testing':
     raise Exception('DIFFGRAM_SYSTEM_MODE must be in "testing" mode to perform any kind of test')
 
+if not settings.UNIT_TESTING_DATABASE_URL:
+    raise Exception('UNIT_TESTING_DATABASE_URL is not set. Please set this to your testing DB.')
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -21,10 +23,10 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    engine = create_engine(settings.DATABASE_URL)
-    print('Checking DB: {}'.format(settings.DATABASE_URL))
+    engine = create_engine(settings.UNIT_TESTING_DATABASE_URL)
+    print('Checking DB: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
     if not database_exists(engine.url):
-        print('Creating DB: {}'.format(settings.DATABASE_URL))
+        print('Creating DB: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
         create_database(engine.url)
         alembic_args = [
             '--raiseerr',
@@ -38,6 +40,6 @@ def pytest_configure(config):
 
 def pytest_unconfigure(config):
     if not config.getoption('--keep-db'):
-        print('Destroying database: {}'.format(settings.DATABASE_URL))
-        drop_database(settings.DATABASE_URL)
+        print('Destroying database: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
+        drop_database(settings.UNIT_TESTING_DATABASE_URL)
 

--- a/shared/settings/settings.py
+++ b/shared/settings/settings.py
@@ -26,6 +26,7 @@ NAME_EQUALS_MAIN = os.getenv('NAME_EQUALS_MAIN', False)  # Assumed to be running
 
 # Database Settings - Default to testing database
 DATABASE_URL = os.environ.get('DATABASE_URL', 'postgresql+psycopg2://postgres:postgres@127.0.0.1:5432/diffgram_testing')
+UNIT_TESTING_DATABASE_URL = os.environ.get('UNIT_TESTING_DATABASE_URL')
 DATABASE_CONNECTION_POOL_SIZE = int(os.getenv('DATABASE_CONNECTION_POOL_SIZE', 10))
 
 # System Internal Secrets

--- a/walrus/tests/conftest.py
+++ b/walrus/tests/conftest.py
@@ -15,18 +15,21 @@ os.chdir(init_config_path)
 if settings.DIFFGRAM_SYSTEM_MODE != 'testing':
     raise Exception('DIFFGRAM_SYSTEM_MODE must be in "testing" mode to perform any kind of test')
 
+if not settings.UNIT_TESTING_DATABASE_URL:
+    raise Exception('UNIT_TESTING_DATABASE_URL is not set. Please set this to your testing DB.')
+
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--keep-db", action="store_true", default=False, help="Don't destroy Database when finishing tests."
+        "--keep-db", action = "store_true", default = False, help = "Don't destroy Database when finishing tests."
     )
 
 
 def pytest_configure(config):
-    engine = create_engine(settings.DATABASE_URL)
-    print('Checking DB: {}'.format(settings.DATABASE_URL))
+    engine = create_engine(settings.UNIT_TESTING_DATABASE_URL)
+    print('Checking DB: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
     if not database_exists(engine.url):
-        print('Creating DB: {}'.format(settings.DATABASE_URL))
+        print('Creating DB: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
         create_database(engine.url)
         alembic_args = [
             '--raiseerr',
@@ -40,6 +43,5 @@ def pytest_configure(config):
 
 def pytest_unconfigure(config):
     if not config.getoption('--keep-db'):
-        print('Destroying database: {}'.format(settings.DATABASE_URL))
-        drop_database(settings.DATABASE_URL)
-
+        print('Destroying database: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
+        drop_database(settings.UNIT_TESTING_DATABASE_URL)


### PR DESCRIPTION
Changing this URL to be separate for system's url to prevent errors of wrongly running tests on an in-user diffgram DB