### PR TITLE
Remove old marketing toolbar and update redirects to landing page

### DIFF
--- a/default/methods/configs/is_open_source.py
+++ b/default/methods/configs/is_open_source.py
@@ -1,0 +1,13 @@
+try:
+    from methods.regular.regular_api import *
+except:
+    from default.methods.regular.regular_api import *
+
+
+@routes.route('/api/configs/is-open-source')
+def api_is_open_source():
+    is_open_source = settings.IS_OPEN_SOURCE
+
+    if is_open_source:
+        return jsonify({"is_open_source": True})
+    return jsonify({"is_open_source": False})

--- a/default/routes_init.py
+++ b/default/routes_init.py
@@ -147,6 +147,7 @@ def do_routes_importing():
 
     from methods.configs.mailgun_is_set import mailgun_is_set
     from methods.configs.admin_install_info import api_admin_install_info
+    from methods.configs.is_open_source import api_is_open_source
 
     from methods.task.credential.credential_type_new import new_credential_type_api
     from methods.task.credential.credential_list import credential_list_api

--- a/frontend/src/components/main_menu/menu.vue
+++ b/frontend/src/components/main_menu/menu.vue
@@ -248,17 +248,17 @@
             </tooltip_button>
 
 
-            <ahref_seo_optimal href="/contact"
-                               v-if="$store.state.org && !$store.state.org.current.id &&
-                       $store.state.builder_or_trainer.mode == 'builder'"
-            >
+
               <v-btn color="primary"
-                     text
+                     outlined
                      style="text-transform: none !important;"
+                     class="mr-2"
+                     @click="contact_us"
+                     v-if="$store.state.org && !$store.state.org.current.id && $store.state.builder_or_trainer.mode == 'builder'"
               >
-                Book A Demo
+                  Book A Demo
               </v-btn>
-            </ahref_seo_optimal>
+
 
             <ahref_seo_optimal href="/user/data_platform/new">
               <v-btn color="primary"
@@ -378,7 +378,7 @@
     watch: {
       '$store.state.user.logged_in': function (value) {
         if (value) this.get_avalible_projects()
-      },  
+      },
       '$route.path': function(value) {
         const do_not_display = value !== "/" && this.routes_without_menu.some(route => {
           return route.includes(value)
@@ -447,6 +447,9 @@
         const response = await getProjectList();
         const project_list = response.data.project_list;
         this.$store.commit("set_userProjects_list", project_list);
+      },
+      contact_us: function(){
+        window.open('https://diffgram.com/main/contact')
       }
     },
   });

--- a/frontend/src/components/main_menu/menu_marketing.vue
+++ b/frontend/src/components/main_menu/menu_marketing.vue
@@ -3,500 +3,215 @@
 
   <v-layout>
 
-    <v-menu v-model="why_menu"
-          offset-y
-          open-on-hover
-          attach
-          >
-
-      <template v-slot:activator="{ on }">
-        <v-btn v-on="on"
-               color="primary"
-                text
-               style="text-transform: none !important;"
-               >
-           Why
-        </v-btn>
-      </template>
-
-      <v-card>
-        <v-layout column>
-
-          <v-flex>
-            <ahref_seo_optimal href="/about">
-              <v-btn color="primary"
-                     text
-                     style="text-transform: none !important;"
-                     >
-                <v-icon left> mdi-compass-rose</v-icon>
-                Our Why
-              </v-btn>
-            </ahref_seo_optimal>
-          </v-flex>
-
-          <v-flex>
-
-            <ahref_seo_optimal href="/your_next_step">
-              <v-btn color="primary"
-                     text style="text-transform: none !important;">
-                <v-icon left> mdi-fast-forward</v-icon>
-                Your Next Step
-              </v-btn>
-            </ahref_seo_optimal>
-
-          </v-flex>
-
-          
-          <v-flex>
-
-            <ahref_seo_optimal href="/single_application">
-              <v-btn color="primary"
-                     text style="text-transform: none !important;">
-                <v-icon left> mdi-circle-slice-8</v-icon>
-                Single Application
-              </v-btn>
-            </ahref_seo_optimal>
-
-          </v-flex>        
-
-
-          <v-flex>
-
-            <ahref_seo_optimal href="/open_source">
-              <v-btn color="primary"
-                     text style="text-transform: none !important;">
-                <v-icon left> mdi-github</v-icon>
-                 Open Source
-              </v-btn>
-            </ahref_seo_optimal>
-
-          </v-flex>
-
-          <v-flex>
-
-            <ahref_seo_optimal href="/engineering_led_support">
-              <v-btn color="primary"
-                     text style="text-transform: none !important;">
-                <v-icon left> mdi-face-agent</v-icon>
-                 Engineering Led Support
-              </v-btn>
-            </ahref_seo_optimal>
-
-          </v-flex>
-         
-        </v-layout>
-      </v-card>    
-    </v-menu>
-
-
-
-    <v-menu v-model="product"
-            offset-y
-            open-on-hover
-            attach
-            >
-
-   
-      <template v-slot:activator="{ on }">
-        <v-btn v-on="on"
-               color="primary"
-              text style="text-transform: none !important;">
-           Product
-        </v-btn>
-      </template>
+<!--    <v-menu v-model="why_menu"-->
+<!--          offset-y-->
+<!--          open-on-hover-->
+<!--          attach-->
+<!--          >-->
+
+<!--      <template v-slot:activator="{ on }">-->
+<!--        <v-btn v-on="on"-->
+<!--               color="primary"-->
+<!--                text-->
+<!--               style="text-transform: none !important;"-->
+<!--               >-->
+<!--           Product-->
+<!--        </v-btn>-->
+<!--      </template>-->
+
+<!--      <v-card>-->
+<!--        <v-layout column>-->
+
+<!--          <v-flex>-->
+<!--            <ahref_seo_optimal href="https://diffgram.com/main/about">-->
+<!--              <v-btn color="primary"-->
+<!--                     text-->
+<!--                     style="text-transform: none !important;"-->
+<!--                     >-->
+<!--                <v-icon left> mdi-compass-rose</v-icon>-->
+<!--                Our Why-->
+<!--              </v-btn>-->
+<!--            </ahref_seo_optimal>-->
+<!--          </v-flex>-->
+
+<!--          <v-flex>-->
 
-      <v-card>
+<!--            <ahref_seo_optimal href="https://diffgram.com/main/product">-->
+<!--              <v-btn color="primary"-->
+<!--                     text style="text-transform: none !important;">-->
+<!--                <v-icon left> mdi-fast-forward</v-icon>-->
+<!--                Product Overview-->
+<!--              </v-btn>-->
+<!--            </ahref_seo_optimal>-->
 
-        <v-layout column>
+<!--          </v-flex>-->
 
 
-          <v-flex>
+<!--          <v-flex>-->
 
-            <ahref_seo_optimal href="/software">
-              <v-btn color="primary"
-                    text style="text-transform: none !important;">
-                <v-icon left> mdi-image-filter-hdr</v-icon>
-                Software Overview
-              </v-btn>
-            </ahref_seo_optimal>
+<!--            <ahref_seo_optimal href="https://diffgram.com/main/3d-lidar">-->
+<!--              <v-btn color="primary"-->
+<!--                     text style="text-transform: none !important;">-->
+<!--                <v-icon left> mdi-circle-slice-8</v-icon>-->
+<!--                3D-->
+<!--              </v-btn>-->
+<!--            </ahref_seo_optimal>-->
 
-          </v-flex>
+<!--          </v-flex>-->
 
-          
-          <v-divider></v-divider>
 
-          <div class="pa-2">Select Benefits:</div>
+<!--          <v-flex>-->
 
-          <v-flex>
+<!--            <ahref_seo_optimal href="https://diffgram.com/main/image">-->
+<!--              <v-btn color="primary"-->
+<!--                     text style="text-transform: none !important;">-->
+<!--                <v-icon left> mdi-github</v-icon>-->
+<!--                 Image-->
+<!--              </v-btn>-->
+<!--            </ahref_seo_optimal>-->
 
-            <ahref_seo_optimal href="/ease_of_use">
-              <v-btn color="primary"
-                    text style="text-transform: none !important;">
-                <v-icon left> mdi-check</v-icon>
-                Ease of Use
-              </v-btn>
-            </ahref_seo_optimal>
+<!--          </v-flex>-->
 
-          </v-flex>
+<!--          <v-flex>-->
 
+<!--            <ahref_seo_optimal href="https://diffgram.com/main/video">-->
+<!--              <v-btn color="primary"-->
+<!--                     text style="text-transform: none !important;">-->
+<!--                <v-icon left> mdi-face-agent</v-icon>-->
+<!--                 Video-->
+<!--              </v-btn>-->
+<!--            </ahref_seo_optimal>-->
 
-          <v-flex>
+<!--          </v-flex>-->
 
-            <ahref_seo_optimal href="/white_label_customization">
-              <v-btn color="primary"
-                    text style="text-transform: none !important;">
-                <v-icon left> mdi-puzzle-edit</v-icon>
-                White-label Customization
-              </v-btn>
-            </ahref_seo_optimal>
+<!--        </v-layout>-->
+<!--      </v-card>-->
+<!--    </v-menu>-->
 
-          </v-flex>
 
-         
-          <v-flex>
 
-            <ahref_seo_optimal href="/automation">
-              <v-btn color="primary"
-                    text style="text-transform: none !important;">
-                <v-icon left> mdi-creation</v-icon>
-                Automation
-              </v-btn>
-            </ahref_seo_optimal>
+<!--    <v-menu v-model="product"-->
+<!--            offset-y-->
+<!--            open-on-hover-->
+<!--            attach-->
+<!--            >-->
 
-          </v-flex>
 
+<!--      <template v-slot:activator="{ on }">-->
+<!--        <v-btn v-on="on"-->
+<!--               color="primary"-->
+<!--              text style="text-transform: none !important;">-->
+<!--           Resources-->
+<!--        </v-btn>-->
+<!--      </template>-->
 
-          <!--
-          <v-flex>
+<!--      <v-card>-->
 
-            <ahref_seo_optimal href="/stream-to-training-pytorch-tensorflow">
-              <v-btn color="primary"
-                    text style="text-transform: none !important;">
-                <v-icon left> mdi-flash</v-icon>
-                Stream to Training
-              </v-btn>
-            </ahref_seo_optimal>
+<!--        <v-layout column>-->
 
-          </v-flex>
-          -->
 
-          <v-flex>
+<!--          <v-flex>-->
 
-            <ahref_seo_optimal href="/human_tasks_workflow">
-              <v-btn color="primary"
-                    text style="text-transform: none !important;">
-                <v-icon left>mdi-human-greeting</v-icon>
-                Human Tasks Workflow
-              </v-btn>
-            </ahref_seo_optimal>
+<!--            <ahref_seo_optimal href="https://diffgram.readme.io/docs" target="_blank">-->
+<!--              <v-btn color="primary"-->
+<!--                    text style="text-transform: none !important;">-->
+<!--                <v-icon left> mdi-image-filter-hdr</v-icon>-->
+<!--                Docs-->
+<!--              </v-btn>-->
+<!--            </ahref_seo_optimal>-->
 
-          </v-flex>
+<!--          </v-flex>-->
 
-          <!--
-          <v-flex>
+<!--          <v-flex>-->
 
-            <ahref_seo_optimal href="/streaming">
-              <v-btn color="primary"
-                    text style="text-transform: none !important;">
-                <v-icon left> mdi-compass</v-icon>
-                Query & Explore
-              </v-btn>
-            </ahref_seo_optimal>
+<!--            <ahref_seo_optimal href="https://www.youtube.com/channel/UC4ZVmvMA6oa3Lwaq6Si17pg" target="_blank">-->
+<!--              <v-btn color="primary"-->
+<!--                    text style="text-transform: none !important;">-->
+<!--                <v-icon left> mdi-check</v-icon>-->
+<!--                Ease of Use-->
+<!--              </v-btn>-->
+<!--            </ahref_seo_optimal>-->
 
-          </v-flex>
+<!--          </v-flex>-->
 
-          -->
-          <v-flex>
 
-            <ahref_seo_optimal href="/secure">
-              <v-btn color="primary"
-                     text style="text-transform: none !important;">
-                <v-icon left> mdi-lock</v-icon>
-                Security & Privacy
-              </v-btn>           
-            </ahref_seo_optimal>
+<!--          <v-flex>-->
 
-          </v-flex>
-          
+<!--            <ahref_seo_optimal href="https://diffgram-workspace.slack.com/join/shared_invite/zt-twn6529v-hhSPzpQrAxvoZB95PhfAFg#/shared-invite/email" target="_blank">-->
+<!--              <v-btn color="primary"-->
+<!--                    text style="text-transform: none !important;">-->
+<!--                <v-icon left> mdi-puzzle-edit</v-icon>-->
+<!--                Join Slack-->
+<!--              </v-btn>-->
+<!--            </ahref_seo_optimal>-->
 
-          <v-divider></v-divider>
-        
+<!--          </v-flex>-->
 
-          <div class="pa-2">Select Deep Dives:</div>
 
-          <v-flex>
+<!--          <v-flex>-->
 
-          <ahref_seo_optimal href="/segmentation">
-            <v-btn color="primary"
-                  text style="text-transform: none !important;">
-              <v-icon left>mdi-shape-polygon-plus</v-icon>
-              Segmentation
-            </v-btn>
-          </ahref_seo_optimal>
+<!--            <ahref_seo_optimal href="https://github.com/diffgram/diffgram" target="_blank">-->
+<!--              <v-btn color="primary"-->
+<!--                    text style="text-transform: none !important;">-->
+<!--                <v-icon left> mdi-creation</v-icon>-->
+<!--                Github-->
+<!--              </v-btn>-->
+<!--            </ahref_seo_optimal>-->
 
-          </v-flex>
+<!--          </v-flex>-->
 
-          <v-flex>
+<!--        </v-layout>-->
+<!--      </v-card>-->
+<!--    </v-menu>-->
 
-          <ahref_seo_optimal href="/video">
-            <v-btn color="primary"
-                  text style="text-transform: none !important;">
-              <v-icon left>mdi-video</v-icon>
-              Video
-            </v-btn>
-          </ahref_seo_optimal>
+<!--    <v-menu v-model="enterprise"-->
+<!--            offset-y-->
+<!--            open-on-hover-->
+<!--            attach-->
+<!--            >-->
 
-          </v-flex>
 
-          <v-flex>
+<!--      <template v-slot:activator="{ on }">-->
+<!--        <v-btn v-on="on"-->
+<!--               color="primary"-->
+<!--              text style="text-transform: none !important;">-->
+<!--           Enterprise-->
+<!--        </v-btn>-->
+<!--      </template>-->
 
-            <ahref_seo_optimal href="/versioning">
-              <v-btn color="primary"
-                    text style="text-transform: none !important;">
-                <v-icon left> mdi-source-branch</v-icon>
-                Versioning
-              </v-btn>
-            </ahref_seo_optimal>
+<!--      <v-card>-->
 
-          </v-flex>
+<!--        <v-layout column>-->
 
+<!--          <v-flex>-->
 
+<!--        <ahref_seo_optimal href="/enterprise">-->
+<!--            <v-btn color="primary"-->
+<!--                  text style="text-transform: none !important;">-->
+<!--              <v-icon left>mdi-domain</v-icon>-->
+<!--              Enterprise-->
+<!--            </v-btn>-->
+<!--        </ahref_seo_optimal>-->
 
-          <!-- Hide while pro network concept is a WIP --> 
-          <!--
-          <v-flex>
+<!--          </v-flex>-->
 
-          <ahref_seo_optimal href="/data_platform">
-            <v-btn color="primary"
-                  text style="text-transform: none !important;">
-              <v-icon left>mdi-professional-hexagon</v-icon>
-              Hire Pros On Demand
-            </v-btn>
-          </ahref_seo_optimal>
+<!--          <v-flex>-->
 
-          </v-flex>
+<!--          <ahref_seo_optimal href="/enterprise/hub">-->
+<!--            <v-btn color="primary"-->
+<!--                  text style="text-transform: none !important;">-->
+<!--              <v-icon left>mdi-earth</v-icon>-->
+<!--              Enterprise Hub-->
+<!--            </v-btn>-->
+<!--          </ahref_seo_optimal>-->
 
-          
-          <v-flex>
+<!--          </v-flex>-->
 
-          <ahref_seo_optimal href="/pro">
-            <v-btn color="primary"
-                  text style="text-transform: none !important;">
-              <v-icon left>mdi-professional-hexagon</v-icon>
-              Sign Up to Be a Pro
-            </v-btn>
-          </ahref_seo_optimal>
+<!--          <v-divider> </v-divider>-->
 
-          </v-flex>
-          -->
-
-          <v-divider> </v-divider>
-
-        </v-layout>
-      </v-card>
-    </v-menu>
-
-    <v-menu v-model="enterprise"
-            offset-y
-            open-on-hover
-            attach
-            >
-
-   
-      <template v-slot:activator="{ on }">
-        <v-btn v-on="on"
-               color="primary"
-              text style="text-transform: none !important;">
-           Enterprise
-        </v-btn>
-      </template>
-
-      <v-card>
-
-        <v-layout column>
-
-          <v-flex>
-
-        <ahref_seo_optimal href="/enterprise">
-            <v-btn color="primary"
-                  text style="text-transform: none !important;">
-              <v-icon left>mdi-domain</v-icon>
-              Enterprise
-            </v-btn>
-        </ahref_seo_optimal>
-
-          </v-flex>
-
-          <v-flex>
-
-          <ahref_seo_optimal href="/enterprise/hub">
-            <v-btn color="primary"
-                  text style="text-transform: none !important;">
-              <v-icon left>mdi-earth</v-icon>
-              Enterprise Hub
-            </v-btn>
-          </ahref_seo_optimal>
-
-          </v-flex>
-
-          <v-divider> </v-divider>
-
-        </v-layout>
-      </v-card>
-    </v-menu>
-
-    <!-- Want to rethink how we do this comparison -->
-
-    <!--
-    <v-menu v-model="compare"
-            offset-y
-            open-on-hover
-            attach
-            >
-
-   
-      <template v-slot:activator="{ on }">
-        <v-btn v-on="on"
-               color="primary"
-              text style="text-transform: none !important;">
-           Compare
-        </v-btn>
-      </template>
-
-      <v-card>
-
-        <v-layout column>
-
-          <v-flex>
-
-        <ahref_seo_optimal href="/diffgram-vs-sagemaker">
-            <v-btn color="primary"
-                  text style="text-transform: none !important;">
-              <v-icon left>mdi-aws</v-icon>
-              Diffgram and Amazon Sagemaker Groundtruth
-            </v-btn>
-        </ahref_seo_optimal>
-
-          </v-flex>
-
-          <v-flex>
-
-          <ahref_seo_optimal href="/diffgram-vs-labelbox">
-            <v-btn color="primary"
-                  text style="text-transform: none !important;">
-              <v-icon left>mdi-ab-testing</v-icon>
-              Diffgram vs Labelbox
-            </v-btn>
-          </ahref_seo_optimal>
-
-          </v-flex>
-
-          <v-divider> </v-divider>
-
-        </v-layout>
-      </v-card>
-    </v-menu>
-    -->
-
-    <!-- Solutions section is a work in progress-->
-    <!--
-    <v-menu v-model="solutions"
-            offset-y
-            open-on-hover
-            attach
-            >
-
-   
-      <template v-slot:activator="{ on }">
-        <v-btn v-on="on"
-               color="primary"
-               v-model="solutions"
-              text style="text-transform: none !important;">
-           Solutions
-        </v-btn>
-      </template>
-
-      <v-card>
-
-        <v-layout column>
-
-          <v-flex>
-
-            <v-btn color="primary"
-                  text style="text-transform: none !important;"
-                   @click="$router.push('/medical')">
-              <v-icon left>mdi-medical-bag</v-icon>
-              Medical & Healthcare
-            </v-btn>
-
-          </v-flex>
-
-          <v-flex>
-
-            <v-btn color="primary"
-                  text style="text-transform: none !important;"
-                   @click="$router.push('/video')">
-              <v-icon left>mdi-video</v-icon>
-              Retail
-            </v-btn>
-
-          </v-flex>
-
-          <v-flex>
-
-            <v-btn color="primary"
-                  text style="text-transform: none !important;"
-                   @click="$router.push('/software')">
-              <v-icon left> mdi-database</v-icon>
-              Something
-            </v-btn>
-
-
-          </v-flex>
-
-          <v-divider> </v-divider>
-
-        </v-layout>
-      </v-card>
-    </v-menu>
-      -->
-
-
-    <v-spacer> </v-spacer>
-
-
-    
-
-    <ahref_seo_optimal href="/install">
-      <v-btn color="primary"
-            text style="text-transform: none !important;"
-             class="hidden-sm-and-down"
-             v-if="$store.state.user.logged_in != true"
-            >
-        Install
-      </v-btn>
-    </ahref_seo_optimal>
-
-    <ahref_seo_optimal href="https://diffgram.readme.io/docs/introduction-to-diffgram"
-                       target="_blank">
-      <v-btn color="primary"
-            text style="text-transform: none !important;">
-        Docs
-        <v-icon right> mdi-open-in-new </v-icon>
-      </v-btn>
-    </ahref_seo_optimal>
-
-    <!--
-    <menu_company>
-
-    </menu_company>
-    -->
-
-    <!--
-    <menu_learn>
-
-    </menu_learn>
-    -->
+<!--        </v-layout>-->
+<!--      </v-card>-->
+<!--    </v-menu>-->
 
   </v-layout>
 </div>

--- a/frontend/src/components/marketing/home_unbounce.vue
+++ b/frontend/src/components/marketing/home_unbounce.vue
@@ -1,22 +1,22 @@
 <template>
-<div >
+<div v-if="!loading">
 
-<iframe
-  src="https://get.diffgram.com"
-  style="
-    position: fixed;
-    top: 50px;
-    bottom: 100px;
-    right: 0px;
-    width: 100%;
-    border: none;
-    margin: 0;
-    padding: 0;
-    overflow: auto;
-    z-index: 0;
-    height: 100%;
-  ">
-</iframe>
+<!--<iframe-->
+<!--  src="https://get.diffgram.com"-->
+<!--  style="-->
+<!--    position: fixed;-->
+<!--    top: 50px;-->
+<!--    bottom: 100px;-->
+<!--    right: 0px;-->
+<!--    width: 100%;-->
+<!--    border: none;-->
+<!--    margin: 0;-->
+<!--    padding: 0;-->
+<!--    overflow: auto;-->
+<!--    z-index: 0;-->
+<!--    height: 100%;-->
+<!--  ">-->
+<!--</iframe>-->
 
 </div>
 </template>
@@ -24,7 +24,7 @@
 <script lang="ts">
 
 import Vue from "vue";
-
+import {is_open_source} from '../../services/configService'
 export default Vue.extend( {
   name: 'home',
 
@@ -33,11 +33,27 @@ export default Vue.extend( {
 
   data () {
     return {
-
+      loading: false
     }
   },
-  created() {
+  async created() {
+    this.loading = true
+    console.log(this.$route)
+    let result = await is_open_source();
+    console.log('is_open_source', result)
+    if(this.$route.path === '/' && !result.is_open_source){
+      window.location.href = 'https://diffgram.com/main/'
+    }
+    else{
+      if(this.$store.state.user.logged_in == true){
+        this.$router.push('/home/dashboard')
+      }
+      else{
+        this.$router.push('/user/login')
+      }
 
+    }
+    this.loading = false;
   },
   methods: {
 

--- a/frontend/src/components/regular/ahref_seo_optimal.vue
+++ b/frontend/src/components/regular/ahref_seo_optimal.vue
@@ -1,6 +1,6 @@
 
 <template>
- 
+
   <a  :href="href"
       :target="target"
       @click="go_to_url_from_href_seo_workaround($event, href)"
@@ -14,9 +14,9 @@
 <script lang="ts">
 
 /* Usage example
- * 
+ *
 * <ahref_seo_optimal href="/software">
- * 
+ *
     <v-btn>
       Diffgram Software
     </v-btn>

--- a/frontend/src/components/user/account/user_data_platform_new.vue
+++ b/frontend/src/components/user/account/user_data_platform_new.vue
@@ -10,7 +10,7 @@
         </v-card-title>
 
         <v-container>
-          
+
         <v_error_multiple :error="error"
                           data-cy="error-email">
         </v_error_multiple>
@@ -22,7 +22,7 @@
                       :rules="[rules.email]">
         </v-text-field>
 
-        <v-text-field 
+        <v-text-field
           :append-icon="password_hide ? 'visibility' : 'visibility_off'"
           @click:append="() => (password_hide = !password_hide)"
           :type="password_hide ? 'password' : 'text'"
@@ -33,14 +33,14 @@
           v-model="password"
         />
 
-        <v-text-field 
+        <v-text-field
             :append-icon="password_hide_check ? 'visibility' : 'visibility_off'"
             @click:append="() => (password_hide_check = !password_hide_check)"
             :type="password_hide_check ? 'password' : 'text'"
             label="Retype Password"
             validate-on-blur
             data-cy="password2"
-            :rules="[rules.password_check]"
+            :rules="[password_checker]"
             v-model="password_check"
         />
 
@@ -126,18 +126,7 @@
             }
             return true
           },
-          password_check: function (value) {
 
-            // Run equals check first
-            if (this.password != this.password_check) {
-              return "Passwords must match"
-            }
-
-            // Don't need to rerun password check
-            // since if they equal, and the first password as checked
-            // then all clear
-            return true
-        }
         }
 
       }
@@ -165,6 +154,18 @@
     },
 
     methods: {
+      password_checker: function (value) {
+
+        // Run equals check first
+        if (this.password != this.password_check) {
+          return "Passwords must match"
+        }
+
+        // Don't need to rerun password check
+        // since if they equal, and the first password as checked
+        // then all clear
+        return true
+      },
       route_account_login: function () {
         this.$router.push("/user/login");
       },

--- a/frontend/src/components/user/login.vue
+++ b/frontend/src/components/user/login.vue
@@ -174,6 +174,8 @@
       "
     >
       <v-alert type="info"> Already Logged In. </v-alert>
+
+      <v-btn x-large color="success"><v-icon>mdi-home</v-icon>Go to Dashboard</v-btn>
     </div>
 
     <div
@@ -257,6 +259,9 @@ export default Vue.extend({
     if (this.$store.state.user.logged_in == true){
       if ("redirect" in this.$route.query) {
         this.$router.push(this.$route.query["redirect"]);
+      }
+      else{
+        this.$router.push('/home/dashboard');
       }
     }
 

--- a/frontend/src/services/configService.js
+++ b/frontend/src/services/configService.js
@@ -21,3 +21,15 @@ export const get_install_info = async () => {
         }
     }
 }
+
+
+export const is_open_source = async () => {
+  try {
+    const { data } = await axios.get('/api/configs/is-open-source')
+    return data
+  } catch(error) {
+    return {
+      error
+    }
+  }
+}


### PR DESCRIPTION
When visting "/" route now when the installation is not open source we will redirect to landing page,
If the installation is open source we redirect to login page or dashboard

Also removed the old marketing toolbar buttons and changed some of the menu buttons to go to the landing pages instead of marketing components.

I still haven't deleted the components, but if you think now is the time to remove them I can do it in this PR too.