### PR TITLE
Fstring conversion, first iteration

### DIFF
--- a/default/main.py
+++ b/default/main.py
@@ -86,7 +86,7 @@ def apply_security_rules(response):
 @app.route('/docs/', defaults={'path' : ''}, methods=['GET'])
 @app.route('/docs/<path:path>', methods=['GET'])
 def docs_redirect(path):
-	return redirect("https://diffgram.readme.io/docs/" + path, code=301)	
+	return redirect(f"https://diffgram.readme.io/docs/{path}", code=301)	
 
 
 @app.route('/', defaults={'path' : ''}, methods=['GET', 'POST'])

--- a/default/methods/annotation/flags.py
+++ b/default/methods/annotation/flags.py
@@ -27,7 +27,7 @@ def api_by_task_is_complete_toggle(task_id):
 			member = get_member(session=session),
 			project_id = task.project_id,
 			file_id = file.id,
-			description = "from_task_" + str(file.ann_is_complete)
+			description = f"from_task_{str(file.ann_is_complete)}"
 			)
 
 		return jsonify( success = True,

--- a/default/methods/attribute/attribute_template_group_update.py
+++ b/default/methods/attribute/attribute_template_group_update.py
@@ -153,7 +153,7 @@ def group_update_core(
 					file_id = untrusted_label_file_id)
 
 				if label_file is None:
-					log['error']['label_file_id'] = "Invalid" + str(untrusted_label_file_id)
+					log['error']['label_file_id'] = f"Invalid{str(untrusted_label_file_id)}"
 					return log
 
 				new_attachment = Attribute_Template_Group_to_File.set(

--- a/default/methods/batch/append_to_batch.py
+++ b/default/methods/batch/append_to_batch.py
@@ -60,7 +60,7 @@ def save_pre_labeled_data_to_db(batch_id):
     """
     with sessionMaker.session_scope_threaded() as session:
         batch = InputBatch.get_by_id(session, batch_id)
-        logger.info('Batch ID {} pre labeled data download started.'.format(batch_id))
+        logger.info(f'Batch ID {batch_id} pre labeled data download started.')
         try:
             if batch.data_temp_dir:
                 batch.download_status_pre_labeled_data = 'downloading'
@@ -71,11 +71,11 @@ def save_pre_labeled_data_to_db(batch_id):
                 batch.pre_labeled_data = json_data
                 batch.download_status_pre_labeled_data = 'success'
                 session.add(batch)
-                logger.info('Batch ID {} pre labeled data download success.'.format(batch_id))
+                logger.info(f'Batch ID {batch_id} pre labeled data download success.')
 
         except Exception as e:
             batch.download_status_pre_labeled_data = 'failed'
-            logger.error('Batch ID {} pre labeled data download failed. {}'.format(batch_id, traceback.format_exc()))
+            logger.error(f'Batch ID {batch_id} pre labeled data download failed. {traceback.format_exc()}')
 
 
 def append_to_batch_core(session, log, batch_id, member, project, request):
@@ -102,7 +102,7 @@ def append_to_batch_core(session, log, batch_id, member, project, request):
         size = int(new_range.split('/')[1])
         chunk_start = int(new_range.split('-')[0])
         chunk_end = int(chunks.split('-')[1])
-        temp_dir_path = '/tmp/batches/{}_batch_payload.json'.format(batch.id)
+        temp_dir_path = f'/tmp/batches/{batch.id}_batch_payload.json'
         if chunk_start == 0:
             session.add(batch)
             url = data_tools.create_resumable_upload_session(

--- a/default/methods/images/images_core.py
+++ b/default/methods/images/images_core.py
@@ -75,7 +75,7 @@ def process_profile_image(session,
 
     # Save File
     temp = tempfile.mkdtemp()
-    new_temp_filename = temp + "/resized" + str(extension)
+    new_temp_filename = f"{temp}/resized{str(extension)}"
     imwrite(new_temp_filename, image)
 
     data_tools.upload_to_cloud_storage(temp_local_path = new_temp_filename,
@@ -86,10 +86,10 @@ def process_profile_image(session,
                                                          expiration_offset = blob_expiry_offset)
 
     # Save Thumb
-    user.profile_image_thumb_blob = user.profile_image_blob + "_thumb"
+    user.profile_image_thumb_blob = f"{user.profile_image_blob}_thumb"
 
     thumbnail_image = imresize(image, (80, 80))
-    new_temp_filename = temp + "/resized" + str(extension)
+    new_temp_filename = f"{temp}/resized{str(extension)}"
     imwrite(new_temp_filename, thumbnail_image)
 
     data_tools.upload_to_cloud_storage(temp_local_path = new_temp_filename,
@@ -137,7 +137,7 @@ def process_image_generic(session,
         raise
 
     image_blob = blob_base + str(new_image.id)
-    image_blob_thumb = image_blob + "_thumb"
+    image_blob_thumb = f"{image_blob}_thumb"
 
     image = imread(file)
     image = image[:, :, :3]  # remove alpha channel
@@ -160,7 +160,7 @@ def process_image_generic(session,
 
     # Save File
     temp = tempfile.mkdtemp()
-    new_temp_filename = temp + "/resized" + str(extension)
+    new_temp_filename = f"{temp}/resized{str(extension)}"
     imwrite(new_temp_filename, image)
     data_tools.upload_to_cloud_storage(temp_local_path = new_temp_filename, blob_path = image_blob, content_type = "image/jpg")
 
@@ -168,7 +168,7 @@ def process_image_generic(session,
 
     # Save Thumb
     thumbnail_image = imresize(image, (thumb_size, thumb_size))
-    new_temp_filename = temp + "/resized" + str(extension)
+    new_temp_filename = f"{temp}/resized{str(extension)}"
     imwrite(new_temp_filename, thumbnail_image)
     data_tools.upload_to_cloud_storage(temp_local_path = new_temp_filename, blob_path = image_blob_thumb, content_type = "image/jpg")
     signed_url_thumb = data_tools.build_secure_url(blob_name = image_blob_thumb, expiration_offset = blob_expiry_offset)

--- a/default/methods/project/project_update.py
+++ b/default/methods/project/project_update.py
@@ -97,7 +97,7 @@ def project_update_core(session,
 
 		email = member.user.email
 
-		subject = project.project_string_id + " scheduled for deletion."
+		subject = f"{project.project_string_id} scheduled for deletion."
 
 		message = project.project_string_id + \
 		" may be deleted in approximately 30 days." + \
@@ -126,7 +126,7 @@ def project_update_core(session,
 		
 		email = member.user.email
 
-		subject = project.project_string_id + " now public."
+		subject = f"{project.project_string_id} now public."
 
 		message = project.project_string_id + \
 		" is now publicly accessible." + \

--- a/default/methods/report/report_runner.py
+++ b/default/methods/report/report_runner.py
@@ -681,7 +681,7 @@ class Report_Runner():
 
         # TODO: Add suport or remove from UI the task filter when base class is Task
         if self.item_of_interest in ['task']:
-            logger.warning('No filter supported for task_id. item_of_interest is {}'.format(self.item_of_interest))
+            logger.warning(f"No filter supported for task_id. item_of_interest is {self.item_of_interest}")
             return query
         return query.filter(self.base_class.task_id == task_id)
 

--- a/default/methods/share/share.py
+++ b/default/methods/share/share.py
@@ -380,16 +380,16 @@ class Share_Project():
         if self.notify is False:
             return
 
-        subject = "Added to project " + self.project_string_id
+        subject = f"Added to project {self.project_string_id}"
 
-        message = " You have been added to: " + self.project_string_id
-        message += " as a " + str(permission_type)
+        message = f" You have been added to: {self.project_string_id}"
+        message += f" as a {str(permission_type)}"
 
         message += ". Access the project here. " + settings.URL_BASE + \
                    "project/" + self.project_string_id
 
-        message += " Added by " + str(self.user_who_made_request.email)
-        message += " With personal note of:" + str(note)
+        message += f" Added by {str(self.user_who_made_request.email)}"
+        message += f" With personal note of:{str(note)}"
 
         communicate_via_email.send(self.user_to_modify.email, subject, message)
 
@@ -410,15 +410,15 @@ class Share_Project():
 
         # We still notify here since the user doesn't exist...
 
-        subject = "Added to project " + self.project_string_id
+        subject = f"Added to project {self.project_string_id}"
 
-        message = " You have been added to: " + self.project_string_id
-        message += " as an: " + str(permission_type)
+        message = f" You have been added to: {self.project_string_id}"
+        message += f" as an: {str(permission_type)}"
 
-        message += " Create an account to get started here: " + signup_link
+        message += f" Create an account to get started here: {signup_link}"
 
-        message += " Added by " + str(self.user_who_made_request.email)
-        message += " " + str(note)
+        message += f" Added by {str(self.user_who_made_request.email)}"
+        message += f" {str(note)}"
 
         # Careful, can't use self.user_to_modify here since user doesn't exist yet....
         communicate_via_email.send(email, subject, message)

--- a/default/methods/share/share_link.py
+++ b/default/methods/share/share_link.py
@@ -137,11 +137,11 @@ class LinkSharer:
         if not member.user or not member.user.email:
             return
         
-        subject = "[{}]{} Has Shared an Instance With You ".format(self.project_string_id, self.user_sending.first_name)
+        subject = f"[{self.project_string_id}]{self.user_sending.first_name} Has Shared an Instance With You "
 
-        message = "{} shared the following instance: \n\r {} \n\r".format(self.user_sending.first_name, self.link_to_send)
+        message = f"{self.user_sending.first_name} shared the following instance: \n\r {self.link_to_send} \n\r"
 
         message += "Notes: \n\r"
 
-        message += "{}".format(self.message)
+        message += f"{self.message}"
         communicate_via_email.send(member.user.email, subject, message)

--- a/default/methods/source_control/file/file_cache_regen.py
+++ b/default/methods/source_control/file/file_cache_regen.py
@@ -67,7 +67,7 @@ def api_file_cache_regen(project_string_id, file_id):
             member_id = member.id,
             project_id = project.id,
             file_id = file_id,
-            description = str('Regenerated Cache. Frame {}'.format(input.get('frame_number')))
+            description = str(f"Regenerated Cache. Frame {input.get('frame_number')}")
         )
 
         log['success'] = True
@@ -89,7 +89,7 @@ def cache_regeneration_core(session, project, file_id, frame_number, log):
     if file.type == 'video':
         # Check that frame number exists
         if frame_number is None:
-            log['error']['frame_number'] = 'File {}: provide frame number.'.format(file_id)
+            log['error']['frame_number'] = f"File {file_id}: provide frame number."
             return result, log
         else:
             file = session.query(File).filter(
@@ -97,7 +97,7 @@ def cache_regeneration_core(session, project, file_id, frame_number, log):
                 File.frame_number == frame_number
             ).first()
             if not file:
-                log['error']['frame_number'] = 'Frame {} does not exists.'.format(frame_number)
+                log['error']['frame_number'] = f"Frame {frame_number} does not exists."
                 return result, log
 
     instance_list_existing = Instance.list(session = session,

--- a/default/methods/source_control/file/file_update.py
+++ b/default/methods/source_control/file/file_update.py
@@ -313,8 +313,7 @@ def file_update_core(
             )
 
     if mode == "REMOVE":
-        log['info']['remove'] = "Removed " + \
-                                str(file_touched_count) + " file(s)."
+        log['info']['remove'] = f"Removed {str(file_touched_count)} file(s)."
 
     if mode == "TRANSFER":
         if transfer_action == "copy":
@@ -322,8 +321,7 @@ def file_update_core(
                                             str(file_touched_count) + " file(s)."
 
         if transfer_action == "move":
-            log['info']['transfer_count'] = "Moved " + \
-                                            str(file_touched_count) + " file(s)."
+            log['info']['transfer_count'] = f"Moved {str(file_touched_count)} file(s)."
 
     # We could log this for all of these operations I guess
     # But seems especially important for the select from meta data

--- a/default/methods/source_control/working_dir/view.py
+++ b/default/methods/source_control/working_dir/view.py
@@ -37,7 +37,7 @@ def view_working_dir_web(project_string_id, username):
 			out = jsonify( success =  True,
 						   working_dir = working_dir.serialize())
 		elif working_dir_ids:
-			logger.info('Fetching multiple directories {}'.format(str(working_dir_ids)))
+			logger.info(f"Fetching multiple directories {str(working_dir_ids)}")
 			working_dirs = session.query(WorkingDir).filter(WorkingDir.id.in_(working_dir_ids)).all()
 
 			if working_dirs is None:

--- a/default/methods/startup/system_startup_checker.py
+++ b/default/methods/startup/system_startup_checker.py
@@ -10,7 +10,7 @@ class DefaultServiceSystemStartupChecker(SystemStartupBase):
         self.service_name = settings.DIFFGRAM_SERVICE_NAME
 
     def execute_startup_checks(self):
-        logger.info('[{}] Performing System Checks...'.format(self.service_name))
+        logger.info(f"[{self.service_name}] Performing System Checks...")
         self.check_settings_values_validity()
         result = SystemEvents.system_startup_events_check(self.service_name)
         if not result:

--- a/default/methods/task/exam/exam_pass.py
+++ b/default/methods/task/exam/exam_pass.py
@@ -165,7 +165,7 @@ def credential_instance_new(credential_type,
 def notify_user_passed_exam(exam_instance):
     user = exam_instance.exam.user_taking_exam
 
-    subject = "Congrats! You passed " + exam_instance.name
+    subject = f"Congrats! You passed {exam_instance.name}"
 
     message = "View your new credentials"
 

--- a/default/methods/task/stats/fast_stats.py
+++ b/default/methods/task/stats/fast_stats.py
@@ -21,7 +21,7 @@ def job_user_stats(job_id, user_id):
 
         if user_id is None or user_id == 'null':
             log = regular_log.default()
-            log['error']['user_id'] = "Invalid, user_id is " + user_id
+            log['error']['user_id'] = f"Invalid, user_id is {user_id}"
             return jsonify(log = log), 400
 
         tasks = Task.stats(

--- a/default/methods/task/task_template/job_list.py
+++ b/default/methods/task/task_template/job_list.py
@@ -196,7 +196,7 @@ def job_view_core(session,
     # If mode is trainer then force to use org id
 
     if meta["search"] is not None:
-        search_text = '%{}%'.format(meta['search'])
+        search_text = f"%{meta['search']}%"
         query = query.filter(Job.name.ilike(search_text))
 
     query = query.order_by(Job.time_created.desc())

--- a/default/methods/task/task_template/job_new_or_update.py
+++ b/default/methods/task/task_template/job_new_or_update.py
@@ -474,7 +474,7 @@ def update_tasks(job, session, log):
         task.label_dict = job.label_dict
         session.add(task)
 
-    log['info']['task_count'] = "Updated " + str(len(task_list)) + " tasks."
+    log['info']['task_count'] = f"Updated {str(len(task_list))} tasks."
     return log
 
 
@@ -770,7 +770,7 @@ def new_or_update_core(session,
     for field_key, field_val in fields_to_process.items():
         if is_updating and getattr(job, field_key) != field_val:
             setattr(job, field_key, field_val)
-            log['info'][field_key] = "Updated {}".format(field_key)
+            log['info'][field_key] = f"Updated {field_key}"
         else:
             setattr(job, field_key, field_val)
 
@@ -810,22 +810,22 @@ def new_or_update_core(session,
 
 def email_about_new_pro_job(job, user):
 
-    subject = "New Draft Pro Job: " + job.name
+    subject = f"New Draft Pro Job: {job.name}"
 
     message = []
 
     message.append(job.name)
     message.append("\n")
-    message.append("ID: " + str(job.id))
+    message.append(f"ID: {str(job.id)}")
     message.append("\n")
-    message.append("file_count_statistic " + str(job.file_count_statistic))
+    message.append(f"file_count_statistic {str(job.file_count_statistic)}")
     message.append("\n")
 
     if user:
         message.append("\n")
-        message.append("User: " + user.first_name + " " + user.last_name)
+        message.append(f"User: {user.first_name} {user.last_name}")
         message.append("\n")
-        message.append("Email:" + str(user.email))
+        message.append(f"Email:{str(user.email)}")
     else:
         message.append("\n No Member.user")
 

--- a/default/methods/task/task_template/job_resync.py
+++ b/default/methods/task/task_template/job_resync.py
@@ -63,7 +63,7 @@ def job_resync_core(session,
     result = True
     task_template = Job.get_by_id(session = session, job_id = task_template_id)
     if task_template.project_id != project.id:
-        log['error']['project_id'] = 'Invalid job given for project {}'.format(project.project_string_id)
+        log['error']['project_id'] = f"Invalid job given for project {project.project_string_id}"
         return False, log
 
     t = threading.Thread(
@@ -92,7 +92,7 @@ def threaded_job_resync(task_template_id, member_id):
             for file in files:
                 if file.id not in file_ids:
                     logger.info(
-                        'Resyncing File {} on Job {} From Dir {}'.format(file.id, task_template_id, directory.id))
+                        f"Resyncing File {file.id} on Job {task_template_id} From Dir {directory.id}")
                     job_sync_dir_manger = job_dir_sync_utils.JobDirectorySyncManager(
                         session = session,
                         job = task_template,
@@ -110,5 +110,5 @@ def threaded_job_resync(task_template_id, member_id):
                     task_template.update_file_count_statistic(session = session)
                     missing_files.append(file)
 
-    logger.info('Resyncing on Job {} Success. {} Missing files synced'.format(task_template_id, len(missing_files)))
+    logger.info(f"Resyncing on Job {task_template_id} Success. {len(missing_files)} Missing files synced")
     return missing_files

--- a/default/methods/task/task_template/task_template_apply.py
+++ b/default/methods/task/task_template/task_template_apply.py
@@ -172,7 +172,7 @@ def copy_task_template_for_exam(session,
 
     """
     # TODO how do we want to name exam jobs to avoid confusion
-    name = og_task_template.name + " " + user.email
+    name = f"{og_task_template.name} {user.email}"
 
     # Override for now, so review freqeuncy is 1:1
     review_by_human_freqeuncy = "every_pass"

--- a/default/methods/ui_schema/ui_schema.py
+++ b/default/methods/ui_schema/ui_schema.py
@@ -235,7 +235,7 @@ def __ui_schema_update(
 
         if getattr(ui_schema, field_key) != field_val:
             setattr(ui_schema, field_key, field_val)
-            log['info'][field_key] = "Updated {}".format(field_key)
+            log['info'][field_key] = f"Updated {field_key}"
 
     if do_add_to_session is True:
         session.add(ui_schema)

--- a/default/methods/user/account/account_verify.py
+++ b/default/methods/user/account/account_verify.py
@@ -114,15 +114,12 @@ def start_verify_via_email( session,
 		if not url_base.endswith('/'):
 			url_base += '/'
 
-		link_verify = url_base + "user/account/verify_email/"+ \
-						 auth.email_sent_to + \
-						 "/" + \
-						 auth.code
+		link_verify = f"{url_base}user/account/verify_email/{auth.email_sent_to}/{auth.code}"
 
 
 		subject = "Verify your Diffgram account now"
 
-		message = " Verify your account now " + link_verify
+		message = f" Verify your account now {link_verify}"
 		
 		message += " "
 

--- a/default/methods/user/account/auth_code.py
+++ b/default/methods/user/account/auth_code.py
@@ -120,8 +120,7 @@ def attempt_redeem_code(session,
     # a user would create account with same email as we send a signup code to
     if auth.email_sent_to and email:
         if auth.email_sent_to != email:
-            return False, "Code only valid for: " + \
-                   str(auth.email_sent_to), None
+            return False, f"Code only valid for: {str(auth.email_sent_to)}", None
 
     if auth.type:
 

--- a/default/methods/user/account/magic_login.py
+++ b/default/methods/user/account/magic_login.py
@@ -73,13 +73,13 @@ def send_magic_login_email(auth):
     # optional, resend code if 15 minutes has passed?
 
     if settings.URL_BASE.endswith('/'):
-        link_verify = settings.URL_BASE + "user/login/" + auth.code
+        link_verify = f"{settings.URL_BASE}user/login/{auth.code}"
     else:
-        link_verify = settings.URL_BASE + "/user/login/" + auth.code
+        link_verify = f"{settings.URL_BASE}/user/login/{auth.code}"
 
     subject = "Magic link Diffgram"
 
-    message = " Login now " + link_verify
+    message = f" Login now {link_verify}"
 
     message += " Expires in 15 minutes."
 

--- a/default/methods/user/api_enable.py
+++ b/default/methods/user/api_enable.py
@@ -50,7 +50,7 @@ def api_enable_user():
 
 			Event.new(
 				session = session,
-				kind = "api_enable_" + str(input['api_name']),
+				kind = f"api_enable_{str(input['api_name'])}",
 				member_id = user.member_id,
 				success = True,
 				email = user.email)

--- a/default/methods/user/edit.py
+++ b/default/methods/user/edit.py
@@ -100,13 +100,13 @@ def user_upload_profile_image():
 
 		file.filename = secure_filename(file.filename) # http://flask.pocoo.org/docs/0.12/patterns/fileuploads/          
 		temp_dir = tempfile.mkdtemp()
-		file_name = temp_dir + "/" + file.filename
+		file_name = f"{temp_dir}/{file.filename}"
 		file.save(file_name)
 
 		with sessionMaker.session_scope() as session:
 			
 			with open(file_name, "rb") as file:              
-				content_type = "image/" + str(extension)
+				content_type = f"image/{str(extension)}"
 				short_file_name = os.path.split(file_name)[1]
 
 				user = session.query(User).filter(User.id == getUserID()).one()

--- a/default/methods/userscript/userscript.py
+++ b/default/methods/userscript/userscript.py
@@ -210,7 +210,7 @@ def __userscript_update(
 
         if getattr(userscript, field_key) != field_val:
             setattr(userscript, field_key, field_val)
-            log['info'][field_key] = "Updated {}".format(field_key)
+            log['info'][field_key] = f"Updated {field_key}"
 
     if do_add_to_session is True:
         session.add(userscript)

--- a/default/play_and_scripts/scripts/create_database.py
+++ b/default/play_and_scripts/scripts/create_database.py
@@ -8,9 +8,9 @@ from sqlalchemy import create_engine
 
 
 engine = create_engine(settings.DATABASE_URL)
-print('Checking DB: {}'.format(settings.DATABASE_URL))
+print(f'Checking DB: {settings.DATABASE_URL}')
 if not database_exists(engine.url):
-    print('Creating DB: {}'.format(settings.DATABASE_URL))
+    print(f'Creating DB: {settings.DATABASE_URL}')
     from shared.database.core import Base
 
     create_database(engine.url)

--- a/default/play_and_scripts/scripts/setup_database_e2e_tests.py
+++ b/default/play_and_scripts/scripts/setup_database_e2e_tests.py
@@ -8,14 +8,14 @@ import pathlib
 import os
 
 parent_path = pathlib.Path().resolve().parent.parent.parent
-init_config_path = '{}/shared'.format(parent_path)
+init_config_path = f"{parent_path}/shared"
 
 os.chdir(init_config_path)
 if settings.DIFFGRAM_SYSTEM_MODE != 'testing_e2e':
     raise Exception('Can only set database when mode is: testing_e2e'
                     '')
 engine = create_engine(settings.DATABASE_URL)
-print('Checking DB: {}'.format(settings.DATABASE_URL))
+print(f'Checking DB: {settings.DATABASE_URL}')
 if not database_exists(engine.url):
     create_database(engine.url)
     alembic_args = [
@@ -26,9 +26,9 @@ if not database_exists(engine.url):
     alembic.config.main(argv = alembic_args)
     print('Database created successfully.')
 else:
-    print('Destroying database: {}'.format(settings.DATABASE_URL))
+    print(f"Destroying database: {settings.DATABASE_URL}")
     drop_database(settings.DATABASE_URL)
-    print('Creating DB: {}'.format(settings.DATABASE_URL))
+    print(f"Creating DB: {settings.DATABASE_URL}")
     create_database(engine.url)
     alembic_args = [
         '--raiseerr',

--- a/default/tests/conftest.py
+++ b/default/tests/conftest.py
@@ -7,7 +7,7 @@ import pathlib
 import os
 
 parent_path = pathlib.Path(__file__).parent.parent.parent.absolute()
-init_config_path = '{}/shared'.format(parent_path)
+init_config_path = f"{parent_path}/shared"
 
 os.chdir(init_config_path)
 if settings.DIFFGRAM_SYSTEM_MODE != 'testing':
@@ -24,9 +24,9 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     engine = create_engine(settings.UNIT_TESTING_DATABASE_URL)
-    print('Checking DB: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
+    print(f"Checking DB: {settings.UNIT_TESTING_DATABASE_URL}")
     if not database_exists(engine.url):
-        print('Creating DB: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
+        print(f"Creating DB: {settings.UNIT_TESTING_DATABASE_URL}")
         create_database(engine.url)
         alembic_args = [
             '--raiseerr',
@@ -40,6 +40,6 @@ def pytest_configure(config):
 
 def pytest_unconfigure(config):
     if not config.getoption('--keep-db'):
-        print('Destroying database: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
+        print(f"Destroying database: {settings.UNIT_TESTING_DATABASE_URL}")
         drop_database(settings.UNIT_TESTING_DATABASE_URL)
 

--- a/default/tests/methods/annotation/test_instance_history.py
+++ b/default/tests/methods/annotation/test_instance_history.py
@@ -38,15 +38,15 @@ class TestInstanceHistory(testing_setup.DiffgramBaseTestCase):
         instance4 = data_mocking.create_instance({'root_id': 0}, self.session)
 
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
 
-        endpoint = "/api/v1/project/{}/instance/{}/history".format(self.project.project_string_id, instance1.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/instance/{instance1.id}/history"
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/annotation/test_instance_template_list.py
+++ b/default/tests/methods/annotation/test_instance_template_list.py
@@ -64,15 +64,15 @@ class TeseInstanceTemplateList(testing_setup.DiffgramBaseTestCase):
                 }
             ]
         }, self.session)
-        endpoint = "/api/v1/project/{}/instance-template/list".format(self.project.project_string_id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/instance-template/list"
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/annotation/test_instance_template_new.py
+++ b/default/tests/methods/annotation/test_instance_template_new.py
@@ -45,15 +45,15 @@ class TeseInstanceTemplateNew(testing_setup.DiffgramBaseTestCase):
             'reference_height': 800
         }
 
-        endpoint = "/api/v1/project/{}/instance-template/new".format(self.project.project_string_id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/instance-template/new"
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/annotation/test_instance_template_update.py
+++ b/default/tests/methods/annotation/test_instance_template_update.py
@@ -59,13 +59,13 @@ class TeseInstanceTemplateUpdate(testing_setup.DiffgramBaseTestCase):
         endpoint = "/api/v1/project/{}/instance-template/{}".format(self.project.project_string_id,
                                                                            instance_template1.id)
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/batch/test_batch_new.py
+++ b/default/tests/methods/batch/test_batch_new.py
@@ -46,15 +46,15 @@ class TestBatchNew(testing_setup.DiffgramBaseTestCase):
         }
 
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
 
-        endpoint = "/api/v1/project/{}/input-batch/new".format(self.project.project_string_id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/input-batch/new"
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/discussions/test_discussion_comment_list.py
+++ b/default/tests/methods/discussions/test_discussion_comment_list.py
@@ -54,15 +54,15 @@ class TeseIssueNew(testing_setup.DiffgramBaseTestCase):
         }, self.session)
 
         request_data = {}
-        endpoint = "/api/v1/project/{}/discussion/{}/comments".format(self.project.project_string_id, discussion.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/discussion/{discussion.id}/comments"
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/discussions/test_discussion_comment_new.py
+++ b/default/tests/methods/discussions/test_discussion_comment_new.py
@@ -51,15 +51,15 @@ class TeseIssueNew(testing_setup.DiffgramBaseTestCase):
             'content': comment_content
         }
 
-        endpoint = "/api/v1/project/{}/discussion/{}/add-comment".format(self.project.project_string_id, discussion.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/discussion/{discussion.id}/add-comment"
         auth_api = common_actions.create_project_auth(project = job.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/discussions/test_discussion_comment_update.py
+++ b/default/tests/methods/discussions/test_discussion_comment_update.py
@@ -54,15 +54,15 @@ class TeseIssueNew(testing_setup.DiffgramBaseTestCase):
             'comment_id': comment1.id,
             'content': new_content
         }
-        endpoint = "/api/v1/project/{}/discussion/{}/update-comment".format(self.project.project_string_id, discussion.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/discussion/{discussion.id}/update-comment"
 
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/discussions/test_discussion_detail.py
+++ b/default/tests/methods/discussions/test_discussion_detail.py
@@ -61,7 +61,7 @@ class TeseIssueList(testing_setup.DiffgramBaseTestCase):
         )
 
         task = data_mocking.create_task({
-            'name': 'task{}'.format(1),
+            'name': f"task{1}",
             'job': job,
             'file': file,
         }, self.session)
@@ -74,15 +74,15 @@ class TeseIssueList(testing_setup.DiffgramBaseTestCase):
 
         request_data = {}
 
-        endpoint = "/api/v1/project/" + self.project.project_string_id + "/issues/" + str(discussion.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/issues/{str(discussion.id)}"
         auth_api = common_actions.create_project_auth(project = job.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response_with_task_id = self.client.get(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response_with_task_id.json

--- a/default/tests/methods/discussions/test_discussion_list.py
+++ b/default/tests/methods/discussions/test_discussion_list.py
@@ -78,7 +78,7 @@ class TeseIssueList(testing_setup.DiffgramBaseTestCase):
         )
 
         task = data_mocking.create_task({
-            'name': 'task{}'.format(1),
+            'name': f'task{1}',
             'job': job,
             'file': file,
         }, self.session)
@@ -95,15 +95,15 @@ class TeseIssueList(testing_setup.DiffgramBaseTestCase):
             'task_id': task.id,
         }
 
-        endpoint = "/api/v1/project/" + self.project.project_string_id + "/discussions/list"
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/discussions/list"
         auth_api = common_actions.create_project_auth(project=job.project, session=self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response_with_task_id = self.client.post(
             endpoint,
             data=json.dumps(request_data),
             headers={
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response_with_task_id.json
@@ -118,7 +118,7 @@ class TeseIssueList(testing_setup.DiffgramBaseTestCase):
             data=json.dumps(request_data),
             headers={
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
 
@@ -134,7 +134,7 @@ class TeseIssueList(testing_setup.DiffgramBaseTestCase):
             data=json.dumps(request_data),
             headers={
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
 

--- a/default/tests/methods/discussions/test_discussion_new.py
+++ b/default/tests/methods/discussions/test_discussion_new.py
@@ -41,7 +41,7 @@ class TeseIssueNew(testing_setup.DiffgramBaseTestCase):
 
         file = data_mocking.create_file({'project_id': job.project.id, 'job_id': job.id}, self.session)
         task = data_mocking.create_task({
-            'name': 'task{}'.format(1),
+            'name': f"task{1}",
             'job': job,
             'file': file,
         }, self.session)
@@ -57,15 +57,15 @@ class TeseIssueNew(testing_setup.DiffgramBaseTestCase):
             ]
         }
 
-        endpoint = "/api/v1/project/" + job.project.project_string_id + "/issues/new"
+        endpoint = f"/api/v1/project/{job.project.project_string_id}/issues/new"
         auth_api = common_actions.create_project_auth(project=job.project, session=self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data=json.dumps(request_data),
             headers={
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json
@@ -82,7 +82,7 @@ class TeseIssueNew(testing_setup.DiffgramBaseTestCase):
 
         file = data_mocking.create_file({'project_id': job.project.id, 'job_id': job.id}, self.session)
         task = data_mocking.create_task({
-            'name': 'task{}'.format(1),
+            'name': f"task{1}",
             'job': job,
             'file': file,
         }, self.session)

--- a/default/tests/methods/discussions/test_discussion_update.py
+++ b/default/tests/methods/discussions/test_discussion_update.py
@@ -67,15 +67,15 @@ class TeseDiscussionUpdate(testing_setup.DiffgramBaseTestCase):
             'attached_elements': [{'type': 'job', 'id': job.id}],
             'description': new_content
         }
-        endpoint = "/api/v1/project/{}/discussion/{}/update".format(self.project.project_string_id, discussion.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/discussion/{discussion.id}/update"
 
-        credentials = b64encode("{}:{}".format(self.auth_api.client_id, self.auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{self.auth_api.client_id}:{self.auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/event/test_event_create.py
+++ b/default/tests/methods/event/test_event_create.py
@@ -44,15 +44,15 @@ class TestEventCreate(testing_setup.DiffgramBaseTestCase):
             'object_type': 'page',
         }
 
-        endpoint = "/api/v1/project/{}/event/create".format(self.project.project_string_id)
-        credentials = b64encode("{}:{}".format(self.auth_api.client_id, self.auth_api.client_secret).encode()).decode(
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/event/create"
+        credentials = b64encode(f"{self.auth_api.client_id}:{self.auth_api.client_secret}".encode()).decode(
             'utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/event/test_user_visit_history.py
+++ b/default/tests/methods/event/test_user_visit_history.py
@@ -53,15 +53,15 @@ class TestUserVisitHistory(testing_setup.DiffgramBaseTestCase):
             'object_type': 'page',
         }, self.session)
 
-        endpoint = "/api/v1/{}/user-visit-history/".format(self.project.project_string_id)
-        credentials = b64encode("{}:{}".format(self.auth_api.client_id, self.auth_api.client_secret).encode()).decode(
+        endpoint = f"/api/v1/{self.project.project_string_id}/user-visit-history/"
+        credentials = b64encode(f"{self.auth_api.client_id}:{self.auth_api.client_secret}".encode()).decode(
             'utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps({'limit': 50}),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/model/test_model_run_list.py
+++ b/default/tests/methods/model/test_model_run_list.py
@@ -64,15 +64,15 @@ class TestModelRunList(testing_setup.DiffgramBaseTestCase):
         }
 
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
 
-        endpoint = "/api/v1/project/{}/model-runs/list".format(self.project.project_string_id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/model-runs/list"
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/source_control/file/test_file_browser.py
+++ b/default/tests/methods/source_control/file/test_file_browser.py
@@ -91,7 +91,7 @@ class TeseIssueNew(testing_setup.DiffgramBaseTestCase):
 
         endpoint = "/api/project/{}/user/{}/file/list".format(self.project.project_string_id,
                                                               self.project_data['users'][0].id)
-        credentials = b64encode("{}:{}".format(self.auth_api.client_id, self.auth_api.client_secret).encode()).decode(
+        credentials = b64encode(f"{self.auth_api.client_id}:{self.auth_api.client_secret}".encode()).decode(
 
             'utf-8')
 
@@ -100,7 +100,7 @@ class TeseIssueNew(testing_setup.DiffgramBaseTestCase):
             data = json.dumps(request_data),
             headers = {
 
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
 
         )

--- a/default/tests/methods/source_control/file/test_file_cache_regen.py
+++ b/default/tests/methods/source_control/file/test_file_cache_regen.py
@@ -52,7 +52,7 @@ class TeseFileCacheRegen(testing_setup.DiffgramBaseTestCase):
         # Image case
         request_data = {}
         self.assertIsNone(file.cache_dict.get('instance_list'))
-        endpoint = "/api/v1/project/{}/file/{}/regenerate-cache".format(self.project.project_string_id, file.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/file/{file.id}/regenerate-cache"
         credentials = b64encode("{}:{}".format(
             self.auth_api.client_id,
             self.auth_api.client_secret).encode()).decode('utf-8')
@@ -61,7 +61,7 @@ class TeseFileCacheRegen(testing_setup.DiffgramBaseTestCase):
             endpoint,
             data = json.dumps(request_data),
             headers = {
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
 
         )
@@ -88,7 +88,7 @@ class TeseFileCacheRegen(testing_setup.DiffgramBaseTestCase):
         # No frame provided case
         request_data = {}
         self.assertIsNone(video_file.cache_dict.get('instance_list'))
-        endpoint = "/api/v1/project/{}/file/{}/regenerate-cache".format(self.project.project_string_id, video_file.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/file/{video_file.id}/regenerate-cache"
         credentials = b64encode("{}:{}".format(
             self.auth_api.client_id,
             self.auth_api.client_secret).encode()).decode('utf-8')
@@ -97,7 +97,7 @@ class TeseFileCacheRegen(testing_setup.DiffgramBaseTestCase):
             endpoint,
             data = json.dumps(request_data),
             headers = {
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
 
         )
@@ -123,7 +123,7 @@ class TeseFileCacheRegen(testing_setup.DiffgramBaseTestCase):
             'frame_number': 54
         }
         self.assertIsNone(frame_file.cache_dict.get('instance_list'))
-        endpoint = "/api/v1/project/{}/file/{}/regenerate-cache".format(self.project.project_string_id, frame_file.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/file/{frame_file.id}/regenerate-cache"
         credentials = b64encode("{}:{}".format(
             self.auth_api.client_id,
             self.auth_api.client_secret).encode()).decode('utf-8')
@@ -132,7 +132,7 @@ class TeseFileCacheRegen(testing_setup.DiffgramBaseTestCase):
             endpoint,
             data = json.dumps(request_data),
             headers = {
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
 
         )

--- a/default/tests/methods/source_control/file/test_file_exists.py
+++ b/default/tests/methods/source_control/file/test_file_exists.py
@@ -52,15 +52,15 @@ class TestFileExists(testing_setup.DiffgramBaseTestCase):
         }
 
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
 
-        endpoint = "/api/v1/project/{}/file/exists".format(self.project.project_string_id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/file/exists"
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json
@@ -72,15 +72,15 @@ class TestFileExists(testing_setup.DiffgramBaseTestCase):
         }
 
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
 
-        endpoint = "/api/v1/project/{}/file/exists".format(self.project.project_string_id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/file/exists"
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/sync_events/test_sync_events_list.py
+++ b/default/tests/methods/sync_events/test_sync_events_list.py
@@ -35,13 +35,13 @@ class TestSyncEventsList(testing_setup.DiffgramBaseTestCase):
         # Create mock tasks
         num_events = 5
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         all_sync_events = []
         for i in range(0, num_events):
             sync_event = data_mocking.create_sync_event({
-                'description': 'syncevent{}'.format(i),
+                'description': f"syncevent{i}",
                 'job_id': job.id,
                 'project': self.project
             }, self.session)
@@ -59,7 +59,7 @@ class TestSyncEventsList(testing_setup.DiffgramBaseTestCase):
 
         with self.client.session_transaction() as session:
             auth_api = common_actions.create_project_auth(project=self.project, session=self.session)
-            credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode(
+            credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode(
                 'utf-8')
             session['Authorization'] = credentials
             common_actions.add_auth_to_session(session, self.project.users[0])
@@ -68,7 +68,7 @@ class TestSyncEventsList(testing_setup.DiffgramBaseTestCase):
             data=json.dumps(request_payload),
             headers={
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         print(response.data)
@@ -80,13 +80,13 @@ class TestSyncEventsList(testing_setup.DiffgramBaseTestCase):
         # Create mock tasks
         num_tasks = 5
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(2),
+            'name': f"my-test-job-{2}",
             'project': self.project
         }, self.session)
         all_tasks = []
         for i in range(0, num_tasks):
             sync_event = data_mocking.create_sync_event({
-                'description': 'syncevent{}'.format(i),
+                'description': f"syncevent{i}",
                 'job_id': job.id,
                 'project': self.project
             }, self.session)

--- a/default/tests/methods/task/task/task_list.py
+++ b/default/tests/methods/task/task/task_list.py
@@ -33,11 +33,11 @@ class TestTaskList(testing_setup.DiffgramBaseTestCase):
 
     def __send_request_task_list(self, request_data):
 
-        endpoint = "/api/v1/project/{}/task/list".format(self.project.project_string_id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/task/list"
 
         with self.client.session_transaction() as session:
             auth_api = common_actions.create_project_auth(project=self.project, session=self.session)
-            credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode(
+            credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode(
                 'utf-8')
             session['Authorization'] = credentials
             common_actions.add_auth_to_session(session, self.project.users[0])
@@ -46,7 +46,7 @@ class TestTaskList(testing_setup.DiffgramBaseTestCase):
             data=json.dumps(request_data),
             headers={
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         return response
@@ -55,13 +55,13 @@ class TestTaskList(testing_setup.DiffgramBaseTestCase):
         # Create mock tasks
         num_tasks = 5
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         all_tasks = []
         for i in range(0, num_tasks):
             task = data_mocking.create_task({
-                'name': 'task{}'.format(i),
+                'name': f"task{i}",
                 'job': job
             }, self.session)
             all_tasks.append(task)
@@ -85,7 +85,7 @@ class TestTaskList(testing_setup.DiffgramBaseTestCase):
         }, self.session)
         for i in range(0, num_tasks_file):
             task = data_mocking.create_task({
-                'name': 'task{}'.format(i),
+                'name': f"task{i}",
                 'job': job,
                 'file': file
             }, self.session)
@@ -115,13 +115,13 @@ class TestTaskList(testing_setup.DiffgramBaseTestCase):
         # Create mock tasks
         num_tasks = 5
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(2),
+            'name': f"my-test-job-{2}",
             'project': self.project
         }, self.session)
         all_tasks = []
         for i in range(0, num_tasks):
             task = data_mocking.create_task({
-                'name': 'task{}'.format(i),
+                'name': f"task{i}",
                 'job': job
             }, self.session)
             all_tasks.append(task)

--- a/default/tests/methods/task/task/test_task_annotator_request.py
+++ b/default/tests/methods/task/task/test_task_annotator_request.py
@@ -40,7 +40,7 @@ class TestTaskAnnotatorRequest(testing_setup.DiffgramBaseTestCase):
             'member_id': self.member.id
         }, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)

--- a/default/tests/methods/task/task/test_task_complete.py
+++ b/default/tests/methods/task/task/test_task_complete.py
@@ -43,7 +43,7 @@ class TestTaskComplete(testing_setup.DiffgramBaseTestCase):
             'member_id': self.member.id
         }, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'allow_reviews': False
         }, self.session)
@@ -58,7 +58,7 @@ class TestTaskComplete(testing_setup.DiffgramBaseTestCase):
         request_data = {
             'action': 'approve'
         }
-        endpoint = "/api/v1/task/{}/complete".format(self.task.id)
+        endpoint = f"/api/v1/task/{self.task.id}/complete"
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
         auth_api.member.user = data_mocking.register_user({
             'username': 'test_user',
@@ -69,7 +69,7 @@ class TestTaskComplete(testing_setup.DiffgramBaseTestCase):
         }, self.session)
         with self.client.session_transaction() as session:
             session['user_id'] = make_secure_val(auth_api.member.user.id)
-            credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+            credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         self.task.add_assignee(self.session, auth_api.member.user)
         self.session.commit()
         response = self.client.post(
@@ -77,7 +77,7 @@ class TestTaskComplete(testing_setup.DiffgramBaseTestCase):
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json
@@ -86,7 +86,7 @@ class TestTaskComplete(testing_setup.DiffgramBaseTestCase):
 
     def test_task_complete_core(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'allow_reviews': False
         }, self.session)

--- a/default/tests/methods/task/task/test_task_next_issue.py
+++ b/default/tests/methods/task/task/test_task_next_issue.py
@@ -38,13 +38,13 @@ class TestTaskNextIssue(testing_setup.DiffgramBaseTestCase):
         # Create mock tasks
         num_tasks = 5
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         all_tasks = []
         for i in range(0, num_tasks):
             task = data_mocking.create_task({
-                'name': 'task{}'.format(i),
+                'name': f"task{i}",
                 'job': job
             }, self.session)
             all_tasks.append(task)
@@ -69,8 +69,8 @@ class TestTaskNextIssue(testing_setup.DiffgramBaseTestCase):
         )
 
         with self.client.session_transaction() as session:
-            endpoint = "/api/v1/task/{}/next-task-with-issues".format(all_tasks[0].id)
-            credentials = b64encode("{}:{}".format(self.auth_api.client_id, self.auth_api.client_secret).encode()).decode('utf-8')
+            endpoint = f"/api/v1/task/{all_tasks[0].id}/next-task-with-issues"
+            credentials = b64encode(f"{self.auth_api.client_id}:{self.auth_api.client_secret}".encode()).decode('utf-8')
             session['Authorization'] = credentials
             common_actions.add_auth_to_session(session, self.project.users[0])
         response = self.client.post(
@@ -78,7 +78,7 @@ class TestTaskNextIssue(testing_setup.DiffgramBaseTestCase):
             data = json.dumps({}),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json
@@ -90,13 +90,13 @@ class TestTaskNextIssue(testing_setup.DiffgramBaseTestCase):
         # Create mock tasks
         num_tasks = 5
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         all_tasks = []
         for i in range(0, num_tasks):
             task = data_mocking.create_task({
-                'name': 'task{}'.format(i),
+                'name': f"task{i}",
                 'job': job
             }, self.session)
             all_tasks.append(task)

--- a/default/tests/methods/task/task/test_task_review.py
+++ b/default/tests/methods/task/task/test_task_review.py
@@ -48,7 +48,7 @@ class TestTaskReview(testing_setup.DiffgramBaseTestCase):
             'member_id': self.member.id
         }, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'allow_reviews': True
         }, self.session)
@@ -63,7 +63,7 @@ class TestTaskReview(testing_setup.DiffgramBaseTestCase):
         request_data = {
             'action': 'approve'
         }
-        endpoint = "/api/v1/task/{}/review".format(self.task.id)
+        endpoint = f"/api/v1/task/{self.task.id}/review"
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
         auth_api.member.user = data_mocking.register_user({
             'username': 'test_user',
@@ -76,14 +76,14 @@ class TestTaskReview(testing_setup.DiffgramBaseTestCase):
         self.session.commit()
         with self.client.session_transaction() as session:
             session['user_id'] = make_secure_val(auth_api.member.user.id)
-            credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+            credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
 
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json
@@ -99,7 +99,7 @@ class TestTaskReview(testing_setup.DiffgramBaseTestCase):
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/task/task/test_task_user_add.py
+++ b/default/tests/methods/task/task/test_task_user_add.py
@@ -49,7 +49,7 @@ class TestTasUserAdd(testing_setup.DiffgramBaseTestCase):
             'member_id': self.member.id
         }, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'allow_reviews': True
         }, self.session)
@@ -62,17 +62,17 @@ class TestTasUserAdd(testing_setup.DiffgramBaseTestCase):
             'relation': 'assignee',
             'user_id_list': [self.member.user_id]
         }
-        endpoint = "/api/v1/project/{}/task/{}/user/add".format(self.project.project_string_id, self.task.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/task/{self.task.id}/user/add"
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
 
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
 
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
 
@@ -88,7 +88,7 @@ class TestTasUserAdd(testing_setup.DiffgramBaseTestCase):
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         self.assertEqual(response.status_code, 400)
@@ -102,7 +102,7 @@ class TestTasUserAdd(testing_setup.DiffgramBaseTestCase):
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         self.assertEqual(response.status_code, 400)

--- a/default/tests/methods/task/task/test_task_user_remove.py
+++ b/default/tests/methods/task/task/test_task_user_remove.py
@@ -50,7 +50,7 @@ class TestTasUserRemove(testing_setup.DiffgramBaseTestCase):
             'member_id': self.member.id
         }, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'allow_reviews': True
         }, self.session)
@@ -64,17 +64,17 @@ class TestTasUserRemove(testing_setup.DiffgramBaseTestCase):
             'user_id_list': [self.member.user_id]
         }
         relation = self.task.add_reviewer(session = self.session, user = self.member.user)
-        endpoint = "/api/v1/project/{}/task/{}/user/remove".format(self.project.project_string_id, self.task.id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/task/{self.task.id}/user/remove"
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
 
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
 
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
 

--- a/default/tests/methods/task/task_template/test_job_list.py
+++ b/default/tests/methods/task/task_template/test_job_list.py
@@ -39,7 +39,7 @@ class TestJobList(testing_setup.DiffgramBaseTestCase):
         all_jobs = []
         for i in range(0, num_jobs):
             job = data_mocking.create_job({
-                'name': 'my-test-job-{}'.format(i),
+                'name': f"my-test-job-{i}",
                 'project': self.project
             }, self.session)
             all_jobs.append(job)
@@ -58,7 +58,7 @@ class TestJobList(testing_setup.DiffgramBaseTestCase):
 
         with self.client.session_transaction() as session:
             auth_api = common_actions.create_project_auth(project=self.project, session=self.session)
-            credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode(
+            credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode(
                 'utf-8')
             session['Authorization'] = credentials
             common_actions.add_auth_to_session(session, self.project.users[0])
@@ -67,7 +67,7 @@ class TestJobList(testing_setup.DiffgramBaseTestCase):
             data=json.dumps(request_data),
             headers={
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         self.assertEqual(response.status_code, 200)
@@ -88,7 +88,7 @@ class TestJobList(testing_setup.DiffgramBaseTestCase):
         all_jobs = []
         for i in range(0, num_jobs):
             job = data_mocking.create_job({
-                'name': 'my-test-job-{}'.format(i),
+                'name': f"my-test-job-{i}",
                 'project': self.project
             }, self.session)
             all_jobs.append(job)
@@ -141,7 +141,7 @@ class TestJobList(testing_setup.DiffgramBaseTestCase):
         )
         other_project = other_project_data['project']
         other_job = data_mocking.create_job({
-            'name': 'my-testother-job-{}'.format(1),
+            'name': f'my-testother-job-{1}',
             'project': other_project
         }, self.session)
         query = self.session.query(Job)

--- a/default/tests/methods/task/task_template/test_job_new_or_update.py
+++ b/default/tests/methods/task/task_template/test_job_new_or_update.py
@@ -58,14 +58,14 @@ class TestJobNewUpdate(testing_setup.DiffgramBaseTestCase):
             'job_id': job.id,
         }
 
-        endpoint = "/api/v1/project/" + job.project.project_string_id + "/job/update"
-        credentials = b64encode("{}:{}".format(self.auth_api.client_id, self.auth_api.client_secret).encode()).decode('utf-8')
+        endpoint = f"/api/v1/project/{job.project.project_string_id}/job/update"
+        credentials = b64encode(f"{self.auth_api.client_id}:{self.auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data=json.dumps(request_data),
             headers={
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         self.assertEqual(response.status_code, 200)
@@ -106,15 +106,15 @@ class TestJobNewUpdate(testing_setup.DiffgramBaseTestCase):
             'member_list_ids': [user.member.id],
         }
 
-        endpoint = "/api/v1/project/{}/job/new".format(project.project_string_id)
+        endpoint = f"/api/v1/project/{project.project_string_id}/job/new"
         auth_api = common_actions.create_project_auth(project=project, session=self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data=json.dumps(request_data),
             headers={
                 'directory_id': str(project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         print(response.data)
@@ -442,15 +442,15 @@ class TestJobNewUpdate(testing_setup.DiffgramBaseTestCase):
             'job_id': job.id,
         }
 
-        endpoint = "/api/v1/project/" + job.project.project_string_id + "/job/set-output-dir"
+        endpoint = f"/api/v1/project/{job.project.project_string_id}/job/set-output-dir"
         auth_api = common_actions.create_project_auth(project=job.project, session=self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data=json.dumps(request_data),
             headers={
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         self.assertEqual(response.status_code, 200)
@@ -469,7 +469,7 @@ class TestJobNewUpdate(testing_setup.DiffgramBaseTestCase):
             data=json.dumps(request_data_error),
             headers={
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         self.assertEqual(response_error.status_code, 400)

--- a/default/tests/methods/task/task_template/test_job_pin.py
+++ b/default/tests/methods/task/task_template/test_job_pin.py
@@ -39,11 +39,11 @@ class TestJobPin(testing_setup.DiffgramBaseTestCase):
 
         request_data = {}
 
-        endpoint = "/api/v1/job/{}/pin".format(job.id)
+        endpoint = f"/api/v1/job/{job.id}/pin"
 
         with self.client.session_transaction() as session:
             auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-            credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode(
+            credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode(
                 'utf-8')
             session['Authorization'] = credentials
             common_actions.add_auth_to_session(session, self.project.users[0])
@@ -52,7 +52,7 @@ class TestJobPin(testing_setup.DiffgramBaseTestCase):
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json
@@ -64,7 +64,7 @@ class TestJobPin(testing_setup.DiffgramBaseTestCase):
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/task/task_template/test_job_resync.py
+++ b/default/tests/methods/task/task_template/test_job_resync.py
@@ -41,15 +41,15 @@ class TestJobResync(testing_setup.DiffgramBaseTestCase):
         request_data = {
             'task_template_id': job.id,
         }
-        endpoint = "/api/v1/project/" + job.project.project_string_id + "/job/resync"
+        endpoint = f"/api/v1/project/{job.project.project_string_id}/job/resync"
         auth_api = common_actions.create_project_auth(project = job.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/task/task_time_tracking/test_task_track_time.py
+++ b/default/tests/methods/task/task_time_tracking/test_task_track_time.py
@@ -43,7 +43,7 @@ class TestTaskTrackTime(testing_setup.DiffgramBaseTestCase):
 
     def test_api_task_track_time(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -58,15 +58,15 @@ class TestTaskTrackTime(testing_setup.DiffgramBaseTestCase):
         task1.add_assignee(self.session, self.member.user)
         with self.client.session_transaction() as session:
             session['user_id'] = make_secure_val(self.auth_api.member.user.id)
-            endpoint = "/api/v1/task/{}/track-time".format(task1.id)
+            endpoint = f"/api/v1/task/{task1.id}/track-time"
             auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-            credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+            credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json
@@ -86,7 +86,7 @@ class TestTaskTrackTime(testing_setup.DiffgramBaseTestCase):
 
     def test_track_time_core(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)

--- a/default/tests/methods/userscript/test_new_userscript.py
+++ b/default/tests/methods/userscript/test_new_userscript.py
@@ -54,15 +54,15 @@ class TestUserScript(testing_setup.DiffgramBaseTestCase):
             }
 
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
 
-        endpoint = "/api/v1/project/{}/userscript/new".format(self.project.project_string_id)
+        endpoint = f"/api/v1/project/{self.project.project_string_id}/userscript/new"
         
         response = self.client.post(
             endpoint,
             data = json.dumps(example),
             headers = {
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/video/test_sequence_preview_create.py
+++ b/default/tests/methods/video/test_sequence_preview_create.py
@@ -89,13 +89,13 @@ class TestSequencePreviewCreate(testing_setup.DiffgramBaseTestCase):
             sequence.id,
         )
         auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data = json.dumps({}),
             headers = {
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         data = response.json

--- a/default/tests/methods/video/test_video_view.py
+++ b/default/tests/methods/video/test_video_view.py
@@ -34,7 +34,7 @@ class TestVideoView(testing_setup.DiffgramBaseTestCase):
     def test_get_video_frame_from_task(self):
         # Create mock task
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         video_file = data_mocking.create_file({
@@ -64,10 +64,10 @@ class TestVideoView(testing_setup.DiffgramBaseTestCase):
             'mode_data': 'list'
         }
 
-        endpoint = "/api/v1/task/{}/video/single/{}/frame-list/".format(task.id, video_file.id)
+        endpoint = f"/api/v1/task/{task.id}/video/single/{video_file.id}/frame-list/"
         with self.client.session_transaction() as session:
             auth_api = common_actions.create_project_auth(project = self.project, session = self.session)
-            credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode(
+            credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode(
                 'utf-8')
             session['Authorization'] = credentials
             common_actions.add_auth_to_session(session, self.project.users[0])
@@ -76,7 +76,7 @@ class TestVideoView(testing_setup.DiffgramBaseTestCase):
             data = json.dumps(request_data),
             headers = {
                 'directory_id': str(job.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         self.assertEqual(response.status_code, 200)

--- a/default/tests/shared/database/task/job/test_user_to_job.py
+++ b/default/tests/shared/database/task/job/test_user_to_job.py
@@ -38,7 +38,7 @@ class TestUserToJob(testing_setup.DiffgramBaseTestCase):
 
     def test_serialize_trainer_info_default(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         user_to_job = data_mocking.create_user_to_job({
@@ -55,7 +55,7 @@ class TestUserToJob(testing_setup.DiffgramBaseTestCase):
 
     def test_serialize(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         user_to_job = data_mocking.create_user_to_job({
@@ -71,7 +71,7 @@ class TestUserToJob(testing_setup.DiffgramBaseTestCase):
 
     def test_get_job_ids_from_user(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         user_to_job = data_mocking.create_user_to_job({
@@ -96,11 +96,11 @@ class TestUserToJob(testing_setup.DiffgramBaseTestCase):
             'member_id': self.member.id
         }, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test22-job-{}'.format(1),
+            'name': f"my-test22-job-{1}",
             'project': self.project
         }, self.session)
         job2 = data_mocking.create_job({
-            'name': 'my2-tes22t-job-{}'.format(1),
+            'name': f"my2-tes22t-job-{1}",
             'project': self.project
         }, self.session)
         user_to_job = data_mocking.create_user_to_job({
@@ -125,7 +125,7 @@ class TestUserToJob(testing_setup.DiffgramBaseTestCase):
 
     def test_get_single_by_ids(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         user_to_job = data_mocking.create_user_to_job({
@@ -141,7 +141,7 @@ class TestUserToJob(testing_setup.DiffgramBaseTestCase):
 
     def test_get_by_job_id(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         user_to_job = data_mocking.create_user_to_job({
@@ -158,7 +158,7 @@ class TestUserToJob(testing_setup.DiffgramBaseTestCase):
 
     def test_list(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         user_to_job = data_mocking.create_user_to_job({

--- a/default/tests/shared/database/task/test_task.py
+++ b/default/tests/shared/database/task/test_task.py
@@ -43,7 +43,7 @@ class TestTask(testing_setup.DiffgramBaseTestCase):
 
     def test_get_task_from_job_id(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -70,7 +70,7 @@ class TestTask(testing_setup.DiffgramBaseTestCase):
 
     def test_add_assignee(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -88,7 +88,7 @@ class TestTask(testing_setup.DiffgramBaseTestCase):
 
     def test_add_reviewer(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -106,7 +106,7 @@ class TestTask(testing_setup.DiffgramBaseTestCase):
 
     def test_has_user(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)

--- a/default/tests/shared/database/task/test_task_event.py
+++ b/default/tests/shared/database/task/test_task_event.py
@@ -34,7 +34,7 @@ class TestTaskEvent(testing_setup.DiffgramBaseTestCase):
 
     def test_serialize(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -58,7 +58,7 @@ class TestTaskEvent(testing_setup.DiffgramBaseTestCase):
 
     def test_generate_task_creation_event(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -75,7 +75,7 @@ class TestTaskEvent(testing_setup.DiffgramBaseTestCase):
 
     def test_generate_task_completion_event(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -92,7 +92,7 @@ class TestTaskEvent(testing_setup.DiffgramBaseTestCase):
 
     def test_generate_task_review_complete(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -109,7 +109,7 @@ class TestTaskEvent(testing_setup.DiffgramBaseTestCase):
 
     def test_generate_task_in_progress_complete(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -127,7 +127,7 @@ class TestTaskEvent(testing_setup.DiffgramBaseTestCase):
 
     def test_generate_task_comment_event(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)

--- a/default/tests/shared/database/task/test_task_time_tracking.py
+++ b/default/tests/shared/database/task/test_task_time_tracking.py
@@ -41,7 +41,7 @@ class TestTaskTimeTracking(testing_setup.DiffgramBaseTestCase):
 
     def test_get_global_record_from_status_record(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -93,7 +93,7 @@ class TestTaskTimeTracking(testing_setup.DiffgramBaseTestCase):
 
     def test_new(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -130,7 +130,7 @@ class TestTaskTimeTracking(testing_setup.DiffgramBaseTestCase):
 
     def test_serialize(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)

--- a/default/tests/shared/database/task/test_task_user.py
+++ b/default/tests/shared/database/task/test_task_user.py
@@ -41,7 +41,7 @@ class TestTaskUser(testing_setup.DiffgramBaseTestCase):
 
     def test_new(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -61,7 +61,7 @@ class TestTaskUser(testing_setup.DiffgramBaseTestCase):
 
     def test_serialize(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
@@ -83,7 +83,7 @@ class TestTaskUser(testing_setup.DiffgramBaseTestCase):
 
     def test_list(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)

--- a/default/tests/shared/utils/task/test_task_assign_reviewer.py
+++ b/default/tests/shared/utils/task/test_task_assign_reviewer.py
@@ -43,7 +43,7 @@ class TestTaskAssignReviewer(testing_setup.DiffgramBaseTestCase):
     def test_task_complete(self):
         # Create mock tasks
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'allow_reviews': True
         }, self.session)

--- a/default/tests/shared/utils/task/test_task_complete.py
+++ b/default/tests/shared/utils/task/test_task_complete.py
@@ -61,7 +61,7 @@ class TestSyncEventsManager(testing_setup.DiffgramBaseTestCase):
 
         # Test review mode
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'allow_reviews': True
         }, self.session)
@@ -76,7 +76,7 @@ class TestSyncEventsManager(testing_setup.DiffgramBaseTestCase):
 
         # Test Auto Assign call
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'allow_reviews': True,
         }, self.session)
@@ -102,7 +102,7 @@ class TestSyncEventsManager(testing_setup.DiffgramBaseTestCase):
 
         # Test Auto Assign call with reviewer
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'allow_reviews': True
         }, self.session)
@@ -136,7 +136,7 @@ class TestSyncEventsManager(testing_setup.DiffgramBaseTestCase):
             'files': [original_file]
         }, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'completion_directory_id': completion_dir.id
         }, self.session)
@@ -157,7 +157,7 @@ class TestSyncEventsManager(testing_setup.DiffgramBaseTestCase):
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
         original_file = data_mocking.create_file({'project_id': self.project.id}, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
         }, self.session)
         task = data_mocking.create_task({'name': 'test task',

--- a/default/tests/shared/utils/test_sync_events_manager.py
+++ b/default/tests/shared/utils/test_sync_events_manager.py
@@ -36,7 +36,7 @@ class TestSyncEventsManager(testing_setup.DiffgramBaseTestCase):
         # Create mock tasks
         num_tasks = 5
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project
         }, self.session)
         manager = SyncEventManager.create_sync_event_and_manager(

--- a/install.py
+++ b/install.py
@@ -47,11 +47,11 @@ class bcolors:
 
     @staticmethod
     def printcolor(string, color):
-        print(color + string + '\033[0m')
+        print(color + string + bcolors.ENDC)
 
     @staticmethod
     def inputcolor(string, color = '\033[96m'):
-        val = input(color + string + '\033[0m')
+        val = input(color + string + bcolors.ENDC)
         return val
 
 
@@ -117,11 +117,11 @@ class DiffgramInstallTool:
         bcolors.printcolor('Testing Connection...', bcolors.OKBLUE)
         try:
             client = BlobServiceClient.from_connection_string(connection_string)
-            print(bcolors.OKGREEN + '[OK] ' + '\033[0m' + 'Connection To Azure Account')
+            print(f"{bcolors.OKGREEN}[OK] {bcolors.ENDC}Connection To Azure Account")
         except Exception as e:
-            print(bcolors.FAIL + '[ERROR] ' + '\033[0m' + 'Connection To Azure Account')
+            print(f"{bcolors.FAIL}[ERROR] {bcolors.ENDC}Connection To Azure Account")
             bcolors.printcolor('Error Connecting to Azure: Please check you entered valid credentials.', bcolors.FAIL)
-            print('Details: {}'.format(traceback.format_exc()))
+            print(f"Details: {traceback.format_exc()}")
             bcolors.printcolor('Please update credentials and try again', bcolors.OKBLUE)
             return False
         time.sleep(0.5)
@@ -129,12 +129,12 @@ class DiffgramInstallTool:
             blob_client = client.get_blob_client(container = bucket_name, blob = test_file_path)
             my_content_settings = ContentSettings(content_type = 'text/plain')
             blob_client.upload_blob('This is a diffgram test file', content_settings = my_content_settings, overwrite=True)
-            print(bcolors.OKGREEN + '[OK] ' + '\033[0m' + 'Write Permissions')
+            print(f"{bcolors.OKGREEN}[OK] {bcolors.ENDC}Write Permissions")
         except:
-            print(bcolors.FAIL + '[ERROR] ' + '\033[0m' + 'Write Permissions')
+            print(f"{bcolors.FAIL}[ERROR] {bcolors.ENDC}Write Permissions")
             bcolors.printcolor('Error Connecting to Azure: Please check you have write permissions on the Azure container.',
                                bcolors.FAIL)
-            print('Details: {}'.format(traceback.format_exc()))
+            print(f"Details: {traceback.format_exc()}")
             bcolors.printcolor('Please update permissions and try again', bcolors.OKBLUE)
             return False
         time.sleep(0.5)
@@ -153,7 +153,7 @@ class DiffgramInstallTool:
                 start = datetime.datetime.utcnow(),
                 expiry = expiry_time,
                 permission = BlobSasPermissions(read = True),
-                content_disposition = 'attachment; filename=' + filename,
+                content_disposition = f"attachment; filename={filename}",
             )
             sas_url = 'https://{}.blob.core.windows.net/{}/{}?{}'.format(
                 client.account_name,
@@ -164,14 +164,14 @@ class DiffgramInstallTool:
             resp = requests.get(sas_url)
             if resp.status_code != 200:
                 raise Exception(
-                    'Error when accessing presigned URL: Status({}). Error: {}'.format(resp.status_code, resp.text))
+                    f"Error when accessing presigned URL: Status({resp.status_code}). Error: {resp.text}")
 
-            print(bcolors.OKGREEN + '[OK] ' + '\033[0m' + 'Read Permissions')
+            print(f"{bcolors.OKGREEN}[OK] {bcolors.ENDC}Read Permissions")
         except:
-            print(bcolors.FAIL + '[ERROR] ' + '\033[0m' + 'Read Permissions')
+            print(f"{bcolors.FAIL}[ERROR] {bcolors.ENDC}Read Permissions")
             bcolors.printcolor('Error Connecting to Azure: Please check you have read permissions on the Azure container.',
                                bcolors.FAIL)
-            print('Details: {}'.format(traceback.format_exc()))
+            print(f"Details: {traceback.format_exc()}")
             bcolors.printcolor('Please update permissions and try again', bcolors.OKBLUE)
             return False
         time.sleep(0.5)
@@ -190,23 +190,23 @@ class DiffgramInstallTool:
             credentials = service_account.Credentials.from_service_account_file(account_path)
             client = storage.Client(credentials = credentials)
             bucket = client.get_bucket(bucket_name)
-            print(bcolors.OKGREEN + '[OK] ' + '\033[0m' + 'Connection To GCP Account')
+            print(f"{bcolors.OKGREEN}[OK] {bcolors.ENDC}Connection To GCP Account")
         except Exception as e:
-            print(bcolors.FAIL + '[ERROR] ' + '\033[0m' + 'Connection To GCP Account')
+            print(f"{bcolors.FAIL}[ERROR] {bcolors.ENDC}Connection To GCP Account")
             bcolors.printcolor('Error Connecting to GCP: Please check you entered valid credentials.', bcolors.FAIL)
-            print('Details: {}'.format(traceback.format_exc()))
+            print(f"Details: {traceback.format_exc()}")
             bcolors.printcolor('Please update credentials and try again', bcolors.OKBLUE)
             return False
         time.sleep(0.5)
         try:
             blob = bucket.blob(test_file_path)
             blob.upload_from_string('This is a diffgram test file', content_type = 'text/plain')
-            print(bcolors.OKGREEN + '[OK] ' + '\033[0m' + 'Write Permissions')
+            print(f"{bcolors.OKGREEN}[OK] {bcolors.ENDC}Write Permissions")
         except:
-            print(bcolors.FAIL + '[ERROR] ' + '\033[0m' + 'Write Permissions')
+            print(f"{bcolors.FAIL}[ERROR] {bcolors.ENDC}Write Permissions")
             bcolors.printcolor('Error Connecting to GCP: Please check you have write permissions on the GCP bucket.',
                                bcolors.FAIL)
-            print('Details: {}'.format(traceback.format_exc()))
+            print(f"Details: {traceback.format_exc()}")
             bcolors.printcolor('Please update permissions and try again', bcolors.OKBLUE)
             return False
         time.sleep(0.5)
@@ -218,19 +218,19 @@ class DiffgramInstallTool:
             filename = test_file_path.split("/")[-1]
             url_signed = blob.generate_signed_url(
                 expiration = expiration_time,
-                response_disposition = 'attachment; filename=' + filename
+                response_disposition = f"attachment; filename={filename}"
             )
             resp = requests.get(url_signed)
             if resp.status_code != 200:
                 raise Exception(
-                    'Error when accessing presigned URL: Status({}). Error: {}'.format(resp.status_code, resp.text))
+                    f"Error when accessing presigned URL: Status({resp.status_code}). Error: {resp.text}")
 
-            print(bcolors.OKGREEN + '[OK] ' + '\033[0m' + 'Read Permissions')
+            print(f"{bcolors.OKGREEN}[OK] {bcolors.ENDC}Read Permissions")
         except:
-            print(bcolors.FAIL + '[ERROR] ' + '\033[0m' + 'Read Permissions')
+            print(f"{bcolors.FAIL}[ERROR] {bcolors.ENDC}Read Permissions")
             bcolors.printcolor('Error Connecting to GCP: Please check you have read permissions on the GCP bucket.',
                                bcolors.FAIL)
-            print('Details: {}'.format(traceback.format_exc()))
+            print(f"Details: {traceback.format_exc()}")
             bcolors.printcolor('Please update permissions and try again', bcolors.OKBLUE)
             return False
         time.sleep(0.5)
@@ -247,11 +247,11 @@ class DiffgramInstallTool:
         bcolors.printcolor('Testing Connection...', bcolors.OKBLUE)
         try:
             client = boto3.client('s3', aws_access_key_id = access_id, aws_secret_access_key = access_secret, region_name = bucket_region)
-            print(bcolors.OKGREEN + '[OK] ' + '\033[0m' + 'Connection To S3 Account')
+            print(f"{bcolors.OKGREEN}[OK] {bcolors.ENDC}Connection To S3 Account")
         except Exception as e:
-            print(bcolors.FAIL + '[ERROR] ' + '\033[0m' + 'Connection To S3 Account')
+            print(f"{bcolors.FAIL}[ERROR] {bcolors.ENDC}Connection To S3 Account")
             bcolors.printcolor('Error Connecting to S3: Please check you entered valid credentials.', bcolors.FAIL)
-            print('Details: {}'.format(traceback.format_exc()))
+            print(f"Details: {traceback.format_exc()}")
             bcolors.printcolor('Please update credentials and try again', bcolors.OKBLUE)
             return False
         time.sleep(0.5)
@@ -260,12 +260,12 @@ class DiffgramInstallTool:
                               Bucket = bucket_name,
                               Key = test_file_path,
                               ContentType = 'text/plain')
-            print(bcolors.OKGREEN + '[OK] ' + '\033[0m' + 'Write Permissions')
+            print(f"{bcolors.OKGREEN}[OK] {bcolors.ENDC}Write Permissions")
         except:
-            print(bcolors.FAIL + '[ERROR] ' + '\033[0m' + 'Write Permissions')
+            print(f"{bcolors.FAIL}[ERROR] {bcolors.ENDC}Write Permissions")
             bcolors.printcolor('Error Connecting to S3: Please check you have write permissions on the S3 bucket.',
                                bcolors.FAIL)
-            print('Details: {}'.format(traceback.format_exc()))
+            print(f"Details: {traceback.format_exc()}")
             bcolors.printcolor('Please update permissions and try again', bcolors.OKBLUE)
             return False
         time.sleep(0.5)
@@ -276,14 +276,14 @@ class DiffgramInstallTool:
             resp = requests.get(signed_url)
             if resp.status_code != 200:
                 raise Exception(
-                    'Error when accessing presigned URL: Status({}). Error: {}'.format(resp.status_code, resp.text))
+                    f"Error when accessing presigned URL: Status({resp.status_code}). Error: {resp.text}")
 
-            print(bcolors.OKGREEN + '[OK] ' + '\033[0m' + 'Read Permissions')
+            print(f"{bcolors.OKGREEN}[OK] {bcolors.ENDC}Read Permissions")
         except:
-            print(bcolors.WARNING + '[ERROR] ' + '\033[0m' + 'Read Permissions')
+            print(f"{bcolors.WARNING}[ERROR] {bcolors.ENDC}Read Permissions")
             bcolors.printcolor('Error Connecting to S3: Please check you have read permissions on the S3 bucket.',
                                bcolors.WARNING)
-            print('Details: {}'.format(traceback.format_exc()))
+            print(f"Details: {traceback.format_exc()}")
             bcolors.printcolor('Please update permissions and try again', bcolors.OKBLUE)
             return False
         time.sleep(0.5)
@@ -367,78 +367,78 @@ class DiffgramInstallTool:
         system = platform.system().lower()
         release = platform.release().lower()
 
-        os_data = '{} {} {}'.format(os_name, system, release)
+        os_data = f"{os_name} {system} {release}"
         return os_data
 
     def populate_env(self):
         env_file = ''
         bcolors.printcolor('Generating Environment Variables file...', bcolors.OKBLUE)
         if self.static_storage_provider == 'gcp':
-            env_file = 'GCP_SERVICE_ACCOUNT_FILE_PATH={}\n'.format(self.gcp_credentials_path)
-            env_file += 'CLOUD_STORAGE_BUCKET={}\n'.format(self.bucket_name)
-            env_file += 'ML__CLOUD_STORAGE_BUCKET={}\n'.format(self.bucket_name)
+            env_file = f"GCP_SERVICE_ACCOUNT_FILE_PATH={self.gcp_credentials_path}\n"
+            env_file += f"CLOUD_STORAGE_BUCKET={self.bucket_name}\n"
+            env_file += f"ML__CLOUD_STORAGE_BUCKET={self.bucket_name}\n"
             env_file += 'SAME_HOST=False\n'.format(self.bucket_name)
-            env_file += 'DIFFGRAM_STATIC_STORAGE_PROVIDER={}\n'.format(self.static_storage_provider)
+            env_file += f"DIFFGRAM_STATIC_STORAGE_PROVIDER={self.static_storage_provider}\n"
         elif self.static_storage_provider == 'aws':
-            env_file = 'DIFFGRAM_AWS_ACCESS_KEY_ID={}\n'.format(self.s3_access_id)
-            env_file += 'DIFFGRAM_AWS_ACCESS_KEY_SECRET={}\n'.format(self.s3_access_secret)
-            env_file += 'DIFFGRAM_S3_BUCKET_NAME={}\n'.format(self.bucket_name)
-            env_file += 'DIFFGRAM_S3_BUCKET_REGION={}\n'.format(self.bucket_region)
-            env_file += 'ML__DIFFGRAM_S3_BUCKET_NAME={}\n'.format(self.bucket_name)
+            env_file = f"DIFFGRAM_AWS_ACCESS_KEY_ID={self.s3_access_id}\n"
+            env_file += f"DIFFGRAM_AWS_ACCESS_KEY_SECRET={self.s3_access_secret}\n"
+            env_file += f"DIFFGRAM_S3_BUCKET_NAME={self.bucket_name}\n"
+            env_file += f"DIFFGRAM_S3_BUCKET_REGION={self.bucket_region}\n"
+            env_file += f"ML__DIFFGRAM_S3_BUCKET_NAME={self.bucket_name}\n"
             env_file += 'SAME_HOST=False\n'.format(self.bucket_name)
-            env_file += 'DIFFGRAM_STATIC_STORAGE_PROVIDER={}\n'.format(self.static_storage_provider)
-            env_file += 'GCP_SERVICE_ACCOUNT_FILE_PATH={}\n'.format('/dev/null')
+            env_file += f"DIFFGRAM_STATIC_STORAGE_PROVIDER={self.static_storage_provider}\n"
+            env_file += "GCP_SERVICE_ACCOUNT_FILE_PATH=/dev/null\n"
         elif self.static_storage_provider == 'azure':
-            env_file = 'DIFFGRAM_AZURE_CONNECTION_STRING={}\n'.format(self.azure_connection_string)
-            env_file += 'DIFFGRAM_AZURE_CONTAINER_NAME={}\n'.format(self.bucket_name)
-            env_file += 'ML__DIFFGRAM_AZURE_CONTAINER_NAME={}\n'.format(self.bucket_name)
+            env_file = f"DIFFGRAM_AZURE_CONNECTION_STRING={self.azure_connection_string}\n"
+            env_file += f"DIFFGRAM_AZURE_CONTAINER_NAME={self.bucket_name}\n"
+            env_file += f"ML__DIFFGRAM_AZURE_CONTAINER_NAME={self.bucket_name}\n"
             env_file += 'SAME_HOST=False\n'.format(self.bucket_name)
-            env_file += 'DIFFGRAM_STATIC_STORAGE_PROVIDER={}\n'.format(self.static_storage_provider)
-            env_file += 'GCP_SERVICE_ACCOUNT_FILE_PATH={}\n'.format('/dev/null')
+            env_file += f"DIFFGRAM_STATIC_STORAGE_PROVIDER={self.static_storage_provider}\n"
+            env_file += "GCP_SERVICE_ACCOUNT_FILE_PATH=/dev/null\n"
 
         fernet_key = base64.urlsafe_b64encode(os.urandom(32))
-        env_file += 'FERNET_KEY={}\n'.format(fernet_key)
-        env_file += 'USER_PASSWORDS_SECRET={}\n'.format(create_random_string(10))
-        env_file += 'INTER_SERVICE_SECRET={}\n'.format(create_random_string(10))
-        env_file += 'SECRET_KEY={}\n'.format(create_random_string(18))
-        env_file += 'WALRUS_SERVICE_URL_BASE={}\n'.format('http://walrus:8082/')
+        env_file += f"FERNET_KEY={fernet_key}\n"
+        env_file += f"USER_PASSWORDS_SECRET={create_random_string(10)}\n"
+        env_file += f"INTER_SERVICE_SECRET={create_random_string(10)}\n"
+        env_file += f"SECRET_KEY={create_random_string(18)}\n"
+        env_file += "WALRUS_SERVICE_URL_BASE=http://walrus:8082/\n"
 
-        env_file += 'DIFFGRAM_ERROR_SEND_TRACES_IN_RESPONSE={}\n'.format(True)
+        env_file += f"DIFFGRAM_ERROR_SEND_TRACES_IN_RESPONSE={True}\n"
 
         install_fingerprint = self.gen_install_finger_print()
-        env_file += 'DIFFGRAM_INSTALL_FINGERPRINT={}\n'.format(install_fingerprint)
-        env_file += 'DIFFGRAM_VERSION_TAG={}\n'.format(self.diffgram_version)
-        env_file += 'DIFFGRAM_HOST_OS={}\n'.format(self.get_system_os())
+        env_file += f"DIFFGRAM_INSTALL_FINGERPRINT={install_fingerprint}\n"
+        env_file += f"DIFFGRAM_VERSION_TAG={self.diffgram_version}\n"
+        env_file += f"DIFFGRAM_HOST_OS={self.get_system_os()}\n"
 
         if self.local_database:
-            env_file += 'POSTGRES_IMAGE={}\n'.format('postgres:12.5')
-            env_file += 'DATABASE_URL={}\n'.format("postgresql+psycopg2://postgres:postgres@db/diffgram")
-            env_file += 'DATABASE_NAME={}\n'.format('diffgram')
-            env_file += 'DATABASE_HOST={}\n'.format("db")
-            env_file += 'DATABASE_NAME={}\n'.format("diffgram")
-            env_file += 'DATABASE_USER={}\n'.format("postgres")
-            env_file += 'DATABASE_PASS={}\n'.format("postgres")
+            env_file += "POSTGRES_IMAGE=postgres:12.5\n"
+            env_file += "DATABASE_URL=postgresql+psycopg2://postgres:postgres@db/diffgram\n"
+            env_file += "DATABASE_NAME=diffgram\n"
+            env_file += "DATABASE_HOST=db\n"
+            env_file += "DATABASE_NAME=diffgram\n"
+            env_file += "DATABASE_USER=postgres\n"
+            env_file += "DATABASE_PASS=postgres\n"
 
         else:
-            env_file += 'POSTGRES_IMAGE={}\n'.format('tianon/true')
-            env_file += 'DATABASE_URL={}\n'.format(self.database_url)
-            env_file += 'DATABASE_HOST={}\n'.format(self.db_host)
-            env_file += 'DATABASE_NAME={}\n'.format(self.db_name)
-            env_file += 'DATABASE_USER={}\n'.format(self.db_username)
-            env_file += 'DATABASE_PASS={}\n'.format(self.db_pass)
+            env_file += "POSTGRES_IMAGE=tianon/true\n"
+            env_file += f"DATABASE_URL={self.database_url}\n"
+            env_file += f"DATABASE_HOST={self.db_host}\n"
+            env_file += f"DATABASE_NAME={self.db_name}\n"
+            env_file += f"DATABASE_USER={self.db_username}\n"
+            env_file += f"DATABASE_PASS={self.db_pass}\n"
 
         if self.mailgun:
-            env_file += 'MAILGUN_KEY={}\n'.format(self.mailgun_key)
-            env_file += 'EMAIL_DOMAIN_NAME={}\n'.format(self.email_domain)
+            env_file += f"MAILGUN_KEY={self.mailgun_key}\n"
+            env_file += f"EMAIL_DOMAIN_NAME={self.email_domain}\n"
 
         if self.z_flag:
-            env_file += 'INTERNAL_POSTGRES_DIR={}\n'.format('/var/lib/postgresql/data:Z')
+            env_file += "INTERNAL_POSTGRES_DIR=/var/lib/postgresql/data:Z\n"
         else:
-            env_file += 'INTERNAL_POSTGRES_DIR={}\n'.format('/var/lib/postgresql/data')
+            env_file += "INTERNAL_POSTGRES_DIR=/var/lib/postgresql/data\n"
         text_file = open(".env", "w")
         text_file.write(env_file)
         text_file.close()
-        bcolors.printcolor('✓ Environment file written to: {}'.format(os.path.abspath(text_file.name)), bcolors.OKGREEN)        
+        bcolors.printcolor(f"✓ Environment file written to: {os.path.abspath(text_file.name)}", bcolors.OKGREEN)
 
 
     def launch_dockers(self):
@@ -448,7 +448,7 @@ class DiffgramInstallTool:
             print('✓ Diffgram Successfully Launched!')
             print('View the Web UI at: http://localhost:8085')
         except Exception as e:
-            print('Error Launching diffgram {}'.format(str(e)))
+            print(f"Error Launching diffgram {str(e)}")
 
     def set_diffgram_version(self):
         version = bcolors.inputcolor('Enter diffgram version: [Or Press Enter to Get The Latest Version]: ')
@@ -492,7 +492,7 @@ class DiffgramInstallTool:
                     bcolors.printcolor(
                         'Connection test failed: Please check that your DB URL has the correct values and try again.',
                         bcolors.FAIL)
-                    bcolors.printcolor('Error data: {}'.format(str(e)), bcolors.FAIL)
+                    bcolors.printcolor(f"Error data: {str(e)}", bcolors.FAIL)
                     valid = False
 
         z_flag = bcolors.inputcolor('Do Add Z Flag to Postgres Mount? (Use only when using SELinux distros or similar) Y/N [Press Enter to Skip]: ')

--- a/local_dispatcher/local_dispatch.py
+++ b/local_dispatcher/local_dispatch.py
@@ -33,7 +33,7 @@ def route_same_host(path):
     host = 'http://127.0.0.1:8080/'
     host_reached = 'default'
     url_parsed = urllib.parse.urlparse(request.url)
-    path_with_params = '{}?{}'.format(path, urllib.parse.unquote(url_parsed.query))
+    path_with_params = f"{path}?{urllib.parse.unquote(url_parsed.query)}"
     # Walrus
     if path[: 10] == "api/walrus":
         host_reached = 'walrus'
@@ -42,7 +42,7 @@ def route_same_host(path):
     # JS local dev server
     if path[: 3] != "api" or path[: 6] == "static":
         host_reached = 'frontend'
-        return requests.get('http://localhost:8081/{}'.format(path_with_params)).text
+        return requests.get(f"http://localhost:8081/{path_with_params}").text
 
     # https://stackoverflow.com/questions/6656363/proxying-to-another-web-service-with-flask
 
@@ -76,12 +76,12 @@ def route_multi_host(path):
     # Default host
     host = 'http://default:8080/'
     host_reached = 'default'
-    logging.warning('MULTI HOST {}'.format(path))
+    logging.warning("MULTI HOST {path}")
     url_parsed = urllib.parse.urlparse(request.url)
-    path_with_params = '{}?{}'.format(path, urllib.parse.unquote(url_parsed.query))
+    path_with_params = f"{path}?{urllib.parse.unquote(url_parsed.query)}"
     # Walrus
 
-    logging.warning('MULTI path_with_params {}'.format(path_with_params))
+    logging.warning(f"MULTI path_with_params {path_with_params}")
     if path[: 10] == "api/walrus":
         host_reached = 'walrus'
         host = 'http://walrus:8082/'
@@ -138,8 +138,8 @@ def _proxy(path):
     # TODO could switch the path thing to be "diffgram.com"
     # if want to run front end with production end points
     # (or could use a staging endpoint here too...)
-    print('_proxy:*--------> {}'.format(path))
-    logging.warning('_proxy:*--------> {}'.format(path))
+    print(f"_proxy:*--------> {path}")
+    logging.warning(f"_proxy:*--------> {path}")
     if SAME_HOST:
         print('route_same_host')
         return route_same_host(path)

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -412,7 +412,7 @@ class Annotation_Update():
         """
 
         if not self.instance_list_new:
-            logger.error('Error, please provide instance_list_new {}'.format(str(self.log)))
+            logger.error(f"Error, please provide instance_list_new {str(self.log)}")
             return None
 
         # Remove requirement for label_file_id in this case
@@ -425,8 +425,8 @@ class Annotation_Update():
                                   overwrite_existing_instances = True)
 
         if len(self.log["error"].keys()) >= 1:
-            logger.error('Error updating annotation {}'.format(str(self.log)))
-            logger.error('Instance list is: {}'.format(self.instance_list_new))
+            logger.error(f"Error updating annotation {str(self.log)}")
+            logger.error(f"Instance list is: {self.instance_list_new}")
             return self.return_orginal_file_type()
 
         return self.new_added_instances
@@ -449,10 +449,10 @@ class Annotation_Update():
 
         if len(ids_not_included) > 0:
             frame_numbers_instance_list_new = [x.get('frame_number') for x in self.instance_list_new]
-            logger.error('Invalid payload on annotation update missing IDs {}'.format(ids_not_included))
-            logger.error('Frame Number {}'.format(self.frame_number))
-            logger.error('frame_numbers_instance_list_new: {}'.format(frame_numbers_instance_list_new))
-            logger.error('File ID {}'.format(self.file.id))
+            logger.error(f"Invalid payload on annotation update missing IDs {ids_not_included}")
+            logger.error(f"Frame Number {self.frame_number}")
+            logger.error(f"frame_numbers_instance_list_new: {frame_numbers_instance_list_new}")
+            logger.error(f"File ID {self.file.id}")
             self.log['warning'] = {}
             self.log['warning'][
                 'new_instance_list_missing_ids'] = 'Invalid payload sent to server, missing the following instances IDs {}'.format(
@@ -509,8 +509,8 @@ class Annotation_Update():
         payload_includes_all_instances = self.__check_all_instances_available_in_new_instance_list()
 
         if not payload_includes_all_instances:
-            logger.error('Error updating annotation {}'.format(str(self.log)))
-            logger.error('Instance list is: {}'.format(self.instance_list_new))
+            logger.error(f"Error updating annotation {str(self.log)}")
+            logger.error(f"Instance list is: {self.instance_list_new}")
             return self.return_orginal_file_type()
 
         self.build_existing_hash_list()
@@ -525,8 +525,8 @@ class Annotation_Update():
         # This may be a little aggressive, eg maybe shuold just "warn" on instances that are invalid.
         # Primary concern in current context is that we don't delete left over ones.
         if len(self.log["error"].keys()) >= 1:
-            logger.error('Error updating annotation {}'.format(str(self.log)))
-            logger.error('Instance list is: {}'.format(self.instance_list_new))
+            logger.error(f"Error updating annotation {str(self.log)}")
+            logger.error(f"Instance list is: {self.instance_list_new}")
             return self.return_orginal_file_type()
 
         self.update_file_hash()
@@ -547,7 +547,7 @@ class Annotation_Update():
                     member = self.member)
 
         else:
-            logger.error('Error updating annotation {}'.format(str(self.log)))
+            logger.error(f"Error updating annotation {str(self.log)}")
         return self.return_orginal_file_type()
 
     def main(self):
@@ -680,8 +680,8 @@ class Annotation_Update():
             else:
                 # Collision detected, we keep the newest instance by created time (which was order sorted).
                 # So this one is just to be deleted and not added to results.
-                logger.warning('Collision detected on {} instance id: {}'.format(inst.hash, inst.id))
-                logger.warning('hashes_dict: {}'.format(hashes_dict))
+                logger.warning(f"Collision detected on {inst.hash} instance id: {inst.id}")
+                logger.warning(f"hashes_dict: {hashes_dict}")
                 inst.soft_delete = True
                 inst.action_type = "from_collision"
                 self.session.add(inst)
@@ -746,7 +746,7 @@ class Annotation_Update():
         """
         project = self.project
         if self.task:
-            logger.info('getting project from task {}'.format(self.task.id))
+            logger.info(f"getting project from task {self.task.id}")
             project = self.task.project
 
         assert project is not None
@@ -867,7 +867,7 @@ class Annotation_Update():
             self.log['duplicate_instance_refs'] = [existing_instance.get('creation_ref_id')]
 
         self.log['debug'] = self.__build_debug_log()
-        logger.warning('Error Duplicate IDs detected on instance_list. Id is: {}'.format(existing_instance.get('id')))
+        logger.warning(f"Error Duplicate IDs detected on instance_list. Id is: {existing_instance.get('id')}")
 
         instance_created_time = instance.get('client_created_time')
         if instance_created_time is None:
@@ -999,7 +999,7 @@ class Annotation_Update():
         try:
             cleaned_instance_list = self.__identify_and_merge_duplicate_ids(self.instance_list_new)
         except Exception as exception:
-            logger.warning(str(exception) + "_trace_4f36a2aa")
+            logger.warning(f"{str(exception)}_trace_4f36a2aa")
             communicate_via_email.send(settings.DEFAULT_ENGINEERING_EMAIL,
                                        '[Exception] Duplicate ID On Annotation_Update', str(self.log))
         valid_models = self.check_allowed_model_ids(cleaned_instance_list)
@@ -1112,7 +1112,7 @@ class Annotation_Update():
             )
 
     def get_min_coordinates_instance(self, instance):
-        logger.debug('Getting min coordinates for {} - {}'.format(instance.id, instance.type))
+        logger.debug(f"Getting min coordinates for {instance.id} - {instance.type}")
 
         if instance.type in ['text_token', 'relation', 'global']:
             return 0, 0
@@ -1162,11 +1162,11 @@ class Annotation_Update():
                    instance.center_3d['y'] - (instance.dimensions_3d['height'] / 2), \
                    instance.center_3d['z'] - (instance.dimensions_3d['depth'] / 2)
         else:
-            logger.error('Invalid instance type for image crop: {}'.format(instance.type))
+            logger.error(f"Invalid instance type for image crop: {instance.type}")
             return None
 
     def get_max_coordinates_instance(self, instance):
-        logger.debug('Getting max coordinates for {} - {}'.format(instance.id, instance.type))
+        logger.debug(f"Getting max coordinates for {instance.id} - {instance.type}")
 
         if instance.type in ['text_token', 'relation', 'global']:
             return 0, 0
@@ -1215,7 +1215,7 @@ class Annotation_Update():
                    instance.center_3d['y'] + (instance.dimensions_3d['height'] / 2), \
                    instance.center_3d['z'] + (instance.dimensions_3d['depth'] / 2)
         else:
-            logger.error('Invalid instance type for image crop: {}'.format(instance.type))
+            logger.error(f"Invalid instance type for image crop: {instance.type}")
             return None
 
     def update_instance(self,
@@ -1302,11 +1302,11 @@ class Annotation_Update():
             member_created_id = self.member.id
 
         if self.file:
-            logger.debug('Creating Instance with file id: {}'.format(self.file.id))
-            logger.debug('Creating Instance with project id: {}'.format(self.file.project.id))
-            logger.debug('Creating Instance with type: {}'.format(type))
+            logger.debug(f"Creating Instance with file id: {self.file.id}")
+            logger.debug(f"Creating Instance with project id: {self.file.project.id}")
+            logger.debug(f"Creating Instance with type: {type}")
             logger.debug(
-                'Creating Instance with TOKENS: {} {} {} {}'.format(start_sentence, end_sentence, end_char, start_char))
+                f"Creating Instance with TOKENS: {start_sentence} {end_sentence} {end_char} {start_char}")
         if version is None:
             version = 0
         version += 1
@@ -1383,13 +1383,13 @@ class Annotation_Update():
                                           to_ref = to_creation_ref)
 
         if len(self.log["error"].keys()) >= 1:
-            logger.error('Error on instance creation {}'.format(self.log))
+            logger.error(f"Error on instance creation {self.log}")
             return False
 
         self.deduct_spatial_coordinates()
 
         if len(self.log["error"].keys()) >= 1:
-            logger.error('Error on instance creation {}'.format(self.log))
+            logger.error(f"Error on instance creation {self.log}")
             return False
 
         """
@@ -1409,14 +1409,14 @@ class Annotation_Update():
         try:  # wrap new concept in try block just in case
             self.instance = self.__validate_user_deletion(self.instance, is_new_instance)
         except Exception as e:
-            logger.error(str(e) + ' trace_82j2j__validate_user_deletion')
+            logger.error(f"{str(e)} trace_82j2j__validate_user_deletion")
             communicate_via_email.send(settings.DEFAULT_ENGINEERING_EMAIL, '[Exception] __validate_user_deletion',
                                        str(self.log))
 
         self.__perform_external_map_action()
 
         self.update_cache_single_instance_in_list_context()
-        logger.debug('is_new_instance {}'.format(is_new_instance))
+        logger.debug(f"is_new_instance {is_new_instance}")
         if is_new_instance is False:
             return
 
@@ -1730,7 +1730,7 @@ class Annotation_Update():
         else:
             # This case can happen when 2 instances with the exact same data are sent on instance_list_new.
             # We only want to keep one of them.
-            logger.warning('Got duplicated hash {}'.format(self.instance.hash))
+            logger.warning(f"Got duplicated hash {self.instance.hash}")
             # The instance_dict hash will always have the newest instance (sorted by created_time)
             self.duplicate_hash_new_instance_list.append(self.instance)
             existing_instance = self.new_instance_dict_hash[self.instance.hash]
@@ -2047,7 +2047,7 @@ class Annotation_Update():
         self,
         instance):
 
-        logger.info("Newly Deleted {}".format(instance.id))
+        logger.info(f"Newly Deleted {instance.id}")
 
         self.new_deleted_instances.append(instance.id)
 
@@ -2104,7 +2104,7 @@ def task_annotation_update(
 
     except Exception as e:
         trace = traceback.format_exc()
-        logger.error('File {} is Locked'.format(task.file_id))
+        logger.error(f"File {task.file_id} is Locked")
         logger.error(trace)
         log['error']['file_locked'] = 'File is being saved by another process, please try again later.'
         return False, None
@@ -2190,7 +2190,7 @@ def annotation_update_web(
             file_id = file_id)
     except Exception as e:
         trace = traceback.format_exc()
-        logger.error('File {} is Locked'.format(file_id))
+        logger.error(f"File {file_id} is Locked")
         logger.error(trace)
         log['error']['file_locked'] = 'File is being saved by another process, please try again later.'
         return False, None
@@ -2229,7 +2229,7 @@ def annotation_update_web(
         member_id = user.member_id,
         project_id = project.id,
         file_id = new_file.id,
-        description = "Changed " + str(new_file.count_instances_changed)
+        description = f"Changed {str(new_file.count_instances_changed)}"
     )
 
     return new_file.serialize_with_type(session), annotation_update

--- a/shared/communicate/email.py
+++ b/shared/communicate/email.py
@@ -12,9 +12,9 @@ class Communicate_Via_Email():
 
     def send(self, email, subject, message, email_list = []):
 
-        result = requests.post("https://api.mailgun.net/v3/" + self.domain_name + "/messages",
+        result = requests.post(f"https://api.mailgun.net/v3/{self.domain_name}/messages",
                              auth = ("api", self.api_key),
-                             data = {"from": "Diffgram <web@" + self.domain_name + ">",
+                             data = {"from": f"Diffgram <web@{self.domain_name}>",
                                      "to": [str(email)] if len(email_list) == 0 else [str(email) for email in
                                                                                       email_list],
                                      "subject": str(subject),

--- a/shared/connection/test_connection.py
+++ b/shared/connection/test_connection.py
@@ -58,9 +58,9 @@ class Test():
 			for i,s in enumerate(difflib.ndiff(a, b)):
 				if s[0]==' ': continue
 				elif s[0]=='-':
-					print(u'Delete "{}" from position {}'.format(s[-1],i))
+					print(f'Delete "{s[-1]}" from position {i}')
 				elif s[0]=='+':
-					print(u'Add "{}" to position {}'.format(s[-1],i))  
+					print(f'Add "{s[-1]}" to position {i}')  
 
 		# Diff falsely fails here....
 

--- a/shared/data_tools_core_azure.py
+++ b/shared/data_tools_core_azure.py
@@ -234,7 +234,7 @@ class DataToolsAzure:
             start = datetime.datetime.utcnow(),
             expiry = expiry_time,
             permission = BlobSasPermissions(read = True),
-            content_disposition = 'attachment; filename=' + filename,
+            content_disposition = f"attachment; filename={filename}",
         )
         sas_url = 'https://{}.blob.core.windows.net/{}/{}?{}'.format(
             self.azure_service_client.account_name,

--- a/shared/data_tools_core_gcp.py
+++ b/shared/data_tools_core_gcp.py
@@ -58,7 +58,7 @@ class DataToolsGCP:
         url = blob.create_resumable_upload_session(content_type = content_type)
         if input is not None:
             input.resumable_url = url
-        logger.info('New GCP Resumable upload: {}'.format(url))
+        logger.info(f"New GCP Resumable upload: {url}")
         return url
 
     def transmit_chunk_of_resumable_upload(
@@ -125,9 +125,9 @@ class DataToolsGCP:
                 data = stream,
                 headers = headers
             )
-            logger.info('GCP Chunk Response: {}'.format(response))
+            logger.info(f"GCP Chunk Response: {response}")
         except Exception as e:
-            logger.error('Upload TO GCP Failed: {}'.format(traceback.format_exc()))
+            logger.error(f"Upload TO GCP Failed: {traceback.format_exc()}")
             raise e
             # TODO if we are going to have a try block
             # here should we error / pass this to Input instance in some way?
@@ -244,7 +244,7 @@ class DataToolsGCP:
         filename = blob_name.split("/")[-1]
         url_signed = blob.generate_signed_url(
             expiration = expiration_time,
-            response_disposition = 'attachment; filename=' + filename
+            response_disposition = f"attachment; filename={filename}"
         )
         return url_signed
 
@@ -288,13 +288,13 @@ class DataToolsGCP:
 
         inference.url_signed_expiry = int(time.time() + 2592000)  # 1 month
 
-        dir = ai.ml.blob_dir + "/out/" + str(inference.image.id)
+        dir = f"{ai.ml.blob_dir}/out/{str(inference.image.id)}"
 
-        blob = self.bucket.blob(dir + "_out.jpg")
+        blob = self.bucket.blob(f"{dir}_out.jpg")
         inference.processed_image_url = blob.generate_signed_url(
             expiration = inference.url_signed_expiry)
 
-        blob = self.bucket.blob(dir + "_out_thumb.jpg")
+        blob = self.bucket.blob(f"{dir}_out_thumb.jpg")
         inference.processed_image_url_thumb = blob.generate_signed_url(
             expiration = inference.url_signed_expiry)
 
@@ -304,7 +304,7 @@ class DataToolsGCP:
 
         # TODO this name may changed base on AI package
 
-        blob_name = version.ml.blob_dir + "/frozen/frozen_inference_graph.pb"
+        blob_name = f"{version.ml.blob_dir}/frozen/frozen_inference_graph.pb"
         version.ml.url_model = self.build_secure_url(
             blob_name,
             600,
@@ -315,7 +315,7 @@ class DataToolsGCP:
     def url_tensorboard_update(self, session, version):
         # Careful this returns blob object not name
         blob = list(self.ML_bucket.list_blobs(
-            prefix = version.ml.blob_dir + "/events",
+            prefix = f"{version.ml.blob_dir}/events",
             max_results = 1))
         if len(blob) >= 1:
             version.ml.url_tensorboard = self.build_secure_url(
@@ -374,15 +374,15 @@ class DataToolsGCP:
         out = ""
         for i, file in enumerate(file_list):
             new = "\nitem {"
-            id = "\nid: " + str(label_dict[file.id])
-            name = "\nname: '" + str(file.label.name) + "'\n }\n"
+            id = f"\nid: {str(label_dict[file.id])}"
+            name = f"\nname: '{str(file.label.name)}'\n }}\n"
             out += new + id + name
 
-        blob = self.ML_bucket.blob(ai.ml.blob_dir + "/label_map.pbtext")
+        blob = self.ML_bucket.blob(f"{ai.ml.blob_dir}/label_map.pbtext")
         blob.upload_from_string(out, content_type = 'text/pbtext')
 
         # TODO maybe rename to label_map_job_dir  ? to differentiate between blob and ml job
-        ai.ml.label_map_dir = ai.ml.job_dir + "/label_map.pbtext"
+        ai.ml.label_map_dir = f"{ai.ml.job_dir}/label_map.pbtext"
 
         print("Built label_map", file = sys.stderr)
 
@@ -463,8 +463,8 @@ class DataToolsGCP:
 
         yaml_data = yaml.dump(annotations_list, default_flow_style = False)
         json_data = json.dumps(annotations_list)
-        ai.ml.annotations_string_yaml = ai.ml.blob_dir + "/annotations.yaml"
-        ai.ml.annotations_string_json = ai.ml.blob_dir + "/annotations.json"
+        ai.ml.annotations_string_yaml = f"{ai.ml.blob_dir}/annotations.yaml"
+        ai.ml.annotations_string_json = f"{ai.ml.blob_dir}/annotations.json"
         session.add(ai)
         blob = self.ML_bucket.blob(ai.ml.annotations_string_yaml)
         blob.upload_from_string(yaml_data, content_type = 'text/yaml')
@@ -502,7 +502,7 @@ class DataToolsGCP:
                 start_at_1_label += 1
                 lowest_label = label_id
 
-        project_str = str(project.id) + "/" + str(version.id) + "/ml/" + str(ml_settings.ml_compute_engine_id)
+        project_str = f"{str(project.id)}/{str(version.id)}/ml/{str(ml_settings.ml_compute_engine_id)}"
         project_str += "/label_map.pbtext"
 
         categoryMap = {}

--- a/shared/data_tools_core_s3.py
+++ b/shared/data_tools_core_s3.py
@@ -238,7 +238,7 @@ class DataToolsS3:
         signed_url = self.s3_client.generate_presigned_url('get_object',
                                                            Params = {
                                                                'Bucket': bucket_name,
-                                                               'ResponseContentDisposition': 'attachment; filename=' + filename,
+                                                               'ResponseContentDisposition': f"attachment; filename={filename}",
                                                                'Key': blob_name},
                                                            ExpiresIn = int(expiration_time))
         return signed_url

--- a/shared/database/action/action_flow.py
+++ b/shared/database/action/action_flow.py
@@ -218,12 +218,12 @@ class Action_Flow(Base):
 
         flow.string_id = safe_name(flow.name)
 
-        flow.string_id += "_" + create_random_string(length = 20)
+        flow.string_id += f"_{create_random_string(length=20)}"
 
 
 # 'abcdefghijklmnopqrstuvwxyz0123456789'
 # can add chars in front if needed ie "." etc.
-valid_chars = "%s%s" % (string.ascii_letters, string.digits)
+valid_chars = f"{string.ascii_letters}{string.digits}"
 
 
 def safe_name(name, character_limit = 10):

--- a/shared/database/event/event.py
+++ b/shared/database/event/event.py
@@ -237,7 +237,7 @@ class Event(Base):
                 id = event_id,
                 base_class_string = 'Event')
 
-            logger.debug('Sent interservice request for Event: {}'.format(event_id))
+            logger.debug(f"Sent interservice request for Event: {event_id}")
 
     @staticmethod
     def __launch_new_event_threaded(**kwargs):
@@ -344,13 +344,13 @@ class Event(Base):
             event_data['event_type'] = 'user'
             result = requests.post(settings.EVENTHUB_URL, json = event_data)
             if result.status_code == 200:
-                logger.info("Sent event: {} to Diffgram Eventhub".format(self.id))
+                logger.info(f"Sent event: {self.id} to Diffgram Eventhub")
             else:
                 # print(result, result.text)
                 logger.error(
                     "Error sending {} to Diffgram Eventhub. Status Code: ".format(self.id, result.status_code))
         except Exception as e:
-            logger.error("Exception sending {} to Diffgram Eventhub: ".format(str(e)))
+            logger.error(f"Exception sending {str(e)} to Diffgram Eventhub: ")
 
     @staticmethod
     def identify_user(user):
@@ -416,7 +416,7 @@ class Event(Base):
                 }
             )
         except Exception as e:
-            logger.error('Error tracking user: {}'.format(e))
+            logger.error(f"Error tracking user: {e}")
             pass
 
     @staticmethod

--- a/shared/database/export.py
+++ b/shared/database/export.py
@@ -142,7 +142,7 @@ class Export(Base):
 
         share_request = None
         if self.user:
-            share_request = "Request " + self.user.email + " to access the project to visually explore this data."
+            share_request = f"Request {self.user.email} to access the project to visually explore this data."
 
         return {
             'docs_high_level': docs_high_level,

--- a/shared/database/hashing_functions.py
+++ b/shared/database/hashing_functions.py
@@ -27,7 +27,7 @@ def hash_str(string__):
 
 def make_secure_val(string__):
 	string__ = str(string__)
-	return "%s,%s" % (string__, hash_str(string__))
+	return f"{string__},{hash_str(string__)}"
 
 
 def check_secure_val(secure_value):
@@ -74,7 +74,7 @@ def make_password_hash(email, password, salt=None, iterations=None):
 
 	# Future, upgrade to Scrypt or Argon2
 
-	return '%s,%s,%s' % (hash, salt, iterations)
+	return f"{hash},{salt},{iterations}"
 
 
 def valid_password(email, attempted_password, hash):

--- a/shared/database/notifications/notification.py
+++ b/shared/database/notifications/notification.py
@@ -113,9 +113,9 @@ class Notification(Base):
 
     def __build_subject_and_message_for_task(self, session, start_time, event_type='completion'):
         print('BUILDING EMAIL', start_time, event_type)
-        subject = 'New Task Completed: {}'.format(self.notification_relation.task_id)
+        subject = f"New Task Completed: {self.notification_relation.task_id}"
         if event_type == 'creation':
-            subject = 'New Task Created: {}'.format(self.notification_relation.task_id)
+            subject = f"New Task Created: {self.notification_relation.task_id}"
 
         if start_time:
             subject = 'New Tasks Completed.'
@@ -144,8 +144,8 @@ class Notification(Base):
 
             links_list = ''
             for task in tasks_in_time_window:
-                url_task = '[{}] {}task/{}'.format(task.job.name, settings.URL_BASE, task.id)
-                links_list += '{} \n'.format(url_task)
+                url_task = f"[{task.job.name}] {settings.URL_BASE}task/{task.id}"
+                links_list += f"{url_task} \n"
             message += links_list
         else:
             message = 'New Task completed on Project: {} \n Task completed by: {} {} \n'.format(
@@ -164,8 +164,8 @@ class Notification(Base):
         return subject, message
 
     def __build_subject_and_message_for_task_template(self):
-        url_task_template = '{}job/{}'.format(settings.URL_BASE, self.notification_relation.job_id)
-        subject = 'New Task Template Completed: {}'.format(self.notification_relation.job_id)
+        url_task_template = f'{settings.URL_BASE}job/{self.notification_relation.job_id}'
+        subject = f'New Task Template Completed: {self.notification_relation.job_id}'
         message = 'New Task Template completed on Project: {} \n To View the Task Template click the following link: {}'.format(
             self.notification_relation.job.project.name,
             url_task_template
@@ -173,7 +173,7 @@ class Notification(Base):
         return subject, message
 
     def __build_subject_and_message_for_file_upload(self, session=None, start_time=None):
-        subject = 'New File Uploaded: {}'.format(self.notification_relation.input.file_id)
+        subject = f"New File Uploaded: {self.notification_relation.input.file_id}"
 
         if start_time:
             subject = 'New Files Uploaded.'
@@ -189,8 +189,8 @@ class Notification(Base):
             print('fileees', files, start_time, datetime.datetime.utcnow())
             links_list = ''
             for file in files:
-                url_task = '==> {}file/{}'.format(settings.URL_BASE, file.id)
-                links_list += '{} \n'.format(url_task)
+                url_task = f"==> {settings.URL_BASE}file/{file.id}"
+                links_list += f"{url_task} \n"
             message += links_list
         else:
             message = 'New File uploaded on Project: {} \n File uploaded by: {} {} \n'.format(

--- a/shared/database/source_control/file.py
+++ b/shared/database/source_control/file.py
@@ -617,8 +617,7 @@ class File(Base, Caching):
                 session, project_id, untrusted_file_id)
 
             if file is None:
-                raise Forbidden("File id not in project " + \
-                                str(untrusted_file_id))
+                raise Forbidden(f"File id not in project {str(untrusted_file_id)}")
 
             if return_mode == "id":
                 trusted_file_list.append(file.id)
@@ -760,8 +759,8 @@ class File(Base, Caching):
         if remove_link is True:
             working_dir_database_models.WorkingDirFileLink.remove(session, working_dir_id, existing_file.id)
 
-        logger.debug('existing_file.type {}'.format(existing_file.type))
-        logger.debug('copy_instance_list {}'.format(copy_instance_list))
+        logger.debug(f"existing_file.type {existing_file.type}")
+        logger.debug(f"copy_instance_list {copy_instance_list}")
         if existing_file.type in ['image', 'frame'] and copy_instance_list is True:
 
             file.count_instances_changed = existing_file.count_instances_changed
@@ -771,12 +770,12 @@ class File(Base, Caching):
                 session = session,
                 file_id = existing_file.id,
                 limit = None)   # Excludes removed by default
-            logger.debug('instance_list len {}'.format(len(instance_list)))
+            logger.debug(f"instance_list len {len(instance_list)}")
             for instance in instance_list:
 
                 instance_sequence_id = instance.sequence_id
                 if sequence_map is not None:
-                    logger.debug('sequence_map {}'.format(sequence_map))
+                    logger.debug(f"sequence_map {sequence_map}")
                     instance_sequence_id = sequence_map.get(instance_sequence_id)
 
                 new_instance = Instance(

--- a/shared/database/source_control/working_dir.py
+++ b/shared/database/source_control/working_dir.py
@@ -166,7 +166,7 @@ class WorkingDir(Base):
 
         if nickname:
             if nickname_match_type == "ilike":
-                nickname_search = "%{}%".format(nickname)
+                nickname_search = f"%{nickname}%"
                 query = query.filter(WorkingDir.nickname.ilike(nickname_search))
             else:
                 query = query.filter(WorkingDir.nickname == nickname)
@@ -576,7 +576,7 @@ class WorkingDirFileLink(Base):
 
         if original_filename is not None:
             if original_filename_match_type == "ilike":
-                original_filename_search = "%{}%".format(original_filename)
+                original_filename_search = f"%{original_filename}%"
                 query = query.filter(File.original_filename.ilike(original_filename_search))
             else:
                 query = query.filter(File.original_filename == original_filename)

--- a/shared/database/sync_events/sync_action_queue.py
+++ b/shared/database/sync_events/sync_action_queue.py
@@ -17,7 +17,7 @@ class SyncActionsQueue(Base):
 
     @staticmethod
     def enqueue(session, sync_event):
-        logger.info('Sending sync event to queue - ID: {}'.format(sync_event.id))
+        logger.info(f"Sending sync event to queue - ID: {sync_event.id}")
         elm = SyncActionsQueue(sync_event=sync_event)
         session.add(elm)
         return elm

--- a/shared/database/system_events/system_events.py
+++ b/shared/database/system_events/system_events.py
@@ -69,7 +69,7 @@ class SystemEvents(Base):
             SystemEvents.new(
                 session = session,
                 kind = 'system_startup',
-                description = 'Diffgram System startup for {} service'.format(service_name),
+                description = f"Diffgram System startup for {service_name} service",
                 install_fingerprint = settings.DIFFGRAM_INSTALL_FINGERPRINT,
                 previous_version = None,
                 diffgram_version = settings.DIFFGRAM_VERSION_TAG,
@@ -92,7 +92,7 @@ class SystemEvents(Base):
         :param session:
         :return:
         """
-        logger.info('Checking for version upgrades [{}]'.format(service_name))
+        logger.info(f"Checking for version upgrades [{service_name}]")
         latest_recorded_version_event = session.query(SystemEvents).filter(
             SystemEvents.kind == 'version_upgrade'
         ).order_by('created_date').first()
@@ -102,7 +102,7 @@ class SystemEvents(Base):
             system_event = SystemEvents.new(
                 session = session,
                 kind = 'version_upgrade',
-                description = 'Diffgram System startup for {} service'.format(service_name),
+                description = f"Diffgram System startup for {service_name} service",
                 install_fingerprint = settings.DIFFGRAM_INSTALL_FINGERPRINT,
                 previous_version = None,
                 diffgram_version = settings.DIFFGRAM_VERSION_TAG,
@@ -120,11 +120,11 @@ class SystemEvents(Base):
             recorded_version = latest_recorded_version_event.diffgram_version
             version_to_check = settings.DIFFGRAM_VERSION_TAG
             if version.parse(version_to_check) > version.parse(recorded_version):
-                logger.info('New version detected: [{}]'.format(version_to_check))
+                logger.info(f"New version detected: [{version_to_check}]")
                 system_event = SystemEvents.new(
                     session = session,
                     kind = 'version_upgrade',
-                    description = 'Diffgram System startup for {} service'.format(service_name),
+                    description = f"Diffgram System startup for {service_name} service",
                     install_fingerprint = settings.DIFFGRAM_INSTALL_FINGERPRINT,
                     previous_version = None,
                     diffgram_version = version_to_check,
@@ -137,11 +137,11 @@ class SystemEvents(Base):
                 )
                 return system_event
             elif version_to_check < recorded_version:
-                logger.info('Downgrade version detected: [{}]'.format(version_to_check))
+                logger.info(f"Downgrade version detected: [{version_to_check}]")
                 system_event = SystemEvents.new(
                     session = session,
                     kind = 'version_downgrade',
-                    description = 'Diffgram System startup for {} service'.format(service_name),
+                    description = f"Diffgram System startup for {service_name} service",
                     install_fingerprint = settings.DIFFGRAM_INSTALL_FINGERPRINT,
                     previous_version = None,
                     diffgram_version = version_to_check,
@@ -192,7 +192,7 @@ class SystemEvents(Base):
             system_event = SystemEvents.new(
                 session = session,
                 kind = 'os_change',
-                description = 'OS Change for {} service'.format(service_name),
+                description = f"OS Change for {service_name} service",
                 install_fingerprint = settings.DIFFGRAM_INSTALL_FINGERPRINT,
                 previous_version = None,
                 diffgram_version = settings.DIFFGRAM_VERSION_TAG,
@@ -258,7 +258,7 @@ class SystemEvents(Base):
             )
             return True
         except Exception as e:
-            logger.error('Error sending event to segment: {}'.format(str(e)))
+            logger.error(f"Error sending event to segment: {str(e)}")
             logger.error(traceback.format_exc())
             pass
 
@@ -274,13 +274,13 @@ class SystemEvents(Base):
             event_data['event_type'] = 'system'
             result = requests.post(settings.EVENTHUB_URL, json = event_data, timeout = 3)
             if result.status_code in [200, 202]:
-                logger.info("Sent event: {} to Diffgram Eventhub [{}]".format(self.id, result.status_code))
+                logger.info(f"Sent event: {self.id} to Diffgram Eventhub [{result.status_code}]")
                 return True
             else:
                 logger.error(
-                    "Error sending {} to Diffgram Eventhub. Status Code: {}".format(self.id, result.status_code))
+                    f"Error sending {self.id} to Diffgram Eventhub. Status Code: {result.status_code}")
         except Exception as e:
-            logger.error("Exception sending {} to Diffgram Eventhub: ".format(str(e)))
+            logger.error(f"Exception sending {str(e)} to Diffgram Eventhub: ")
 
     @staticmethod
     def new(session,

--- a/shared/database/task/job/job.py
+++ b/shared/database/task/job/job.py
@@ -433,7 +433,7 @@ class Job(Base, Caching):
                     member_id=member_id)
                 if not user:
                     log['error']['reviewer_list'] = {}
-                    log['error']['reviewer_list'][member_id] = "Invalid member_id " + str(member_id)
+                    log['error']['reviewer_list'][member_id] = f"Invalid member_id {str(member_id)}"
                     return log
                 else:
                     user_list.append(user)
@@ -533,7 +533,7 @@ class Job(Base, Caching):
 
                 if not user:
                     log['error']['update_member_list'] = {}
-                    log['error']['update_member_list'][member_id] = "Invalid member_id " + str(member_id)
+                    log['error']['update_member_list'][member_id] = f"Invalid member_id {str(member_id)}"
                     return log
                 else:
                     user_list.append(user)

--- a/shared/database/task/task_time_tracking.py
+++ b/shared/database/task/task_time_tracking.py
@@ -118,7 +118,7 @@ class TaskTimeTracking(Base, SerializerMixin):
         existing_global_record = True
         if time_track_record_global is None:
             # Create new Record
-            logger.info('New Global Track Time Record task_id:{} status:{} user_id:{}'.format(task_id, status, user_id))
+            logger.info(f"New Global Track Time Record task_id:{task_id} status:{status} user_id:{user_id}")
             time_track_record_global = TaskTimeTracking(
                 job_id = job_id,
                 task_id = task_id,
@@ -134,7 +134,7 @@ class TaskTimeTracking(Base, SerializerMixin):
 
         existing_status_record = True
         if time_track_record is None:
-            logger.info('New Status Track Time Record task_id:{} status:{} user_id:{}'.format(task_id, status, user_id))
+            logger.info(f"New Status Track Time Record task_id:{task_id} status:{status} user_id:{user_id}")
             # Create a status specific record
             time_track_record = TaskTimeTracking(
                 job_id = job_id,
@@ -152,7 +152,7 @@ class TaskTimeTracking(Base, SerializerMixin):
 
         if existing_global_record or existing_status_record:
             # Update Record
-            logger.info('Update Track Time Record task_id:{} status:{} user_id:{}'.format(task_id, status, user_id))
+            logger.info(f"Update Track Time Record task_id:{task_id} status:{status} user_id:{user_id}")
             old_global_time = time_track_record_global.time_spent
             if old_global_time < time_spent:
                 new_time_spent_delta = time_spent - old_global_time

--- a/shared/database/ui_schema/ui_schema.py
+++ b/shared/database/ui_schema/ui_schema.py
@@ -172,7 +172,7 @@ class UI_Schema(Base, SerializerMixin):
 
         if name:
             if name_match_type == "ilike":
-                name_search = "%{}%".format(name)
+                name_search = f"%{name}%"
                 query = query.filter(UI_Schema.name.ilike(name_search))
             else:
                 query = query.filter(UI_Schema.name == name)

--- a/shared/database/userscript/userscript.py
+++ b/shared/database/userscript/userscript.py
@@ -134,7 +134,7 @@ class UserScript(Base):
 
         if name:
             if name_match_type == "ilike":
-                name_search = "%{}%".format(name)
+                name_search = f"%{name}%"
                 query = query.filter(UserScript.name.ilike(name_search))
             else:
                 query = query.filter(UserScript.name == name)

--- a/shared/database/video/sequence.py
+++ b/shared/database/video/sequence.py
@@ -199,7 +199,7 @@ class Sequence(Base):
                 instance = self.get_preview_instance(session = session)
 
                 if instance:
-                    logger.debug("Rebuilding Instance {} Preview".format(instance.id))
+                    logger.debug(f"Rebuilding Instance {instance.id} Preview")
 
                     self.instance_preview_cache = instance.serialize_for_sequence_preview(
                         session = session)
@@ -229,7 +229,7 @@ class Sequence(Base):
             the instance we are getting has a thumbnail.
         """
         if instance:
-            logger.debug('Regenerating instance thumb for {}'.format(instance.id))
+            logger.debug(f"Regenerating instance thumb for {instance.id}")
             self.regenerate_instance_thumb(
                 session = session,
                 instance = instance)
@@ -303,7 +303,7 @@ class Sequence(Base):
         is_new_sequence = False
 
         # Default case, instance already had a sequence id
-        logger.debug('Updating sequence for sequence id {}'.format(instance.sequence_id))
+        logger.debug(f"Updating sequence for sequence id {instance.sequence_id}")
         if instance.sequence_id:
             sequence = Sequence.update_single_existing_sequence(
                 session = session,
@@ -312,7 +312,7 @@ class Sequence(Base):
             )
 
         if not instance.sequence_id:
-            logger.debug('No ID checking for number {}'.format(instance.number))
+            logger.debug(f"No ID checking for number {instance.number}")
             # Most common case for new instances
             # We have a number from UI but we don't have it mapped To a sequence
 

--- a/shared/feature_flags/feature_checker.py
+++ b/shared/feature_flags/feature_checker.py
@@ -92,13 +92,13 @@ class FeatureChecker:
         if self.user:
             if self.user.default_plan:
                 plan = self.user.default_plan
-                logger.info('User on plan {}'.format(plan.template.public_name))
+                logger.info(f"User on plan {plan.template.public_name}")
             else:
                 plan = self.get_or_create_free_plan()
                 # Attach free plan to users who don't have the plan
                 self.user.default_plan = plan
                 self.session.add(self.user)
-                logger.info('Attached new free plan to user {}'.format(self.user.id))
+                logger.info(f"Attached new free plan to user {self.user.id}")
 
         elif self.project:
             plan = self.project.plan
@@ -107,8 +107,8 @@ class FeatureChecker:
                 # Attach free plan to project that don't have the plan
                 self.project.plan = plan
                 self.session.add(self.project)
-                logger.info('Attached new free plan to project {}'.format(self.project.project_string_id))
-            logger.info('project on plan {}'.format(plan.template.public_name))
+                logger.info(f"Attached new free plan to project {self.project.project_string_id}")
+            logger.info(f"project on plan {plan.template.public_name}")
         if not plan:
             return None
 

--- a/shared/instance_tools.py
+++ b/shared/instance_tools.py
@@ -71,8 +71,7 @@ class Instance_tools():
 
 	def get_migration_path(self, project, image):
 
-		return settings.PROJECT_IMAGES_BASE_DIR + \
-			str(project.id) + "/" + str(image.id)
+		return f"{settings.PROJECT_IMAGES_BASE_DIR + str(project.id)}/{str(image.id)}"
 
 
 
@@ -84,8 +83,8 @@ class Instance_tools():
 		x_min, y_min = instance.x_min, instance.y_min
 		x_max, y_max = instance.x_max, instance.y_max
 		print(x_min, y_min, x_max, y_max)
-		logger.debug('Min Coordinates: ({},{})'.format(x_min, y_min))
-		logger.debug('Max Coordinates: ({},{})'.format(x_max, y_max))
+		logger.debug(f"Min Coordinates: ({x_min},{y_min})")
+		logger.debug(f"Max Coordinates: ({x_max},{y_max})")
 		cropped_image = image[y_min : y_max, x_min : x_max]
 
 		# Maintain aspect ratio
@@ -111,10 +110,10 @@ class Instance_tools():
 		# as well, but I think it would reduce other issues if we saved
 		# it to the sequence instead?
 
-		image_out_filename = self.temp + 'image_out.jpg'
+		image_out_filename = f"{self.temp}image_out.jpg"
 		imwrite(image_out_filename, cropped_image)
 
-		instance.preview_image_blob_dir = settings.PROJECT_INSTANCES_IMAGES_BASE_DIR + str(instance.id) + "/_thumb.jpg"
+		instance.preview_image_blob_dir = f"{settings.PROJECT_INSTANCES_IMAGES_BASE_DIR + str(instance.id)}/_thumb.jpg"
 
 		data_tools.upload_to_cloud_storage(
 			temp_local_path = image_out_filename,

--- a/shared/permissions/project_permissions.py
+++ b/shared/permissions/project_permissions.py
@@ -84,7 +84,7 @@ class Project_permissions():
 
         with sessionMaker.session_scope() as session:
             if not project_string_id or project_string_id == "null" or project_string_id == "undefined":
-                raise Forbidden(default_denied_message + " [ First Sanity Checks ] project_string_id None, null, etc.")
+                raise Forbidden(f"{default_denied_message} [ First Sanity Checks ] project_string_id None, null, etc.")
 
             project = Project.get(session, project_string_id)
             if project is None:
@@ -95,20 +95,20 @@ class Project_permissions():
 
             if request.authorization is not None:
 
-                basic_auth_denied_message = default_denied_message + " [Basic Auth Based] "
+                basic_auth_denied_message = f"{default_denied_message} [Basic Auth Based] "
 
                 client_id = request.authorization.get('username', None)
                 if not client_id:
-                    raise Forbidden(basic_auth_denied_message + " No username. (client_id)")
+                    raise Forbidden(f"{basic_auth_denied_message} No username. (client_id)")
                 client_secret = request.authorization.get('password', None)
                 if not client_secret:
-                    raise Forbidden(basic_auth_denied_message + " No password. (client_secret)")
+                    raise Forbidden(f"{basic_auth_denied_message} No password. (client_secret)")
 
                 result = API_Permissions.by_project(session = session,
                                                     project_string_id = project_string_id,
                                                     Roles = Roles)
                 if result is not True:
-                    raise Forbidden(basic_auth_denied_message + "Failed API Permissions")
+                    raise Forbidden(f"{basic_auth_denied_message}Failed API Permissions")
 
                 # Project APIs, maybe should role this into API_Permissions
                 check_all_apis(
@@ -117,7 +117,7 @@ class Project_permissions():
 
                 return True
 
-            user_denied_message = default_denied_message + " [Human User Based] "
+            user_denied_message = f"{default_denied_message} [Human User Based] "
 
             result = Project_permissions.check_permissions(
                 session = session,
@@ -163,7 +163,7 @@ class Project_permissions():
 
         if project_string_id is None:
             # TODO merge None checks from other thing up top here.
-            raise Forbidden(user_denied_message + "project_string_id is None")
+            raise Forbidden(f"{user_denied_message}project_string_id is None")
 
         if Project_permissions.check_if_project_is_public(project, Roles):
             return True
@@ -174,7 +174,7 @@ class Project_permissions():
         if project is None:
             project = Project.get(session, project_string_id)
             if project is None:
-                raise Forbidden(user_denied_message + " Failed to Get Project ")
+                raise Forbidden(f"{user_denied_message} Failed to Get Project ")
 
             if Project_permissions.check_if_project_is_public(project, Roles):
                 return True
@@ -185,7 +185,7 @@ class Project_permissions():
 
         # TODO merge LoggedIn() with getUserID() similar internal logic
         if LoggedIn() != True:
-            raise Unauthorized(user_denied_message + " Failed LoggedIn ")
+            raise Unauthorized(f"{user_denied_message} Failed LoggedIn ")
 
         if 'allow_any_logged_in_user' in Roles:  # TODO not happy with this name, want more clarity on how this effects other permissions like apis / project etc.
             return True
@@ -278,4 +278,4 @@ def check_api(apis_required_list,
     If an API is in the list, it must be enabled
     """
     if getattr(project, api_to_check) is not True:
-        raise Forbidden(api_to_check + " not enabled.")
+        raise Forbidden(f"{api_to_check} not enabled.")

--- a/shared/query_engine/query_creator.py
+++ b/shared/query_engine/query_creator.py
@@ -105,7 +105,7 @@ class QueryCreator:
                 return suggestions, suggest_type
             for x in self.parser.terminals:
                 print(x.user_repr())
-            logger.error('Unexpected token {}'.format(str(token_exception)))
+            logger.error(f"Unexpected token {str(token_exception)}")
             return False, None
 
     def create_query(self, query_string):

--- a/shared/query_engine/sqlalchemy_query_exectutor.py
+++ b/shared/query_engine/sqlalchemy_query_exectutor.py
@@ -62,11 +62,11 @@ class SqlAlchemyQueryExecutor(BaseDiffgramQueryExecutor):
                 return self.final_query
 
             else:
-                error_msg = 'Invalid children number for start: Must have only 1 and has {}'.format(len(local_tree.children))
+                error_msg = f"Invalid children number for start: Must have only 1 and has {len(local_tree.children)}"
                 logger.error(error_msg)
                 self.log['error']['start'] = error_msg
         else:
-            logger.error('Invalid child count for start. Must be 1 and is {}'.format(len(args)))
+            logger.error(f"Invalid child count for start. Must be 1 and is {len(args)}")
             self.log['error']['start'] = 'Invalid child count for factor. Must be 1'
         return self.final_query
 
@@ -87,7 +87,7 @@ class SqlAlchemyQueryExecutor(BaseDiffgramQueryExecutor):
             local_tree.or_statement = or_(*conditions)
             return local_tree
         else:
-            logger.error('Invalid child count for expr. Must be 1 and is {}'.format(len(args)))
+            logger.error(f"Invalid child count for expr. Must be 1 and is {len(args)}")
             self.log['error']['expr'] = 'Invalid child count for factor. Must be 1'
 
     def term(self, *args):
@@ -107,7 +107,7 @@ class SqlAlchemyQueryExecutor(BaseDiffgramQueryExecutor):
             local_tree.and_statement = and_(*conditions)
             return local_tree
         else:
-            logger.error('Invalid child count for term. Must be 1 and is {}'.format(len(args)))
+            logger.error(f"Invalid child count for term. Must be 1 and is {len(args)}")
             self.log['error']['term'] = 'Invalid child count for factor. Must be 1'
 
     def factor(self, *args):
@@ -175,7 +175,7 @@ class SqlAlchemyQueryExecutor(BaseDiffgramQueryExecutor):
                                                     label_name = label_name,
                                                     project_id = self.diffgram_query.project.id)
             if not label_file:
-                error_string = 'Label {} does not exists'.format(str(label_name))
+                error_string = f"Label {str(label_name)} does not exists"
                 logger.error(error_string)
                 self.log['error']['label_name'] = error_string
                 return
@@ -213,7 +213,7 @@ class SqlAlchemyQueryExecutor(BaseDiffgramQueryExecutor):
         entity_type1 = self.__determine_entity_type(token1)
         entity_type2 = self.__determine_entity_type(token2)
         if len(token1.value.split('.')) == 1:
-            error_string = 'Error with token: {}. Should specify the label name or global count'.format(token1.value)
+            error_string = f"Error with token: {token1.value}. Should specify the label name or global count"
             logger.error(error_string)
             self.log['error']['compare_expr'] = error_string
             return False
@@ -280,7 +280,7 @@ class SqlAlchemyQueryExecutor(BaseDiffgramQueryExecutor):
                 return
 
         else:
-            self.log['error']['compare_expr'] = 'Invalid compare expression {}'.format(str(args))
+            self.log['error']['compare_expr'] = f"Invalid compare expression {str(args)}"
 
     def execute_query(self):
         """

--- a/shared/regular/regular_input.py
+++ b/shared/regular/regular_input.py
@@ -144,7 +144,7 @@ def input_check(spec,
     # What if variable is allowed to be None?
     if variable is None:
         if required is True:
-            log["error"][name] = "Missing " + name
+            log["error"][name] = f"Missing {name}"
             return log, None, name
         else:
             # Note we return default instead of variable
@@ -158,8 +158,7 @@ def input_check(spec,
 
         if string_len_not_zero is True and not allow_empty:
             if len(variable) == 0:
-                log["error"][name] = "String " + name + \
-                                     " must not be of length zero."
+                log["error"][name] = f"String {name} must not be of length zero."
                 return log, None, name
 
     elif spec_type == list:

--- a/shared/regular/regular_methods.py
+++ b/shared/regular/regular_methods.py
@@ -105,15 +105,15 @@ def transmit_interservice_request(
     }
     if service_target == 'walrus':
 
-        endpoint = settings.WALRUS_SERVICE_URL_BASE + 'api/walrus/v1/interservice/receive'
+        endpoint = f"{settings.WALRUS_SERVICE_URL_BASE}api/walrus/v1/interservice/receive"
     else:
         raise NotImplementedError
     response = requests.post(endpoint, data = json.dumps(data))
     try:
         data = response.json()
-        if logger: logger.info('[Interservice]' + str(data))
+        if logger: logger.info(f"[Interservice]{str(data)}")
     except:
-        if logger: logger.info('[Interservice]' + str(response))
+        if logger: logger.info(f"[Interservice]{str(response)}")
 
 
 def regular_query(

--- a/shared/settings/settings.py
+++ b/shared/settings/settings.py
@@ -130,10 +130,10 @@ WEBHOOKS_URL_BASE = os.getenv('WEBHOOKS_URL_BASE', 'http://localhost:8085')
 
 # Labelbox Integrations
 LABEL_BOX_SECRET = os.getenv('LABELBOX_SECRET')  # Put a new generated secret here to auth callbacks (seperate from API keys)
-LABEL_BOX_WEBHOOKS_URL = '{}/api/walrus/v1/webhooks/labelbox-webhook'.format(WEBHOOKS_URL_BASE)
+LABEL_BOX_WEBHOOKS_URL = f'{WEBHOOKS_URL_BASE}/api/walrus/v1/webhooks/labelbox-webhook'
 
 # Scale AI Integrations
-SCALE_AI_WEBHOOKS_URL = '{}/api/walrus/v1/webhooks/scale-ai'.format(WEBHOOKS_URL_BASE)
+SCALE_AI_WEBHOOKS_URL = f'{WEBHOOKS_URL_BASE}/api/walrus/v1/webhooks/scale-ai'
 
 # Task Templates Threading Settings
 TASK_TEMPLATE_THREAD_SLEEP_TIME_MIN = 30

--- a/shared/tests/create_database.py
+++ b/shared/tests/create_database.py
@@ -6,10 +6,10 @@ from sqlalchemy import create_engine
 
 
 engine = create_engine(settings.DATABASE_URL)
-print('Checking DB: {}'.format(settings.DATABASE_URL))
+print(f"Checking DB: {settings.DATABASE_URL}")
 
 if not database_exists(engine.url):
-    print('Creating DB: {}'.format(settings.DATABASE_URL))
+    print(f"Creating DB: {settings.DATABASE_URL}")
     from shared.database.core import Base
     create_database(engine.url)
     Base.metadata.create_all(engine)

--- a/shared/tests/e2e_helpers/setup_database_e2e_tests.py
+++ b/shared/tests/e2e_helpers/setup_database_e2e_tests.py
@@ -8,10 +8,10 @@ if settings.DIFFGRAM_SYSTEM_MODE != 'testing_e2e':
     raise Exception('Can only set database when mode is: testing_e2e'
                     '')
 engine = create_engine(settings.DATABASE_URL)
-print('Checking DB: {}'.format(settings.DATABASE_URL))
+print(f"Checking DB: {settings.DATABASE_URL}")
 
 if not database_exists(engine.url):
-    print('Creating DB: {}'.format(settings.DATABASE_URL))
+    print(f"Creating DB: {settings.DATABASE_URL}")
     from shared.database.core import Base
 
     create_database(engine.url)
@@ -19,9 +19,9 @@ if not database_exists(engine.url):
     print('Database created successfully.')
 
 else:
-    print('Destroying database: {}'.format(settings.DATABASE_URL))
+    print(f"Destroying database: {settings.DATABASE_URL}")
     drop_database(settings.DATABASE_URL)
-    print('Creating DB: {}'.format(settings.DATABASE_URL))
+    print(f"Creating DB: {settings.DATABASE_URL}")
     from shared.database.core import Base
 
     create_database(engine.url)

--- a/shared/tests/test_utils/data_mocking.py
+++ b/shared/tests/test_utils/data_mocking.py
@@ -357,12 +357,12 @@ def create_job(job_data, session):
     if job_data.get('project'):
         job = Job(member_created = None, project = job_data.get('project'))
     else:
-        project_string_id = '{}-job-project'.format(get_random_string(8))
+        project_string_id = f"{get_random_string(8)}-job-project"
         project_context = {
             'project_string_id': project_string_id,
-            'project_name': '{}-job-project'.format(project_string_id),
+            'project_name': f"{project_string_id}-job-project",
             'users': [
-                {'username': '{}-job-user'.format(get_random_string(5)),
+                {'username': f"{get_random_string(5)}-job-user",
                  'email': 'test@test.com',
                  'password': 'diffgram123',
                  'project_string_id': project_string_id
@@ -588,7 +588,7 @@ def create_task(task_data, session):
 
     # # #
     if 'job' not in task_data:
-        job = create_job({'name': 'jobtest:{}'.format(task_data.get('name'))}, session)
+        job = create_job({'name': f"jobtest:{task_data.get('name')}"}, session)
     else:
         job = task_data.get('job')
     task.job_id = job.id
@@ -710,8 +710,8 @@ def create_project_with_context(context_data, session):
 
     default_project_limit = 10
     user = register_user(
-        {'username': 'project_owner_{}'.format(project_string_id),
-         'email': 'test{}@test.com'.format(project_string_id),
+        {'username': f"project_owner_{project_string_id}",
+         'email': f"test{project_string_id}@test.com",
          'password': 'diffgram123'},
         session
     )

--- a/shared/utils/job_dir_sync_utils.py
+++ b/shared/utils/job_dir_sync_utils.py
@@ -51,7 +51,7 @@ class JobDirectorySyncManager:
             job = job_obj,
             log = self.log
         )
-        logger.debug('File {} added to job {}'.format(file.id, job_obj.id))
+        logger.debug(f"File {file.id} added to job {job_obj.id}")
 
         if create_tasks is False:
             log['info']['create_tasks flag'] = "create_tasks is False"
@@ -59,9 +59,9 @@ class JobDirectorySyncManager:
 
         valid_status_to_create_tasks = ['active', 'in_review', 'complete']
         if job_obj.status not in valid_status_to_create_tasks:
-            log['info']['job status'] = "not in " + str(valid_status_to_create_tasks)
+            log['info']['job status'] = f"not in {str(valid_status_to_create_tasks)}"
             logger.debug(
-                'Job status not active, skipping. Statuses must be one of {}'.format(str(valid_status_to_create_tasks)))
+                f"Job status not active, skipping. Statuses must be one of {str(valid_status_to_create_tasks)}")
             return True, log
 
         logger.debug('Creating task...')
@@ -71,7 +71,7 @@ class JobDirectorySyncManager:
         if potential_existing_task is None:
             task = self.create_task_from_file(file, job = job_obj, incoming_directory = incoming_directory)
             task.is_root = True
-            logger.debug('New task created. {}'.format(task.id))
+            logger.debug(f"New task created. {task.id}")
         else:
             task = potential_existing_task
 
@@ -79,7 +79,7 @@ class JobDirectorySyncManager:
             sync_event_manager.add_create_task(task)
             sync_event_manager.set_status('completed')
         if result is not True:
-            log['error']['create_file_links'] = 'Error creating links for file id: {}'.format(file.id)
+            log['error']['create_file_links'] = f"Error creating links for file id: {file.id}"
             return False, log
         if regular_log.log_has_error(log):
             return False, log
@@ -172,9 +172,8 @@ class JobDirectorySyncManager:
             self.session.query(JobWorkingDir).filter(JobWorkingDir.working_dir_id == self.directory.id).update(
                 {"sync_type": "archived"}
             )
-        logger.info('Removed  {} from jobs.'.format(self.directory.id))
-        self.log['info']['working_dir_updates_{}'.format(self.directory.id)] = 'Removed  {} from jobs.'.format(
-            self.directory.id)
+        logger.info(f"Removed  {self.directory.id} from jobs.")
+        self.log['info'][f"working_dir_updates_{self.directory.id}"] = f"Removed  {self.directory.id} from jobs."
         return True, self.log
 
     def remove_job_from_all_dirs(self, soft_delete = True):
@@ -200,7 +199,7 @@ class JobDirectorySyncManager:
 
         job_obj = self.job
         if job is not None:
-            logger.debug('Creating task from file {} and job {}'.format(file.id, job.id))
+            logger.debug(f"Creating task from file {file.id} and job {job.id}")
             job_obj = job
         if job_obj.file_handling == "isolate":
             new_file = File.copy_file_from_existing(
@@ -246,7 +245,7 @@ class JobDirectorySyncManager:
         :param create_tasks:
         :return:
         """
-        logger.debug('Add files to all jobs file:{} create tasks: {}'.format(file.id, create_tasks))
+        logger.debug(f"Add files to all jobs file:{file.id} create tasks: {create_tasks}")
         file_link_directory = self.directory
         if source_dir:
             file_link_directory = source_dir
@@ -330,7 +329,7 @@ class JobDirectorySyncManager:
                         status = 'init',
                         member_created = member
                     )
-                    logger.debug('Created sync_event {}'.format(sync_event_manager.sync_event.id))
+                    logger.debug(f"Created sync_event {sync_event_manager.sync_event.id}")
                     result, log = self.__add_file_into_job(
                         file,
                         directory,
@@ -338,12 +337,12 @@ class JobDirectorySyncManager:
                         sync_event_manager = sync_event_manager
                     )
                     if result is not True:
-                        log['error']['sync_file_dirs'] = 'Error syncing dirs for file id: {}'.format(file.id)
+                        log['error']['sync_file_dirs'] = f"Error syncing dirs for file id: {file.id}"
                     if regular_log.log_has_error(log):
                         return False, log
         else:
             logger.debug(
-                'Single file sync event with file: {} and folder {}'.format(file_to_link_dataset.id, file_to_link.id))
+                f"Single file sync event with file: {file_to_link_dataset.id} and folder {file_to_link.id}")
             sync_event_manager = SyncEventManager.create_sync_event_and_manager(
                 session = self.session,
                 dataset_source_id = file_to_link_dataset.id,
@@ -362,7 +361,7 @@ class JobDirectorySyncManager:
                 status = 'init',
                 member_created = member
             )
-            logger.debug('Created sync_event {}'.format(sync_event_manager.sync_event.id))
+            logger.debug(f"Created sync_event {sync_event_manager.sync_event.id}")
             result, log = self.__add_file_into_job(
                 file_to_link,
                 file_to_link_dataset,
@@ -370,7 +369,7 @@ class JobDirectorySyncManager:
                 sync_event_manager = sync_event_manager,
             )
             if result is not True:
-                log['error']['sync_file_dirs'] = 'Error syncing dirs for file id: {}'.format(file_to_link.id)
+                log['error']['sync_file_dirs'] = f"Error syncing dirs for file id: {file_to_link.id}"
             if regular_log.log_has_error(log):
                 return False, log
         self.job.update_file_count_statistic(session = self.session)

--- a/shared/utils/job_launch_utils.py
+++ b/shared/utils/job_launch_utils.py
@@ -153,8 +153,7 @@ def task_template_launch_limits(session,
     print(result)
 
     if result > 0:
-        log['error']['file_status'] = "Files processing. " + \
-                                      "Try again in 30-60 minutes."
+        log['error']['file_status'] = f"Files processing. Try again in 30-60 minutes."
 
     # Credentials
     # ie Warn if missing ...

--- a/shared/utils/label_map_util_test.py
+++ b/shared/utils/label_map_util_test.py
@@ -31,7 +31,7 @@ class LabelMapUtilTest(tf.test.TestCase):
     for i in range(1, num_classes + 1):
       item = label_map_proto.item.add()
       item.id = i
-      item.name = 'label_' + str(i)
+      item.name = f"label_{str(i)}"
       item.display_name = str(i)
     return label_map_proto
 

--- a/shared/utils/logging.py
+++ b/shared/utils/logging.py
@@ -73,7 +73,7 @@ class DiffgramLogger:
         handler.setFormatter(logging.Formatter(fmt_str))
         logger = logging.getLogger(self.logger_name)
         logger.addHandler(handler)
-        logger.info('Logger {} setup success.'.format(self.logger_name))
+        logger.info(f"Logger {self.logger_name} setup success.")
         DiffgramLogger.logging_initialized[self.logger_name] = True
         return logger
 

--- a/shared/utils/source_control/file/file_transfer_core.py
+++ b/shared/utils/source_control/file/file_transfer_core.py
@@ -53,12 +53,12 @@ def perform_sync_events_after_file_transfer(session,
             created_task = None,
             completed_task = None,
             transfer_action = transfer_action,
-            event_effect_type = 'file_{}'.format(transfer_action),
+            event_effect_type = f"file_{transfer_action}",
             event_trigger_type = 'file_operation',
             status = 'completed',
             member_created = member
         )
-        logger.debug('Created sync_event {}'.format(sync_event_manager.sync_event.id))
+        logger.debug(f"Created sync_event {sync_event_manager.sync_event.id}")
     # TODO: UPDATE JOBS WHERE DIRECTORY SHOULD BE SYNCED
     # Note that at this point we pass the source directory even though new file link has been created.
     # This is because the session has not been committed and new file link still won't be found in query.

--- a/shared/utils/task/task_complete.py
+++ b/shared/utils/task/task_complete.py
@@ -32,7 +32,7 @@ def trigger_task_complete_sync_event(session, task, job, log):
         status = 'init',
         member_created = None
     )
-    logger.debug('Created sync_event {}'.format(sync_event_manager.sync_event.id))
+    logger.debug(f"Created sync_event {sync_event_manager.sync_event.id}")
     if job.completion_directory and job.output_dir_action in ['copy', 'move']:
         job_observable = task_file_observers.JobObservable(session = session,
                                                            log = log,
@@ -60,7 +60,7 @@ def trigger_task_complete_sync_event(session, task, job, log):
         status = 'init',
         member_created = None
     )
-    logger.debug('Created sync_event {}'.format(sync_event_manager.sync_event.id))
+    logger.debug(f"Created sync_event {sync_event_manager.sync_event.id}")
     if job.completion_directory and job.output_dir_action in ['copy', 'move']:
         job_observable = task_file_observers.JobObservable(session = session,
                                                            log = log,

--- a/shared/utils/task/task_file_observers.py
+++ b/shared/utils/task/task_file_observers.py
@@ -187,7 +187,7 @@ class DirectoryJobObserver(Observer):
                     )
                 self.job_observable.sync_events_manager.set_description(desc)
                 self.job_observable.sync_events_manager.set_transfer_action(action_type)
-                self.job_observable.sync_events_manager.set_event_effect_type('{}_file'.format(action_type))
+                self.job_observable.sync_events_manager.set_event_effect_type(f"{action_type}_file")
                 logger.debug(desc)
 
     def _update_observer(self, action_type=None, trigger_type=None):

--- a/walrus/methods/action/action_flow_trigger_queue.py
+++ b/walrus/methods/action/action_flow_trigger_queue.py
@@ -119,7 +119,7 @@ class ActionFlowTriggerQueueThread:
         """
         if not action_flow_trigger_event:
             return None
-        logger.info('Executing flow for event {}'.format(action_flow_trigger_event.id))
+        logger.info(f"Executing flow for event {action_flow_trigger_event.id}")
         # Check if there are any other duplicate events on the window (In case of a concurrent update on the queue)
         # And if so delete, duplicate trigger_events with aggregations
         project = action_flow_trigger_event.project
@@ -158,14 +158,14 @@ class ActionFlowTriggerQueueThread:
                         ActionFlowTriggerEventQueue.id == action_flow_trigger_event.id
                     ).delete()
         except Exception as e:
-            logger.error('Errror on action flow trigger queue. {}'.format(str(e)))
+            logger.error(f"Errror on action flow trigger queue. {str(e)}")
             if action_flow_trigger_event_id:
                 with sessionMaker.session_scope_threaded() as session:
                     action_flow_trigger_event = session.query(ActionFlowTriggerEventQueue).filter(
                         ActionFlowTriggerEventQueue.id == action_flow_trigger_event_id
                     ).first()
 
-                    logger.critical('Error launching Processing action event {}'.format(action_flow_trigger_event.id))
+                    logger.critical(f"Error launching Processing action event {action_flow_trigger_event.id}")
                     logger.error(traceback.format_exc())
                     logger.info('Deleting Action Trigger Event queue element'.format(action_flow_trigger_event.id))
                     session.query(ActionFlowTriggerEventQueue).filter(

--- a/walrus/methods/connectors/azure_connector.py
+++ b/walrus/methods/connectors/azure_connector.py
@@ -100,7 +100,7 @@ class AzureConnector(Connector):
             start = datetime.datetime.utcnow(),
             expiry = expiry_time,
             permission = BlobSasPermissions(read = True),
-            content_disposition = 'attachment; filename=' + filename,
+            content_disposition = f"attachment; filename={filename}",
         )
         sas_url = 'https://{}.blob.core.windows.net/{}/{}?{}'.format(
             self.connection_client.account_name,
@@ -132,7 +132,7 @@ class AzureConnector(Connector):
                     session = session,
                     member_id = opts['event_data']['request_user'],
                     kind = 'microsoft_azure_new_import_warning',
-                    description = 'Skipped import for {}, invalid file type.'.format(opts['path']),
+                    description = f"Skipped import for {opts['path']}, invalid file type.",
                     error_log = log,
                     project_id = project.id,
                     member = member,
@@ -158,7 +158,7 @@ class AzureConnector(Connector):
                 session = session,
                 member_id = opts['event_data']['request_user'],
                 kind = 'microsoft_azure_new_import_success',
-                description = 'New cloud import for {}'.format(opts['path']),
+                description = f"New cloud import for {opts['path']}",
                 error_log = opts,
                 project_id = project.id,
                 member = member,
@@ -361,9 +361,9 @@ class AzureConnector(Connector):
             filename = generate_file_name_from_export(export, session)
 
             if opts['path'] != '':
-                key = '{}{}.{}'.format(opts['path'], filename, opts['format'].lower())
+                key = f"{opts['path']}{filename}.{opts['format'].lower()}"
             else:
-                key = '{}.{}'.format(filename, opts['format'].lower())
+                key = f"{filename}.{opts['format'].lower()}"
 
             file = io.BytesIO(result)
             blob_client = self.connection_client.get_blob_client(container = opts['bucket_name'], blob = key)
@@ -376,7 +376,7 @@ class AzureConnector(Connector):
                 session = session,
                 member_id = opts['event_data']['request_user'],
                 kind = 'microsoft_azure_new_export_success',
-                description = 'New cloud export for {}{}'.format(opts['path'], filename),
+                description = f"New cloud export for {opts['path']}{filename}",
                 error_log = opts,
                 member = member,
                 project_id = project.id,
@@ -410,7 +410,7 @@ class AzureConnector(Connector):
                 start = datetime.datetime.utcnow(),
                 expiry = expiry_time,
                 permission = BlobSasPermissions(read = True),
-                content_disposition = 'attachment; filename=' + filename,
+                content_disposition = f"attachment; filename={filename}",
             )
             sas_url = 'https://{}.blob.core.windows.net/{}/{}?{}'.format(
                 self.connection_client.account_name,
@@ -421,7 +421,7 @@ class AzureConnector(Connector):
             resp = requests.get(sas_url)
             if resp.status_code != 200:
                 raise Exception(
-                    'Error when accessing presigned URL: Status({}). Error: {}'.format(resp.status_code, resp.text))
+                    f"Error when accessing presigned URL: Status({resp.status_code}). Error: {resp.text}")
         except:
             log['error']['azure_write_perms'] = 'Error Connecting to Azure: Please check you have read permissions on the Azure container.'
             log['error']['details'] = traceback.format_exc()

--- a/walrus/methods/connectors/google_cloud_storage_connector.py
+++ b/walrus/methods/connectors/google_cloud_storage_connector.py
@@ -167,11 +167,11 @@ class GoogleCloudStorageConnector(Connector):
                     session=session,
                     member_id=opts['event_data']['request_user'],
                     kind='google_cloud_new_import_error',
-                    description='New cloud import for {}'.format(opts['path']),
+                    description=f"New cloud import for {opts['path']}",
                     error_log=log
                 )
             raise LookupError(
-                'File must type of: {} {}'.format(str(images_allowed_file_names), str(videos_allowed_file_names)))
+                f"File must type of: {str(images_allowed_file_names)} {str(videos_allowed_file_names)}")
         # metadata = self.connection_client.head_object(Bucket=opts['bucket_name, Key=path)
         with sessionMaker.session_scope() as session:
             member = session.query(Member).filter(Member.user_id == opts['event_data']['request_user']).first()
@@ -189,7 +189,7 @@ class GoogleCloudStorageConnector(Connector):
                 session=session,
                 member_id=opts['event_data']['request_user'],
                 kind='google_cloud_new_import_success',
-                description='New cloud import for {}'.format(opts['path']),
+                description=f"New cloud import for {opts['path']}",
                 error_log=opts
             )
         return {'result': created_input}
@@ -271,7 +271,7 @@ class GoogleCloudStorageConnector(Connector):
                             session=session,
                             member_id=opts['event_data']['request_user'],
                             kind='google_cloud_new_import_warning',
-                            description='Skipped import for {}, invalid file type.'.format(blob.name),
+                            description=f"Skipped import for {blob.name}, invalid file type.",
                             error_log=log,
                             project_id=project.id,
                             member=member,
@@ -298,7 +298,7 @@ class GoogleCloudStorageConnector(Connector):
                         session=session,
                         member_id=opts['event_data']['request_user'],
                         kind='google_cloud_new_import_success',
-                        description='New cloud import for {}'.format(blob.name),
+                        description=f"New cloud import for {blob.name}",
                         error_log=opts,
                         project_id=project.id,
                         member=member,
@@ -401,7 +401,7 @@ class GoogleCloudStorageConnector(Connector):
                     session=session,
                     member_id=opts['event_data']['request_user'],
                     kind='google_cloud_new_export_error',
-                    description='Google cloud export error for {}'.format(opts['path']),
+                    description=f"Google cloud export error for {opts['path']}",
                     error_log=log,
                     member=member,
                     project_id=project.id,
@@ -417,9 +417,9 @@ class GoogleCloudStorageConnector(Connector):
             filename = generate_file_name_from_export(export, session)
 
             if opts['path'] != '':
-                blob = bucket.blob('{}{}.{}'.format(opts['path'], filename, opts['format'].lower()))
+                blob = bucket.blob(f"{opts['path']}{filename}.{opts['format'].lower()}")
             else:
-                blob = bucket.blob('{}.{}'.format(filename, opts['format'].lower()))
+                blob = bucket.blob(f"{filename}.{opts['format'].lower()}")
             blob.upload_from_string(result)
             log = regular_log.default()
             log['opts'] = opts
@@ -427,7 +427,7 @@ class GoogleCloudStorageConnector(Connector):
                 session=session,
                 member_id=opts['event_data']['request_user'],
                 kind='google_cloud_new_export_success',
-                description='New cloud export for {}'.format(blob.name),
+                description=f"New cloud export for {blob.name}",
                 error_log=opts,
                 member=member,
                 project_id=project.id,
@@ -471,12 +471,12 @@ class GoogleCloudStorageConnector(Connector):
             filename = test_file_path.split("/")[-1]
             url_signed = blob.generate_signed_url(
                 expiration = expiration_time,
-                response_disposition = 'attachment; filename=' + filename
+                response_disposition = f"attachment; filename={filename}"
             )
             resp = requests.get(url_signed)
             if resp.status_code != 200:
                 raise Exception(
-                    'Error when accessing presigned URL: Status({}). Error: {}'.format(resp.status_code, resp.text))
+                    f"Error when accessing presigned URL: Status({resp.status_code}). Error: {resp.text}")
         except:
             log['error']['gcp_write_perms'] = 'Error Connecting to GCP: Please check you have read permissions on the GCP bucket.'
             log['error']['details'] = traceback.format_exc()

--- a/walrus/methods/connectors/labelbox_connector.py
+++ b/walrus/methods/connectors/labelbox_connector.py
@@ -336,7 +336,7 @@ class LabelBoxSyncManager:
     def update_instance_list_for_video(self, frames_data, diffgram_task):
         frame_packet_map = {}
         for frame in frames_data:
-            logger.debug('Processing Frame {}'.format(frame['frameNumber']))
+            logger.debug(f"Processing Frame {frame['frameNumber']}")
             video_data = {
                 'current_frame': frame['frameNumber'],
                 'video_mode': True,
@@ -445,8 +445,8 @@ class LabelBoxSyncManager:
 
     def transform_labelbox_label_to_diffgram_instance(self, label_object, diffgram_label_file_data,
                                                       sequence_num=None, instance_map=None):
-        logger.debug('Bulding instance from: {}'.format(label_object))
-        logger.debug('Bulding instance with diffgram label_file ID: {}'.format(diffgram_label_file_data['id']))
+        logger.debug(f"Bulding instance from: {label_object}")
+        logger.debug(f"Bulding instance with diffgram label_file ID: {diffgram_label_file_data['id']}")
         instance_id = None
         if instance_map.instance_id:
             instance_id = instance_map.instance_id
@@ -489,7 +489,7 @@ class LabelBoxSyncManager:
             'y_min': None,
             'points': []
         }
-        logger.debug('Sequence num is: {}'.format(sequence_num))
+        logger.debug(f"Sequence num is: {sequence_num}")
         if sequence_num is not None:
             diffgram_instance_format['number'] = sequence_num
         diffgram_instance_format['label_file_id'] = diffgram_label_file_data['id']
@@ -606,7 +606,7 @@ class LabelBoxSyncManager:
                                                    'query': query,
                                                    'data': data,
                                                    'event_data': {}})
-        logger.debug('Webhook for {} succesfully created on Labelbox.'.format(self.labelbox_project.uid))
+        logger.debug(f"Webhook for {self.labelbox_project.uid} succesfully created on Labelbox.")
         return result
 
     @_with_task_template
@@ -653,10 +653,10 @@ class LabelBoxSyncManager:
             diffgram_file_external_map = external_map_by_id.get(diffgram_file.id)
             if diffgram_file_external_map and diffgram_file_external_map.external_id and not force_create \
                     and external_map_by_id.get(diffgram_file.id).external_id not in deleted_data_rows:
-                logger.debug('File {} exists. Skipping..'.format(diffgram_file.id))
+                logger.debug(f"File {diffgram_file.id} exists. Skipping..")
                 continue
             if diffgram_file.type == "image":
-                logger.debug('Adding image {}  in Labelbox'.format(diffgram_file.id))
+                logger.debug(f"Adding image {diffgram_file.id}  in Labelbox")
                 if diffgram_file.image:
                     data = diffgram_file.image.serialize_for_source_control(self.session)
                     data_row = {
@@ -669,7 +669,7 @@ class LabelBoxSyncManager:
                     file_urls.append(data_row)
             if diffgram_file.type == "video":
                 if diffgram_file.video:
-                    logger.debug('Adding video {}  in Labelbox'.format(diffgram_file.id))
+                    logger.debug(f"Adding video {diffgram_file.id}  in Labelbox")
                     data = diffgram_file.video.serialize_list_view(self.session, self.task_template.project)
                     data_row = {
                         labelbox.schema.data_row.DataRow.row_data: data['file_signed_url'],
@@ -738,7 +738,7 @@ class LabelBoxSyncManager:
         for dataset in datasets:
             # Assumption here is that the labeling interface has already been checked so we assume we need to
             # create the dataset if it does not exits.
-            logger.debug('Syncing dataset {}-{}  in Labelbox'.format(dataset.nickname, dataset.id))
+            logger.debug(f"Syncing dataset {dataset.nickname}-{dataset.id}  in Labelbox")
             if dataset.default_external_map:
                 # Fetch dataset
                 logger.debug('Dataset already exists... attaching.')
@@ -805,7 +805,7 @@ class LabelBoxSyncManager:
                     session=self.session,
                     external_id=labelbox_dataset.uid,
                     dataset=dataset,
-                    url='https://app.labelbox.com/dataset/{}'.format(labelbox_dataset.uid),
+                    url=f"https://app.labelbox.com/dataset/{labelbox_dataset.uid}",
                     diffgram_class_string="dataset",
                     type="labelbox",
                     add_to_session=True,
@@ -831,14 +831,14 @@ def labelbox_web_hook_manager():
     secret = settings.LABEL_BOX_SECRET
     log = regular_log.default()
     computed_signature = hmac.new(bytearray(secret.encode('utf-8')), msg=payload, digestmod=hashlib.sha1).hexdigest()
-    if request.headers['X-Hub-Signature'] != 'sha1=' + computed_signature:
+    if request.headers['X-Hub-Signature'] != f"sha1={computed_signature}":
         error = 'Error: computed_signature does not match signature provided in the headers'
         logger.error('Error: computed_signature does not match signature provided in the headers')
         return error
     with sessionMaker.session_scope() as session:
         labelbox_event = request.headers['X-Labelbox-Event']
         payload = request.json
-        logger.debug('Payload for labelbox webhooks: {}'.format(payload))
+        logger.debug(f"Payload for labelbox webhooks: {payload}")
         labelbox_project_id = payload['project']['id']
         project_external_mapping = ExternalMap.get(
             session=session,
@@ -850,7 +850,7 @@ def labelbox_web_hook_manager():
             task_template = Job.get_by_id(session, project_external_mapping.job_id)
             if task_template:
                 connection = task_template.interface_connection
-                logger.debug('Connection for labelbox: {}'.format(connection))
+                logger.debug(f"Connection for labelbox: {connection}")
                 connector_manager = ConnectorManager(connection=connection, session=session)
                 connector = connector_manager.get_connector_instance()
                 connector.connect()

--- a/walrus/methods/connectors/s3_connector.py
+++ b/walrus/methods/connectors/s3_connector.py
@@ -123,7 +123,7 @@ class S3Connector(Connector):
                     session=session,
                     member_id=opts['event_data']['request_user'],
                     kind='aws_s3_new_import_warning',
-                    description='Skipped import for {}, invalid file type.'.format(opts['path']),
+                    description=f"Skipped import for {opts['path']}, invalid file type.",
                     error_log=log,
                     project_id=project.id,
                     member=member,
@@ -150,7 +150,7 @@ class S3Connector(Connector):
                 session=session,
                 member_id=opts['event_data']['request_user'],
                 kind='aws_s3_new_import_success',
-                description='New cloud import for {}'.format(opts['path']),
+                description=f"New cloud import for {opts['path']}",
                 error_log=opts,
                 project_id=project.id,
                 member=member,
@@ -347,9 +347,9 @@ class S3Connector(Connector):
             filename = generate_file_name_from_export(export, session)
 
             if opts['path'] != '':
-                key = '{}{}.{}'.format(opts['path'], filename, opts['format'].lower())
+                key = f"{opts['path']}{filename}.{opts['format'].lower()}"
             else:
-                key = '{}.{}'.format(filename, opts['format'].lower())
+                key = f"{filename}.{opts['format'].lower()}"
 
             file = io.BytesIO(result)
             self.connection_client.upload_fileobj(file, opts['bucket_name'], key)
@@ -359,7 +359,7 @@ class S3Connector(Connector):
                 session=session,
                 member_id=opts['event_data']['request_user'],
                 kind='aws_s3_new_export_success',
-                description='New cloud export for {}{}'.format(opts['path'], filename),
+                description=f"New cloud export for {opts['path']}{filename}",
                 error_log=opts,
                 member=member,
                 project_id=project.id,
@@ -387,7 +387,7 @@ class S3Connector(Connector):
             resp = requests.get(signed_url)
             if resp.status_code != 200:
                 raise Exception(
-                    'Error when accessing presigned URL: Status({}). Error: {}'.format(resp.status_code, resp.text))
+                    f"Error when accessing presigned URL: Status({resp.status_code}). Error: {resp.text}")
         except:
             log['error']['s3_write_perms'] = 'Error Connecting to S3: Please check you have read permissions on the S3 bucket.'
             log['error']['details'] = traceback.format_exc()

--- a/walrus/methods/connectors/scale_ai_connector.py
+++ b/walrus/methods/connectors/scale_ai_connector.py
@@ -278,7 +278,7 @@ class ScaleAISyncManager:
             external_id=scale_ai_task.id,
             connection=task.job.interface_connection,
             diffgram_class_string='task',
-            type='{}_task'.format(task.job.interface_connection.integration_name),
+            type=f"{task.job.interface_connection.integration_name}_task",
             url='',
             add_to_session=True,
             flush_session=True
@@ -286,7 +286,7 @@ class ScaleAISyncManager:
         # Commented to bottom to avoid circular dependencies on job.
         self.task_template.default_external_map = external_map
 
-        logger.debug('Created ScaleAI Task {}'.format(scale_ai_task.id))
+        logger.debug(f"Created ScaleAI Task {scale_ai_task.id}")
         return external_map
 
     def set_task_in_progress(self, task):
@@ -384,7 +384,7 @@ class ScaleAISyncManager:
         objects_to_annotate = self.get_label_objects()
         scale_ai_project = self.get_scale_ai_project()
         attachment_type = task.file.type
-        logger.debug('Creating ScaleAI of for task_template type {}'.format(self.task_template.instance_type))
+        logger.debug(f"Creating ScaleAI of for task_template type {self.task_template.instance_type}")
         if self.task_template.instance_type == 'box':
             scale_ai_type = 'bounding_box'
             if self.task_template.guide_default:
@@ -471,7 +471,7 @@ def send_task_to_scale_ai():
         if task:
             task_template = task.job
             connection = task_template.interface_connection
-            logger.debug('Connection for ScaleAI: {}'.format(connection))
+            logger.debug(f"Connection for ScaleAI: {connection}")
             connector_manager = ConnectorManager(connection=connection, session=session)
             connector = connector_manager.get_connector_instance()
             connector.connect()
@@ -485,7 +485,7 @@ def send_task_to_scale_ai():
             )
 
             scale_ai_task, log = scale_ai_sync_manager.send_diffgram_task(task)
-            logger.debug('Scale AI create result: {} || {}'.format(scale_ai_task, log))
+            logger.debug(f"Scale AI create result: {scale_ai_task} || {log}")
             if not scale_ai_task:
                 return jsonify(log=log), 400
 
@@ -527,7 +527,7 @@ def task_completed_scaleai():
         external_map_task = ExternalMap.get(
             session=session,
             external_id=input['task']['task_id'],
-            type='{}_task'.format('scale_ai')
+            type="scale_ai_task"
         )
         task = external_map_task.task
         task_template = task.job

--- a/walrus/methods/data_mocking/generate_data.py
+++ b/walrus/methods/data_mocking/generate_data.py
@@ -279,7 +279,7 @@ class DiffgramDataMocker:
             r = rand_int_0_255()    # red
             g = rand_int_0_255()    # green
             b = rand_int_0_255()    # blue
-            random_color = '#%02X%02X%02X' % (r, g, b)
+            random_color = f"#{r:02X}{g:02X}{b:02X}"
             colour = {
                 "a": 1,
                 "hex": random_color,
@@ -291,7 +291,7 @@ class DiffgramDataMocker:
                     }
             }
 
-            label_name = 'Diffgram Sample Label {}'.format(i + 1)
+            label_name = f"Diffgram Sample Label {i + 1}"
             label = self.session.query(Label).filter(
                 Label.name == label_name,
                 Label.default_sequences_to_single_frame == False
@@ -442,7 +442,7 @@ class DiffgramDataMocker:
         n = str(uuid.uuid4())
         project = Project.new(session=self.session,
                               name='Diffgram Sample Project',
-                              project_string_id='sample_project_{}'.format(n),
+                              project_string_id=f"sample_project_{n}",
                               goal='testing',
                               user=user,
                               member_created=user.member,
@@ -458,7 +458,7 @@ class DiffgramDataMocker:
         if structure == '1_pass':
             task_template = self.__create_sample_task_template('Sample Task Template [Diffgram]', project, reviews, member)
             # Try to get the default dataset.
-            input_dir, input_dir_exists = self.generate_sample_dataset('Pending [1st pass] ' + str(time.time())[-5:], project=project)
+            input_dir, input_dir_exists = self.generate_sample_dataset(f"Pending [1st pass] {str(time.time())[-5:]}", project=project)
 
             if not input_dir_exists:
                 self.generate_test_data_on_dataset_copy_file(input_dir, num_files)
@@ -476,19 +476,19 @@ class DiffgramDataMocker:
             self.create_tasks_for_sample_task_template(task_template, attached_dir=input_dir)
         elif structure == '2_pass':
             for i in range(0, 2):
-                task_template = self.__create_sample_task_template('Sample Task Template {} pass'.format(i + 1),
+                task_template = self.__create_sample_task_template(f"Sample Task Template {i + 1} pass",
                                                                    project, reviews, member)
                 # Try to get the default dataset.
                 if i == 0:
-                    input_dir, input_dir_exists = self.generate_sample_dataset('Pending [{} pass]'.format(i + 1),
+                    input_dir, input_dir_exists = self.generate_sample_dataset(f"Pending [{i + 1} pass]",
                                                                                project=project)
                     if not input_dir_exists:
                         self.generate_test_data_on_dataset_copy_file(input_dir)
                 else:
-                    input_dir, input_dir_exists = self.generate_sample_dataset('Completed [{} pass]'.format(i),
+                    input_dir, input_dir_exists = self.generate_sample_dataset(f"Completed [{i} pass]",
                                                                                project=project)
 
-                output_dir, output_dir_exists = self.generate_sample_dataset('Completed [{} pass]'.format(i + 1),
+                output_dir, output_dir_exists = self.generate_sample_dataset(f"Completed [{i + 1} pass]",
                                                                              project=project)
                 task_template.output_dir_action = 'copy'
                 task_template.completion_directory = output_dir

--- a/walrus/methods/export/export_generation.py
+++ b/walrus/methods/export/export_generation.py
@@ -140,14 +140,14 @@ def new_external_export(
                                           bucket_type = 'ml')
         except Exception as exception:
             trace_data = traceback.format_exc()
-            logger.error("[Export, YAML] {}".format(str(exception)))
+            logger.error(f"[Export, YAML] {str(exception)}")
             logger.error(trace_data)
 
         json_data = json.dumps(annotations)
         data_tools.upload_from_string(export.json_blob_name, json_data, content_type = 'text/json', bucket_type = 'ml')
 
     end_time = time.time()
-    logger.info("[Export processor] ran in {}".format(end_time - start_time))
+    logger.info(f"[Export processor] ran in {end_time - start_time}")
 
     Event.new(
         kind = "export_generation",
@@ -181,8 +181,7 @@ def annotation_export_core(
     Generic method to export a file list
     """
 
-    images_dir = settings.PROJECT_IMAGES_BASE_DIR + \
-                 str(project.id) + "/"
+    images_dir = f"{settings.PROJECT_IMAGES_BASE_DIR + str(project.id)}/"
 
     export.file_list_length = len(file_list)
 
@@ -320,7 +319,7 @@ def annotation_export_core(
 
             if index % 10 == 0:
                 # TODO would need to commit the session for this to be useful right?
-                logger.info("Percent done {}".format(export.percent_complete))
+                logger.info(f"Percent done {export.percent_complete}")
                 try_to_commit(session = session)  # push update
 
     export.status = "complete"

--- a/walrus/methods/export/export_utils.py
+++ b/walrus/methods/export/export_utils.py
@@ -16,7 +16,7 @@ def generate_file_name_from_export(export, session):
     # TODO (low priority) switch to starting to array with "".join() it
     # it's a bit faster and more importantly easier to read / check.
 
-    filename = '_diffgram_annotations__source_' + str(export.source) + '_'
+    filename = f"_diffgram_annotations__source_{str(export.source)}_"
     
     if export.source == "task":
         filename += str(export.task.id)
@@ -32,7 +32,7 @@ def generate_file_name_from_export(export, session):
         filename += str(export.working_dir.nickname)
 
     # Always add timestamps to avoid duplicate names.
-    filename += "_datetime_" + datetime.datetime.utcnow().isoformat()
+    filename += f"_datetime_{datetime.datetime.utcnow().isoformat()}"
 
     return filename
 

--- a/walrus/methods/export/export_web.py
+++ b/walrus/methods/export/export_web.py
@@ -333,7 +333,7 @@ def check_export_billing(
             exclude_removed = True,
             return_kind = "count")
 
-    logger.info('Checking limits for export with {} instances'.format(new_instance_count))
+    logger.info(f"Checking limits for export with {new_instance_count} instances")
 
     if max_allowed_instances:
         if new_instance_count > max_allowed_instances:

--- a/walrus/methods/input/input_update.py
+++ b/walrus/methods/input/input_update.py
@@ -286,7 +286,7 @@ class Update_Input():
                        "ID", "Project", "project_string_id", ]
 
         for header in header_list:
-            message.append(header + "\t")
+            message.append(f"{header}	")
 
         for input in input_list:
             message.append("\n")
@@ -295,20 +295,20 @@ class Update_Input():
             if input.original_filename:
                 filename = input.original_filename[: 20]
 
-            message.append(str(input.status) + "\t\t")
-            message.append(str(input.percent_complete) + "\t")
-            message.append(datetime.datetime.strftime(input.created_time, date_format) + "\t")
-            message.append(datetime.datetime.strftime(input.time_updated, date_format) + "\t")
-            message.append(str(filename) + "\t")
-            message.append(str(input.id) + "\t")
-            message.append(str(input.project.name) + "\t")
-            message.append(str(input.project.project_string_id) + "\t")
+            message.append(f"{str(input.status)}		")
+            message.append(f"{str(input.percent_complete)}	")
+            message.append(f"{datetime.datetime.strftime(input.created_time, date_format)}	")
+            message.append(f"{datetime.datetime.strftime(input.time_updated, date_format)}	")
+            message.append(f"{str(filename)}	")
+            message.append(f"{str(input.id)}	")
+            message.append(f"{str(input.project.name)}	")
+            message.append(f"{str(input.project.project_string_id)}	")
 
         if input_list:
             try:
                 communicate_via_email.send(
                     email = "support@diffgram.com",
-                    subject = "Input report: " + str(len(input_list)) + " items.",
+                    subject = f"Input report: {str(len(input_list))} items.",
                     message = "".join(message)
                 )
             except Exception as e:

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -98,7 +98,7 @@ def process_media_unit_of_work(item):
                 process_media_queue_manager.remove_item_from_processing_list(item)
 
             except Exception as e:
-                logger.error("[Process Media] Main failed on {}".format(item.input_id))
+                logger.error(f"[Process Media] Main failed on {item.input_id}")
                 logger.error(str(e))
                 logger.error(traceback.format_exc())
                 process_media_queue_manager.remove_item_from_processing_list(item)
@@ -129,7 +129,7 @@ def start_queue_check_loop(VIDEO_QUEUE, FRAME_QUEUE):
         try:
             add_deferred_items_time = check_if_add_items_to_queue(add_deferred_items_time, VIDEO_QUEUE, FRAME_QUEUE)
         except Exception as exception:
-            logger.info("[Media Queue Failed] {}".format(str(exception)))
+            logger.info(f"[Media Queue Failed] {str(exception)}")
             add_deferred_items_time = 30  # reset
 
 
@@ -147,7 +147,7 @@ def is_memory_available(memory_limit_float = 75.0):
     if memory_percent is None: return True  # Don't stop if this check fails
 
     if memory_percent > memory_limit_float:
-        logger.warn("[Memory] {} % used is > {} limit.".format(memory_percent, memory_limit_float))
+        logger.warn(f"[Memory] {memory_percent} % used is > {memory_limit_float} limit.")
         return False
 
     return True
@@ -161,7 +161,7 @@ def check_if_add_items_to_queue(add_deferred_items_time, VIDEO_QUEUE, FRAME_QUEU
         return add_deferred_items_time
 
     if FRAME_QUEUE.qsize() >= 30:
-        logger.info("FRAME QUEUE LIMIT " + str(FRAME_QUEUE.qsize()))
+        logger.info(f"FRAME QUEUE LIMIT {str(FRAME_QUEUE.qsize())}")
         return add_deferred_items_time
 
     with sessionMaker.session_scope_threaded() as session:
@@ -169,7 +169,7 @@ def check_if_add_items_to_queue(add_deferred_items_time, VIDEO_QUEUE, FRAME_QUEU
         try:
             update_input = Update_Input(session = session).automatic_retry()
         except Exception as exception:
-            logger.error("Couldn't find Update_Input {}".format(str(exception)))
+            logger.error(f"Couldn't find Update_Input {str(exception)}")
             return 30
 
         input = session.query(Input).with_for_update(skip_locked = True).filter(
@@ -193,7 +193,7 @@ def check_if_add_items_to_queue(add_deferred_items_time, VIDEO_QUEUE, FRAME_QUEU
             priority = 100,  # 100 is current default priority
             input_id = input.id)
         add_item_to_queue(item)
-        logger.info(str(input.id) + " Added to queue.")
+        logger.info(f"{str(input.id)} Added to queue.")
 
         return add_deferred_items_time
 
@@ -221,7 +221,7 @@ def wait_until_queue_pressure_is_lower(queue, limit, check_interval = 1):
         if queue.qsize() < limit:
             return True
         else:
-            logger.warn("Queue Presure Too High: {} size is above limit of {} ".format(str(queue.qsize()), limit))
+            logger.warn(f"Queue Presure Too High: {str(queue.qsize())} size is above limit of {limit} ")
             time.sleep(check_interval)
 
 
@@ -464,7 +464,7 @@ class Process_Media():
 
             # We are exiting main loop here
             if len(self.log["error"].keys()) >= 1:
-                logger.error('Error updating instances: {}'.format(str(self.log['error'])))
+                logger.error(f"Error updating instances: {str(self.log['error'])}")
                 return
 
             return
@@ -474,7 +474,7 @@ class Process_Media():
             # Important!
             # We are exiting main loop here
             if len(self.log["error"].keys()) >= 1:
-                logger.error('Error updating instances: {}'.format(str(self.log['error'])))
+                logger.error(f"Error updating instances: {str(self.log['error'])}")
                 return
 
             return
@@ -529,7 +529,7 @@ class Process_Media():
             # careful we expect keys available here ie
             # log['error']['status_text']
             if len(self.log["error"].keys()) >= 1:
-                logger.error('Error downloading media: {}'.format(str(self.log['error'])))
+                logger.error(f"Error downloading media: {str(self.log['error'])}")
                 self.input.update_log['error'] = self.log['error']
                 return False
 
@@ -611,7 +611,7 @@ class Process_Media():
         )
         if existing_file_list:
             self.input.status = "failed"
-            self.input.status_text = "Existing filename with ID {} in directory.".format(str(existing_file_list[0].id))
+            self.input.status_text = f"Existing filename with ID {str(existing_file_list[0].id)} in directory."
             self.input.update_log = {'error': {
                 'existing_file_id': existing_file_list[0].id}
             }
@@ -621,7 +621,7 @@ class Process_Media():
 
     def __copy_video(self):
 
-        logger.debug('Copying Video {}'.format(self.input.file_id))
+        logger.debug(f"Copying Video {self.input.file_id}")
 
         self.input.newly_copied_file = File.copy_file_from_existing(
             session = self.session,
@@ -709,7 +709,7 @@ class Process_Media():
         return new_file
 
     def __copy_image(self):
-        logger.debug('Copying Image {}'.format(self.input.file_id))
+        logger.debug(f"Copying Image {self.input.file_id}")
 
         self.input.newly_copied_file = File.copy_file_from_existing(
             session = self.session,
@@ -746,7 +746,7 @@ class Process_Media():
     def __copy_file(self):
         # Prep work
         if self.input.media_type == "video":
-            logger.info('Starting Sequenced Copy from File {}'.format(self.input.file.id))
+            logger.info(f"Starting Sequenced Copy from File {self.input.file.id}")
             # Get the sequence_map.
             self.__copy_video()
             return
@@ -789,7 +789,7 @@ class Process_Media():
                 logger.debug(("Image or Frame File Update"))
 
                 if file and file.frame_number:
-                    logger.info("{}, {}".format(file.frame_number, self.input.video_parent_length))
+                    logger.info(f"{file.frame_number}, {self.input.video_parent_length}")
 
                 if process_instance_result is True and self.input.media_type == 'frame':
                     self.__update_parent_video_at_last_frame()
@@ -947,7 +947,7 @@ class Process_Media():
         directory = self.input.directory
         if directory is None:
             directory = self.project.directory_default
-            logger.info("[update_jobs_with_attached_dirs] Default Dir Used : {}".format(self.project.directory_default))
+            logger.info(f"[update_jobs_with_attached_dirs] Default Dir Used : {self.project.directory_default}")
 
         jobs = JobWorkingDir.list(
             session = self.session,
@@ -1018,13 +1018,13 @@ class Process_Media():
 
             if log_has_error(self.log):
                 self.input.status = 'failed'
-                logger.error('Sensor fussion file failed to process. Input {}'.format(self.input.id))
+                logger.error(f"Sensor fussion file failed to process. Input {self.input.id}")
                 logger.error(self.log)
 
             self.declare_success(self.input)
 
         except Exception as e:
-            logger.error('Exception on process sensor fusion: {}'.format(traceback.format_exc()))
+            logger.error(f"Exception on process sensor fusion: {traceback.format_exc()}")
             self.log['error']['process_sensor_fusion_json'] = traceback.format_exc()
             self.input.status = 'failed'
             self.input.update_log = self.log
@@ -1223,7 +1223,7 @@ class Process_Media():
          of frame processing time (which is 25->40% of overall time.)
 
         """
-        print('Processing Frame: {}'.format(self.frame_number))
+        print(f"Processing Frame: {self.frame_number}")
         try:
             result = self.read_raw_file()
             if result is False: return False
@@ -1238,7 +1238,7 @@ class Process_Media():
 
             self.proprogate_frame_instance_update_errors_to_parent(log)
 
-            logger.error('Error Processing frame {}, input {} '.format(self.frame_number, self.input.id))
+            logger.error(f"Error Processing frame {self.frame_number}, input {self.input.id} ")
             logger.error(traceback.format_exc())
 
     def process_image_for_frame(self):
@@ -1473,10 +1473,10 @@ class Process_Media():
             TextFile()
         """
         try:
-            logger.debug('Started processing text file from input: {}'.format(self.input_id))
+            logger.debug(f"Started processing text file from input: {self.input_id}")
             result = self.read_raw_text_file()
             if not result:
-                logger.error('Error reading text file {}'.format(self.input.temp_dir_path_and_filename))
+                logger.error(f"Error reading text file {self.input.temp_dir_path_and_filename}")
             # Why is content_type needed here?
             # self.content_type = "image/" + str(self.input.extension)
 
@@ -1674,7 +1674,7 @@ class Process_Media():
             }
 
         else:
-            logger.error('Invalid media type {}'.format(self.input.media_type))
+            logger.error(f"Invalid media type {self.input.media_type}")
             return
 
         allowed_model_id_list = self.__get_allowed_model_ids()
@@ -1724,7 +1724,7 @@ class Process_Media():
         except Exception as e:
             trace = traceback.format_exc()
             self.input.status = "failed"
-            self.input.status_text = "Instance List Creation error: {}".format(trace)
+            self.input.status_text = f"Instance List Creation error: {trace}"
             logger.error(trace)
 
             return False
@@ -1740,7 +1740,7 @@ class Process_Media():
         if not parent_input.update_log:
             parent_input.update_log = regular_log.default()
 
-        parent_input.update_log['error']["Frame " + str(self.frame_number)] = error_log
+        parent_input.update_log['error'][f"Frame {str(self.frame_number)}"] = error_log
         parent_input.update_log['last_updated'] = str(time.time())
 
         self._add_input_to_session(parent_input)
@@ -1770,11 +1770,10 @@ class Process_Media():
                 imwrite(new_temp_filename, np.asarray(self.raw_numpy_image), compress_level=2)
         #For bmp, tif and tiff files save as PNG and compress
         elif str(self.input.extension) in ['.bmp', '.tif', '.tiff']:
-            new_temp_filename = self.input.temp_dir + "/resized_" + str(time.time()) + \
-                                    '.png'
+            new_temp_filename = f"{self.input.temp_dir}/resized_{str(time.time())}.png"
             imwrite(new_temp_filename, np.asarray(self.raw_numpy_image), compress_level=3)
         else:
-            raise NotImplementedError(f'Extension: {self.input.extension} not supported yet.')
+            raise NotImplementedError(f"Extension: {self.input.extension} not supported yet.")
             pass
 
         data_tools.upload_to_cloud_storage(
@@ -1810,7 +1809,7 @@ class Process_Media():
                                       content_type = 'application/json')
         self.new_text_file.tokens_url_signed = data_tools.build_secure_url(self.new_text_file.tokens_url_signed_blob_path,
                                                                            self.new_text_file.tokens_url_signed_expiry)
-        logger.info('Saved Tokens on: {}'.format(self.new_text_file.tokens_url_signed_blob_path))
+        logger.info(f"Saved Tokens on: {self.new_text_file.tokens_url_signed_blob_path}")
 
     def save_raw_text_file(self):
         offset = 2592000
@@ -1821,7 +1820,7 @@ class Process_Media():
                                                                    str(self.new_text_file.id))
 
         # TODO: Please review. On image there's a temp directory for resizing. But I don't feel the need for that here.
-        logger.debug('Uploading text file from {}'.format(self.input.temp_dir_path_and_filename))
+        logger.debug(f"Uploading text file from {self.input.temp_dir_path_and_filename}")
 
         data_tools.upload_to_cloud_storage(
             temp_local_path = self.input.temp_dir_path_and_filename,
@@ -1841,11 +1840,11 @@ class Process_Media():
         """
 
         # Save Thumb
-        self.new_image.url_signed_thumb_blob_path = self.new_image.url_signed_blob_path + "_thumb"
+        self.new_image.url_signed_thumb_blob_path = f"{self.new_image.url_signed_blob_path}_thumb"
 
         thumbnail_image = imresize(self.raw_numpy_image, (160, 160))
 
-        new_temp_filename = self.input.temp_dir + "/resized" + ".jpg"
+        new_temp_filename = f"{self.input.temp_dir}/resized.jpg"
 
         imwrite(new_temp_filename, thumbnail_image, quality=95)
 
@@ -2000,7 +1999,7 @@ class Process_Media():
             self.input.status = "failed"
             self.input.status_text = "Error downloading media."
 
-        logger.info(str(self.input.id) + " InputID Probably Downloaded")
+        logger.info(f"{str(self.input.id)} InputID Probably Downloaded")
 
     def download_from_cloud_storage_to_file(self):
 
@@ -2038,7 +2037,7 @@ class Process_Media():
             self.input.status_text = "Invalid url (Did not start with http)"
             self.log['error']['status_text'] = self.input.status_text
 
-            logger.error("Exceeded retry limit, no valid response LOG: {}".format(str(self.log)))
+            logger.error(f"Exceeded retry limit, no valid response LOG: {str(self.log)}")
             return
         self.input.original_filename, self.input.extension = get_file_name_and_extension(
             self.input.url, input_original_filename = self.input.original_filename)
@@ -2094,15 +2093,15 @@ class Process_Media():
                     # type or something...
                     if len(trial_extension) == 2:
                         # Assume it's the second one
-                        self.input.extension = "." + trial_extension[1]
+                        self.input.extension = f".{trial_extension[1]}"
                     elif len(trial_extension) == 1:
                         # handle if only one item (ie "video" not "video/extension") Is there a better way to
                         # test for this?
-                        self.input.extension = "." + trial_extension[0]
+                        self.input.extension = f".{trial_extension[0]}"
                     else:
                         # Unexpected case, not default "/" split, and not a single extension.
                         self.input.status = "failed"
-                        self.input.status_text = "Invalid Extension" + str(content_type)
+                        self.input.status_text = f"Invalid Extension{str(content_type)}"
                         self.log['error']['status_text'] = self.input.status_text
                         return
 
@@ -2113,7 +2112,7 @@ class Process_Media():
             if self.input.media_type is None or \
                 self.input.media_type not in ["image", "video"]:
                 self.input.status = "failed"
-                self.input.status_text = "Invalid media type: " + str(self.input.extension)
+                self.input.status_text = f"Invalid media type: {str(self.input.extension)}"
                 self.log['error']['status_text'] = self.input.status_text
                 return
 
@@ -2128,9 +2127,9 @@ class Process_Media():
             try:
                 with open(self.input.temp_dir_path_and_filename, 'wb') as f:
                     f.write(response.content)
-                logger.info(str(self.input.id) + " ID Write Finished")
+                logger.info(f"{str(self.input.id)} ID Write Finished")
             except:
-                logger.info(str(self.input.id) + " ID Failure to write")
+                logger.info(f"{str(self.input.id)} ID Failure to write")
 
             self.input.status = "downloaded"
 
@@ -2211,9 +2210,9 @@ class Process_Media():
 
         except Exception as e:
             self.input.status = 'failed'
-            self.log['error']['process_video'] = 'Failed To process video: {}'.format(traceback.format_exc())
+            self.log['error']['process_video'] = f"Failed To process video: {traceback.format_exc()}"
             self.input.update_log = self.log
-            logger.error('Failed To process video: {}'.format(traceback.format_exc()))
+            logger.error(f"Failed To process video: {traceback.format_exc()}")
 
         self.clean_up_temp_dir_on_thread()
 
@@ -2318,7 +2317,7 @@ def get_file_name_and_extension(url, input_original_filename = None):
         if extension == '':
             extension = None
         else:
-            extension = "." + extension
+            extension = f".{extension}"
 
     file_name = secure_filename(file_name)
     if input_original_filename is not None:
@@ -2343,7 +2342,7 @@ def clean_up_temp_dir(path):
         shutil.rmtree(path)  # delete directory
         logger.info("Cleaned successfully")
     except OSError as exc:
-        logger.error("shutil error {}".format(str(exc)))
+        logger.error(f"shutil error {str(exc)}")
         pass
 
 

--- a/walrus/methods/input/upload.py
+++ b/walrus/methods/input/upload.py
@@ -106,7 +106,7 @@ class Upload():
             # Try finding the pre_labels with the file_name as a backup
             file_data = pre_labels.get(file_name)
             if file_data is None:
-                logger.warning('Input: {} File {} has no pre_labeled data associated'.format(input.id, file_name))
+                logger.warning(f"Input: {input.id} File {file_name} has no pre_labeled data associated")
                 return
 
         if file_data.get('file_metadata'):
@@ -133,7 +133,7 @@ class Upload():
             # Try finding the pre_labels with the file_name as a backup
             file_data = pre_labels.get(file_name)
             if file_data is None:
-                logger.warning('Input: {} File {} has no pre_labeled data associated'.format(input.id, file_name))
+                logger.warning(f"Input: {input.id} File {file_name} has no pre_labeled data associated")
                 return
         project_labels = self.get_project_labels()
 
@@ -239,7 +239,7 @@ class Upload():
             member_id=user.member_id if user else None,
             success=True,
             project_id=self.project.id,
-            description=str(input.media_type) + " " + str(self.project.project_string_id),
+            description=f"{str(input.media_type)} {str(self.project.project_string_id)}",
             input_id=input.id
         )
 
@@ -252,10 +252,10 @@ class Upload():
 
         stream = self.binary_file.stream.read()
         content_size = len(stream)
-        logger.info('upload_large_api: raw_data_blob_path {}'.format(input.raw_data_blob_path))
-        logger.info('upload_large_api: input_type {}'.format(input.type))
-        logger.info('upload_large_api: media_type {}'.format(input.media_type))
-        logger.info('upload_large_api: input ID {}'.format(input.id))
+        logger.info(f"upload_large_api: raw_data_blob_path {input.raw_data_blob_path}")
+        logger.info(f"upload_large_api: input_type {input.type}")
+        logger.info(f"upload_large_api: media_type {input.media_type}")
+        logger.info(f"upload_large_api: input ID {input.id}")
         try:
             response = data_tools.transmit_chunk_of_resumable_upload(
                 stream=stream,
@@ -269,7 +269,7 @@ class Upload():
                 chunk_index=self.dzchunkindex,
                 input = self.input,
             )
-            logger.info('Upload Response: {}'.format(response))
+            logger.info(f"Upload Response: {response}")
             if response is False:
                 logger.error('Upload failed: Please try again, or try using API/SDK. (Raw upload error)')
                 input.status = "failed"
@@ -277,7 +277,7 @@ class Upload():
                 return
 
         except Exception as exception:
-            logger.error('Upload failed: {}'.format(traceback.format_exc()))
+            logger.error(f"Upload failed: {traceback.format_exc()}")
             input.status = "failed"
             input.status_text = "Please try again, or try using API/SDK. (Raw upload error)"
             raise Exception #TODO REMOVE
@@ -352,7 +352,7 @@ class Upload():
 
         if not self.input.media_type:
             self.input.status = "failed"
-            self.input.status_text = "Invalid file type: " + self.input.extension
+            self.input.status_text = f"Invalid file type: {self.input.extension}"
 
         # self.input.user =
 
@@ -482,7 +482,7 @@ def input_from_local(session,
     input.media_type = Process_Media.determine_media_type(input.extension)
     if not input.media_type:
         input.status = "failed"
-        input.status_text = "Invalid file type: " + input.extension
+        input.status_text = f"Invalid file type: {input.extension}"
         return False, log, input
 
     session.add(input)

--- a/walrus/methods/machine_learning/semantic_segmentation.py
+++ b/walrus/methods/machine_learning/semantic_segmentation.py
@@ -139,7 +139,7 @@ class Semantic_segmentation_data_prep():
                 ImageDraw.Draw(background).polygon(points_local, outline = 255, fill = 255)
             background = np.array(background)
 
-            file_name = self.temp + "/" + str(i) + ".png"
+            file_name = f"{self.temp}/{str(i)}.png"
 
             # Could do 0 index thing but this preserves which polygon it'session referring to... not sure
 
@@ -226,7 +226,7 @@ class Semantic_segmentation_data_prep():
 
         mask = np.array(mask)
 
-        file_name = self.temp + "/" + str(image.id) + ".png"
+        file_name = f"{self.temp}/{str(image.id)}.png"
 
         # Is this the path we want???
         # OR should we save by time stamp? I guess export dir is already unique

--- a/walrus/methods/sensor_fusion/sensor_fusion_file_processor.py
+++ b/walrus/methods/sensor_fusion/sensor_fusion_file_processor.py
@@ -32,8 +32,8 @@ class SensorFusionFileProcessor:
         self.input.status = "processing"
         self.try_to_commit()
         logger.info('INPUT BLOB BUCKET {} |||'.format(settings.CLOUD_STORAGE_BUCKET, settings.DIFFGRAM_STATIC_STORAGE_PROVIDER))
-        logger.info('INPUT BLOB URL {} |||'.format(self.input.raw_data_blob_path))
-        logger.info('INPUT BLOB temp_dir_path_and_filename {}'.format(self.input.temp_dir_path_and_filename))
+        logger.info(f"INPUT BLOB URL {self.input.raw_data_blob_path} |||")
+        logger.info(f"INPUT BLOB temp_dir_path_and_filename {self.input.temp_dir_path_and_filename}")
 
         with open(self.input.temp_dir_path_and_filename, encoding = 'latin1') as json_data:
             sensor_fusion_spec = json.load(json_data)
@@ -47,7 +47,7 @@ class SensorFusionFileProcessor:
         pcd_file_builder = PCDFileBuilder(point_list = sensor_fusion_spec.get('point_list'))
 
         pcd_save_path = self.input.temp_dir_path_and_filename.split('.json')[0]
-        pcd_save_path = pcd_save_path + '.pcd'
+        pcd_save_path = f"{pcd_save_path}.pcd"
         pcd_file_builder.generate_pcd_file(save_path = pcd_save_path)
         return pcd_save_path
 
@@ -57,7 +57,7 @@ class SensorFusionFileProcessor:
             creates point cloud object
         :return:
         """
-        blob_path = '{}{}/{}'.format(settings.PROJECT_PCD_FILES_BASE_DIR, str(self.input.project_id), str(file_3d.id))
+        blob_path = f"{settings.PROJECT_PCD_FILES_BASE_DIR}{str(self.input.project_id)}/{str(file_3d.id)}"
         self.data_tools.upload_to_cloud_storage(temp_local_path = pcd_file_path, blob_path = blob_path)
 
         point_cloud = PointCloud.new(

--- a/walrus/methods/startup/system_startup_checker.py
+++ b/walrus/methods/startup/system_startup_checker.py
@@ -10,7 +10,7 @@ class WalrusServiceSystemStartupChecker(SystemStartupBase):
         self.service_name = settings.DIFFGRAM_SERVICE_NAME
 
     def execute_startup_checks(self):
-        logger.info('[{}] Performing System Checks...'.format(self.service_name))
+        logger.info(f"[{self.service_name}] Performing System Checks...")
         self.check_settings_values_validity()
         result = SystemEvents.system_startup_events_check(self.service_name)
         if not result:

--- a/walrus/methods/sync_events/sync_actions_handler.py
+++ b/walrus/methods/sync_events/sync_actions_handler.py
@@ -15,7 +15,7 @@ from shared.utils import job_dir_sync_utils
 
 def on_launch_error_retry(retry_state):
     if retry_state.outcome:
-        logger.error('Error on Sync execution. Retrying... {}/3'.format(retry_state.attempt_number))
+        logger.error(f"Error on Sync execution. Retrying... {retry_state.attempt_number}/3")
 
 
 class SyncActionsHandlerThread:
@@ -96,9 +96,9 @@ class SyncActionsHandlerThread:
 
                 )
             else:
-                logger.info('{} event effect not supported for processing.'.format(sync_event.event_effect_type))
+                logger.info(f"{sync_event.event_effect_type} event effect not supported for processing.")
         else:
-            logger.info('{} event trigger not supported for processing.'.format(sync_event.event_trigger_type))
+            logger.info(f"{sync_event.event_trigger_type} event trigger not supported for processing.")
 
     def check_for_new_sync_actions(self):
         """
@@ -117,7 +117,7 @@ class SyncActionsHandlerThread:
                         self.process_sync_actions(session, sync_action)
                         session.query(SyncActionsQueue).filter(SyncActionsQueue.id == sync_action.id).delete()
                     except Exception as e:
-                        logger.critical('Error executing SynAction {}'.format(sync_action.sync_event.id))
+                        logger.critical(f"Error executing SynAction {sync_action.sync_event.id}")
                         sync_action.sync_event.status = 'failed'
                         sync_action.sync_event.execution_log = traceback.format_exc()
                         sync_action.sync_event.description = str(e)
@@ -136,4 +136,4 @@ class SyncActionsHandlerThread:
                         sync_action.sync_event.description = str(e)
                         session_error.query(SyncActionsQueue).filter(SyncActionsQueue.id == sync_action.id).delete()
                         session_error.add(sync_action.sync_event)
-                logger.critical('Unhandled Error in except clause Sync Action ID: {}'.format(sync_action_id))
+                logger.critical(f"Unhandled Error in except clause Sync Action ID: {sync_action_id}")

--- a/walrus/methods/task/task_template/task_template_after_launch_strategies/datasaur_task_template_after_launch_strategy.py
+++ b/walrus/methods/task/task_template/task_template_after_launch_strategies/datasaur_task_template_after_launch_strategy.py
@@ -15,7 +15,7 @@ class DatasaurTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
     def create_datasaur_labelset(self, label_data, connector):
         result = connector.put_data({
             'action_type': 'create_label_set',
-            'name': 'labelset-{}-{}'.format(self.task_template.name, self.task_template.id),
+            'name': f"labelset-{self.task_template.name}-{self.task_template.id}",
             'event_data': {},
             'label_data': label_data
         })
@@ -51,7 +51,7 @@ class DatasaurTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
         """
         datasaur_project = None
         connection = self.task_template.interface_connection
-        logger.debug('Connection for Datasaur: {}'.format(connection))
+        logger.debug(f"Connection for Datasaur: {connection}")
         connector_manager = ConnectorManager(connection=connection, session=self.session)
         connector = connector_manager.get_connector_instance()
         connector.connect()
@@ -62,7 +62,7 @@ class DatasaurTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
                 element = {
                     'uuid': str(uuid.uuid4()),
                     'diffgram_label_file': label_element['id'],
-                    'name': '{}'.format(label_element['label']['name']),
+                    'name': f"{label_element['label']['name']}",
                     'color': label_element['colour']['hex'].upper(),
                 }
                 label_data.append(element)
@@ -70,7 +70,7 @@ class DatasaurTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
             # First we need to build a label set
             label_set_result = self.create_datasaur_labelset(label_data, connector)
             label_set = label_set_result['result']['createLabelSet']
-            logger.debug('Created label_set {}'.format(label_set))
+            logger.debug(f"Created label_set {label_set}")
             if label_set.get('id'):
                 logger.info('Datasaur Labelset created succesfully ID:'.format(label_set['id']))
                 ExternalMap.new(
@@ -79,7 +79,7 @@ class DatasaurTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
                     external_id=label_set['id'],
                     connection=connection,
                     diffgram_class_string='',
-                    type='{}_label_set'.format(connection.integration_name),
+                    type=f"{connection.integration_name}_label_set",
                     url='',
                     add_to_session=True,
                     flush_session=True
@@ -93,7 +93,7 @@ class DatasaurTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
                         external_id=label_element['uuid'],
                         connection=connection,
                         diffgram_class_string='label_file',
-                        type='{}_label'.format(connection.integration_name),
+                        type=f"{connection.integration_name}_label",
                         url='',
                         add_to_session=True,
                         flush_session=True
@@ -109,7 +109,7 @@ class DatasaurTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
                 files_to_process_by_id[str(file.id)] = file
             print('files_to_process_by_id', files_to_process_by_id)
             result = self.create_datasaur_project(connector, label_set, files_to_process)
-            logger.debug('Create datasaur Project result: {}'.format(result))
+            logger.debug(f"Create datasaur Project result: {result}")
             if 'result' in result:
                 datasaur_project = result['result']
                 ExternalMap.new(
@@ -118,8 +118,8 @@ class DatasaurTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
                     external_id=datasaur_project['id'],
                     connection=connection,
                     diffgram_class_string='task_template',
-                    type='{}_project'.format(connection.integration_name),
-                    url='https://datasaur.ai/projects/{}/'.format(datasaur_project['id']),
+                    type=f"{connection.integration_name}_project",
+                    url=f"https://datasaur.ai/projects/{datasaur_project['id']}/",
                     add_to_session=True,
                     flush_session=True,
                 )
@@ -137,7 +137,7 @@ class DatasaurTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
                         file=diffgram_file,
                         connection=connection,
                         diffgram_class_string='file',
-                        type='{}_file'.format(connection.integration_name),
+                        type=f"{connection.integration_name}_file",
                         url='',
                         add_to_session=True,
                         flush_session=True,
@@ -159,7 +159,7 @@ class DatasaurTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
                 raise Exception(result)
 
         except Exception as e:
-            logger.error('Error during datasaur launch strategy. {}'.format(traceback.format_exc()))
+            logger.error(f"Error during datasaur launch strategy. {traceback.format_exc()}")
             if datasaur_project:
                 logger.error('Rolling back project creation...')
                 result = connector.put_data({

--- a/walrus/methods/task/task_template/task_template_after_launch_strategies/labelbox_task_template_after_launch_strategy.py
+++ b/walrus/methods/task/task_template/task_template_after_launch_strategies/labelbox_task_template_after_launch_strategy.py
@@ -27,7 +27,7 @@ class LabelboxTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
         for label_element in self.task_template.label_dict['label_file_list_serialized']:
 
             element = {
-                'name': '{}'.format(label_element['label']['name']),
+                'name': f"{label_element['label']['name']}",
                 'color': label_element['colour']['hex'].upper(),
                 'tool': self.LABELBOX_DIFFGRAM_TOOLS_MAPPING[self.task_template.instance_type],
                 'required': False,
@@ -131,7 +131,7 @@ class LabelboxTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
             'event_data': {},
         })
         if result_has_error(result):
-            raise Exception('Failed to setup labelbox project. {}'.format(str(result)))
+            raise Exception(f"Failed to setup labelbox project. {str(result)}")
         if 'result' in result:
             labelbox_project = result['result']
         else:
@@ -146,14 +146,14 @@ class LabelboxTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
             connection=connection,
             diffgram_class_string='task_template',
             type=connection.integration_name,
-            url='https://app.labelbox.com/projects/{}/overview'.format(labelbox_project.uid),
+            url=f"https://app.labelbox.com/projects/{labelbox_project.uid}/overview",
             add_to_session=True,
             flush_session=True
         )
         # Commented to bottom to avoid circular dependencies on job.
         self.task_template.default_external_map = external_map
 
-        logger.debug('Created Labelbox Project {}'.format(labelbox_project.uid))
+        logger.debug(f"Created Labelbox Project {labelbox_project.uid}")
         return external_map
 
     def get_labelbox_frontend(self, connector):
@@ -162,7 +162,7 @@ class LabelboxTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
             'event_data': {},
         })
         if result_has_error(result):
-            raise Exception('Failed to setup labelbox frontend. {}'.format(str(result)))
+            raise Exception(f"Failed to setup labelbox frontend. {str(result)}")
         frontend = result['result']
         logger.debug('Created Labelbox Frontend.')
         return frontend
@@ -178,7 +178,7 @@ class LabelboxTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
             'event_data': {},
         })
         if result_has_error(result):
-            raise Exception('Failed to setup labelbox onthology. {}'.format(str(result)))
+            raise Exception(f"Failed to setup labelbox onthology. {str(result)}")
         logger.debug('Created Labelbox Project Ontology.')
         # Now save ontology relations
         query_ontology = """
@@ -210,7 +210,7 @@ class LabelboxTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
             # We don't check perms here because we assume this was checked on the task template creation.
             # Otherwise, we would need request context here, which we don't have.
             connection = self.task_template.interface_connection
-            logger.debug('Connection for labelbox: {}'.format(connection))
+            logger.debug(f"Connection for labelbox: {connection}")
             connector_manager = ConnectorManager(connection=connection, session=self.session)
             connector = connector_manager.get_connector_instance()
             connector.connect()
@@ -262,7 +262,7 @@ class LabelboxTaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
                     self.task_template.default_external_map = None
                     self.session.delete(self.task_template.default_external_map)
                 labelbox_project.delete()
-                logger.debug('ROLLBACK. Deleted Labelbox Project {}'.format(labelbox_project.uid))
+                logger.debug(f"ROLLBACK. Deleted Labelbox Project {labelbox_project.uid}")
                 # Allow time for rate limiter in case of a rate limit exception.
                 time.sleep(5)
             raise e

--- a/walrus/methods/task/task_template/task_template_after_launch_strategies/scale_ai_task_template_after_launch_strategy.py
+++ b/walrus/methods/task/task_template/task_template_after_launch_strategies/scale_ai_task_template_after_launch_strategy.py
@@ -30,14 +30,14 @@ class ScaleAITaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
             connection=connection,
             diffgram_class_string='task_template',
             type=connection.integration_name,
-            url='https://dashboard.scale.com/test/tasks?project={}'.format(scale_ai_project['name']),
+            url=f"https://dashboard.scale.com/test/tasks?project={scale_ai_project['name']}",
             add_to_session=True,
             flush_session=True
         )
         # Commented to bottom to avoid circular dependencies on job.
         self.task_template.default_external_map = external_map
 
-        logger.debug('Created ScaleAI Project {}'.format(scale_ai_project['name']))
+        logger.debug(f"Created ScaleAI Project {scale_ai_project['name']}")
 
     def execute_after_launch_strategy(self):
         """
@@ -51,7 +51,7 @@ class ScaleAITaskTemplateAfterLaunchStrategy(TaskTemplateAfterLaunchStrategy):
             # We don't check perms here because we assume this was checked on the task template creation.
             # Otherwise, we would need request context here, which we don't have.
             connection = self.task_template.interface_connection
-            logger.debug('Connection for ScaleAI: {}'.format(connection))
+            logger.debug(f"Connection for ScaleAI: {connection}")
             connector_manager = ConnectorManager(connection=connection, session=self.session)
             connector = connector_manager.get_connector_instance()
             connector.connect()

--- a/walrus/methods/task/task_template/task_template_launch_handler.py
+++ b/walrus/methods/task/task_template/task_template_launch_handler.py
@@ -92,7 +92,7 @@ def task_template_new_exam(session, task_template):
 
 def on_launch_error_retry(retry_state):
     if retry_state.outcome:
-        logger.error('Error Launching job. Retrying... {}/3'.format(retry_state.attempt_number))
+        logger.error(f"Error Launching job. Retrying... {retry_state.attempt_number}/3")
 
 
 class TaskTemplateLauncherThread:
@@ -177,7 +177,7 @@ class TaskTemplateLauncherThread:
                         return
                     job_launch = JobLaunch.get_by_id(session=session, job_launch_id=task_template_queue_element.job_launch_id)
                     job = Job.get_by_id(session, job_id=job_launch.job_id)
-                    logger.critical('Error launching Job {}'.format(job.id))
+                    logger.critical(f"Error launching Job {job.id}")
                     task_template_queue_element.job_launch.status = 'failed'
                     # TODO, we can remove this when we have a better UI visualization for JobLaunch
                     task_template_queue_element.job_launch.job.status = 'failed'
@@ -223,7 +223,7 @@ class AfterLaunchControl:
             self.task_template.interface_connection))
         if self.task_template.interface_connection:
             interface_connection = self.task_template.interface_connection
-            logger.debug('integration name is {}'.format(interface_connection.integration_name))
+            logger.debug(f"integration name is {interface_connection.integration_name}")
             # If task template has an integration with labelbox. Change the after launch strategy.
             if interface_connection.integration_name == 'labelbox':
                 strategy = LabelboxTaskTemplateAfterLaunchStrategy(

--- a/walrus/methods/utils/graceful_killer.py
+++ b/walrus/methods/utils/graceful_killer.py
@@ -70,9 +70,9 @@ class GracefulKiller(metaclass = Singleton):
                 break
             else:
                 logger.warning('Pending Data to Process: ')
-                logger.warning('VIDEO_QUEUE: {}'.format(process_media_queue_manager.VIDEO_QUEUE.qsize()))
-                logger.warning('FRAME_QUEUE: {}'.format(process_media_queue_manager.FRAME_QUEUE.qsize()))
-                logger.warning('PROCESSING_INPUTS: {}'.format(len(process_media_queue_manager.PROCESSING_INPUT_LIST)))
+                logger.warning(f"VIDEO_QUEUE: {process_media_queue_manager.VIDEO_QUEUE.qsize()}")
+                logger.warning(f"FRAME_QUEUE: {process_media_queue_manager.FRAME_QUEUE.qsize()}")
+                logger.warning(f"PROCESSING_INPUTS: {len(process_media_queue_manager.PROCESSING_INPUT_LIST)}")
 
             time.sleep(self.SLEEP_TIME)
             num_retries += 1
@@ -82,9 +82,9 @@ class GracefulKiller(metaclass = Singleton):
         else:
             logger.error('Unable to shutdown gracefully. MAX RETRIES After {} seconds.'.format(
                 self.MAX_CHECKS * self.SLEEP_TIME))
-            logger.error('VIDEO_QUEUE: {}'.format(process_media_queue_manager.VIDEO_QUEUE.qsize()))
-            logger.error('FRAME_QUEUE: {}'.format(process_media_queue_manager.FRAME_QUEUE.qsize()))
-            logger.error('PROCESSING_INPUTS: {}'.format(len(process_media_queue_manager.PROCESSING_INPUT_LIST)))
+            logger.error(f"VIDEO_QUEUE: {process_media_queue_manager.VIDEO_QUEUE.qsize()}")
+            logger.error(f"FRAME_QUEUE: {process_media_queue_manager.FRAME_QUEUE.qsize()}")
+            logger.error(f"PROCESSING_INPUTS: {len(process_media_queue_manager.PROCESSING_INPUT_LIST)}")
             self.set_inputs_with_error_status(process_media_queue_manager.PROCESSING_INPUT_LIST)
             # TODO: set failed inputs to failed status
             self.exit_process()

--- a/walrus/methods/video/interpolation.py
+++ b/walrus/methods/video/interpolation.py
@@ -493,7 +493,7 @@ def interpolate_api(task_id):
             )
         except Exception as e:
             trace = traceback.format_exc()
-            logger.error('File {} is Locked'.format(task.file.id))
+            logger.error(f"File {task.file.id} is Locked")
             logger.error(trace)
             log['error']['file_locked'] = 'File is being saved by another process, please try again later.'
             return jsonify(log), 400
@@ -543,7 +543,7 @@ def interpolate_all_frames_using_task(task_id):
             )
         except Exception as e:
             trace = traceback.format_exc()
-            logger.error('File {} is Locked'.format(task.file.id))
+            logger.error(f"File {task.file.id} is Locked")
             logger.error(trace)
             log['error']['file_locked'] = 'File is being saved by another process, please try again later.'
             return jsonify(log), 400
@@ -604,7 +604,7 @@ def interpolate_all_frames(project_string_id, video_file_id):
                 nowait = True)
         except Exception as e:
             trace = traceback.format_exc()
-            logger.error('File {} is Locked'.format(video_file_id))
+            logger.error(f"File {video_file_id} is Locked")
             logger.error(trace)
             log['error']['file_locked'] = 'File is being saved by another process, please try again later.'
             return jsonify(log), 400

--- a/walrus/methods/video/video.py
+++ b/walrus/methods/video/video.py
@@ -81,7 +81,7 @@ class New_video():
         data_tools.upload_to_cloud_storage(
             temp_local_path = video_file_name,
             blob_path = video.file_blob_path,
-            content_type = "video/" + str(extension[1:]),
+            content_type = f"video/{str(extension[1:])}",
             timeout = 60 * 10
         )
 
@@ -139,7 +139,7 @@ class New_video():
         """
         process_media.check_and_wait_for_memory(memory_limit_float=85.0)
 
-        logger.info('Reading video data for {} - {}'.format(input.id, video_file_name))
+        logger.info(f"Reading video data for {input.id} - {video_file_name}")
         try:
 
             clip = moviepy_editor.VideoFileClip(video_file_name)
@@ -170,14 +170,14 @@ class New_video():
 
         if fps < 0 or fps > 120:
             input.status = "failed"
-            input.status_text = "Invalid fps setting of " + fps
+            input.status_text = f"Invalid fps setting of {fps}"
             return None
 
         original_fps = clip.fps  # Cache, since it will change
 
         # Always using original. FPS conversion is now deprecated
         fps = original_fps
-        logger.info('Setting FPS for {} - InputID: {}'.format(input.id, video_file_name))
+        logger.info(f"Setting FPS for {input.id} - InputID: {video_file_name}")
         clip = clip.set_fps(fps)
         # https://zulko.github.io/moviepy/ref/VideoClip/VideoClip.html#moviepy.video.VideoClip.VideoClip.set_fps
         # Returns a copy of the clip with a new default fps for functions like write_videofile, iterframe, etc.
@@ -196,26 +196,26 @@ class New_video():
         # temp higher limit for testing stuff
         # enough for a 120fps 5 minutes, or 60 fps 10 minutes
         frame_count_limit = 36000
-        logger.info('Frame Count Is: {} - InputID: {}'.format(length, frame_count_limit))
+        logger.info(f"Frame Count Is: {length} - InputID: {frame_count_limit}")
         if length > frame_count_limit:
             input.status = "failed"
             input.status_text = "Frame count of " + str(length) + \
                                 " exceeded limit of " + str(frame_count_limit) + " (per video)" + \
                                 " Lower FPS conversion in settings, split into seperate files, or upgrade account."
-            logger.error('Video upload exceed frame count limit of {}'.format(frame_count_limit))
+            logger.error(f"Video upload exceed frame count limit of {frame_count_limit}")
             return None
 
         max_size = settings.DEFAULT_MAX_SIZE
 
-        logger.info('Resizing Video... - InputID: {}'.format(input.id))
+        logger.info(f"Resizing Video... - InputID: {input.id}")
         if clip.w > max_size or clip.h > max_size:
             clip = resize_video(clip)
 
-        video_file_name = os.path.splitext(video_file_name)[0] + "_re_saved.mp4"
+        video_file_name = f"{os.path.splitext(video_file_name)[0]}_re_saved.mp4"
 
-        logger.info('Writing video file... - InputID: {}'.format(input.id))
+        logger.info(f"Writing video file... - InputID: {input.id}")
         num_cores = os.cpu_count()
-        logger.info('Num Core to write video: {}'.format(num_cores))
+        logger.info(f"Num Core to write video: {num_cores}")
 
         process_media.check_and_wait_for_memory(memory_limit_float=75.0)
 
@@ -276,7 +276,7 @@ class New_video():
         afterwards from file can be challenging becasue as the system does
         various modifications the parent gets further and further removed.
         """
-        logger.info('Creating Video Objects... - InputID: {}'.format(input.id))
+        logger.info(f"Creating Video Objects... - InputID: {input.id}")
         parent_video_split_duration = None
         try:
             parent_input = input.parent_input(self.session)
@@ -314,7 +314,7 @@ class New_video():
         video.root_blob_path_to_frames = settings.PROJECT_IMAGES_BASE_DIR + \
                                          str(self.project.id) + "/" + str(video.id) + "/frames/"
 
-        logger.info('Re uploading Video... - InputID: {}'.format(input.id))
+        logger.info(f"Re uploading Video... - InputID: {input.id}")
         self.upload_video_file(video_file_name, ".mp4", video)
 
         input.status = "finished_writing_video_file"
@@ -371,7 +371,7 @@ class New_video():
 
         input.time_pushed_all_frames_to_queue = datetime.datetime.utcnow()
 
-        logger.info('Finished Video loading. - InputID: {}'.format(input.id))
+        logger.info(f"Finished Video loading. - InputID: {input.id}")
         return input.file
 
     def try_to_commit(self):
@@ -391,7 +391,7 @@ class New_video():
 
         # Error Case
         if len(self.input.update_log["error"].keys()) >= 1:
-            logger.error('check_update_log_errors: {}'.format(str(self.input.update_log["error"])))
+            logger.error(f"check_update_log_errors: {str(self.input.update_log['error'])}")
             return False
 
         # Success / Default Case
@@ -529,7 +529,7 @@ class New_video():
         # TODO use File.new() for consistency here (ie as we add new things)
 
         # Single frame naming
-        input.original_filename = original_filename + "_" + str(index)
+        input.original_filename = f"{original_filename}_{str(index)}"
         input.extension = ".jpg"
         input.media_type = "frame"
 
@@ -682,7 +682,7 @@ class New_video():
                 self.highest_frame_encountered = int(frame_number)
 
         # Careful need to pass this to child inputs too
-        logger.info("found_sequences " + str(self.found_sequences))
+        logger.info(f"found_sequences {str(self.found_sequences)}")
 
     def determine_new_sequences_from_instance_list(
         self,

--- a/walrus/methods/video/video_preprocess.py
+++ b/walrus/methods/video/video_preprocess.py
@@ -184,7 +184,7 @@ class Video_Preprocess():
         new_sub_clip_filename = str(self.offset_in_seconds) + "_" + \
                                 self.parent_input.original_filename
 
-        output_temp_local_path = self.parent_input.temp_dir + "/" + new_sub_clip_filename
+        output_temp_local_path = f"{self.parent_input.temp_dir}/{new_sub_clip_filename}"
 
         try:
             ffmpeg_extract_subclip(
@@ -192,10 +192,10 @@ class Video_Preprocess():
                 self.offset_in_seconds,
                 end_time,
                 targetname = output_temp_local_path)
-            logger.info(str(i) + " (Iteration) ffmpeg_extract_subclip Success")
+            logger.info(f"{str(i)} (Iteration) ffmpeg_extract_subclip Success")
         except Exception as e:
-            self.log['info'] = "Last iteration: " + str(i)
-            logger.error('Error splitting video {}'.format(str(e)))
+            self.log['info'] = f"Last iteration: {str(i)}"
+            logger.error(f"Error splitting video {str(e)}")
             return False
 
         """
@@ -248,7 +248,7 @@ class Video_Preprocess():
 
         # this must be before we upload so we get the id
         self.new_input()
-        logger.info(str(i) + " (Iteration) new_input finished")
+        logger.info(f"{str(i)} (Iteration) new_input finished")
 
         # Copy the frame packet map if exists.
         self.input.instance_list = self.parent_input.instance_list
@@ -259,9 +259,9 @@ class Video_Preprocess():
             data_tools.upload_to_cloud_storage(
                 temp_local_path = output_temp_local_path,
                 blob_path = self.input.raw_data_blob_path,
-                content_type = "video/" + self.parent_input.extension
+                content_type = f"video/{self.parent_input.extension}"
             )
-            logger.info(str(i) + " (Iteration) upload_to_cloud_storage finished")
+            logger.info(f"{str(i)} (Iteration) upload_to_cloud_storage finished")
 
         # Should be able to run right after upload
         # Double check this is just the path and not whole dir..
@@ -295,7 +295,7 @@ class Video_Preprocess():
         # Could do a - 1 or something for splitting it but
         self.offset_in_seconds = end_time
 
-        logger.info(str(i) + " split overall function Success")
+        logger.info(f"{str(i)} split overall function Success")
 
         return True
 

--- a/walrus/tests/conftest.py
+++ b/walrus/tests/conftest.py
@@ -8,7 +8,7 @@ import os
 from shared.database_setup_supporting import *
 
 parent_path = pathlib.Path(__file__).parent.parent.parent.absolute()
-init_config_path = '{}/shared'.format(parent_path)
+init_config_path = f"{parent_path}/shared"
 
 os.chdir(init_config_path)
 
@@ -27,9 +27,9 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     engine = create_engine(settings.UNIT_TESTING_DATABASE_URL)
-    print('Checking DB: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
+    print(f"Checking DB: {settings.UNIT_TESTING_DATABASE_URL}")
     if not database_exists(engine.url):
-        print('Creating DB: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
+        print(f"Creating DB: {settings.UNIT_TESTING_DATABASE_URL}")
         create_database(engine.url)
         alembic_args = [
             '--raiseerr',
@@ -43,5 +43,5 @@ def pytest_configure(config):
 
 def pytest_unconfigure(config):
     if not config.getoption('--keep-db'):
-        print('Destroying database: {}'.format(settings.UNIT_TESTING_DATABASE_URL))
+        print(f"Destroying database: {settings.UNIT_TESTING_DATABASE_URL}")
         drop_database(settings.UNIT_TESTING_DATABASE_URL)

--- a/walrus/tests/connectors/test_s3.py
+++ b/walrus/tests/connectors/test_s3.py
@@ -92,15 +92,15 @@ class TestS3Connector(testing_setup.DiffgramBaseTestCase):
 
         }
 
-        endpoint = "/api/walrus/v1/project/" + self.project_string_id + "/input/packet"
+        endpoint = f"/api/walrus/v1/project/{self.project_string_id}/input/packet"
         auth_api = common_actions.create_project_auth(project=self.project, session=self.session)
-        credentials = b64encode("{}:{}".format(auth_api.client_id, auth_api.client_secret).encode()).decode('utf-8')
+        credentials = b64encode(f"{auth_api.client_id}:{auth_api.client_secret}".encode()).decode('utf-8')
         response = self.client.post(
             endpoint,
             data=json.dumps(request_data),
             headers={
                 'directory_id': str(self.project.directory_default_id),
-                'Authorization': 'Basic {}'.format(credentials)
+                'Authorization': f"Basic {credentials}"
             }
         )
         self.assertTrue(response.status_code == 200)

--- a/walrus/tests/methods/task/task_template/task_template_after_launch_strategies/test_datasaur_task_template_after_launch_strategy.py
+++ b/walrus/tests/methods/task/task_template/task_template_after_launch_strategies/test_datasaur_task_template_after_launch_strategy.py
@@ -95,7 +95,7 @@ class TestScaleAITaskTemplateAfterLaunchStrategy(testing_setup.DiffgramBaseTestC
                         "a": 1}, "label": {"id": 5, "name": "Car wheel", "default_sequences_to_single_frame": False}}],
             "label_file_colour_map": {}}
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'status': 'active',
             'type': "Normal",
@@ -137,7 +137,7 @@ class TestScaleAITaskTemplateAfterLaunchStrategy(testing_setup.DiffgramBaseTestC
                         external_id='mytestid',
                         connection_id=connection.id,
                         diffgram_class_string='',
-                        type='{}_label_set'.format(connection.integration_name),
+                        type=f"{connection.integration_name}_label_set",
                     )
 
                     self.assertNotEqual(external_map, None)
@@ -148,7 +148,7 @@ class TestScaleAITaskTemplateAfterLaunchStrategy(testing_setup.DiffgramBaseTestC
                         external_id='datasaur_test',
                         connection_id=connection.id,
                         diffgram_class_string='task_template',
-                        type='{}_project'.format(connection.integration_name),
+                        type=f"{connection.integration_name}_project",
                     )
                     self.assertNotEqual(project_map, None)
 
@@ -159,6 +159,6 @@ class TestScaleAITaskTemplateAfterLaunchStrategy(testing_setup.DiffgramBaseTestC
                         file_id=file.id,
                         connection_id=connection.id,
                         diffgram_class_string='file',
-                        type='{}_file'.format(connection.integration_name),
+                        type=f"{connection.integration_name}_file",
                     )
                     self.assertNotEqual(files_maps, None)

--- a/walrus/tests/methods/task/task_template/task_template_after_launch_strategies/test_labelbox_task_template_after_launch_strategy.py
+++ b/walrus/tests/methods/task/task_template/task_template_after_launch_strategies/test_labelbox_task_template_after_launch_strategy.py
@@ -110,7 +110,7 @@ class TestLabelboxTaskTemplateAfterLaunchStrategy(testing_setup.DiffgramBaseTest
         ],
             "label_file_colour_map": {}}
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'status': 'active',
             'type': "Normal",

--- a/walrus/tests/methods/task/task_template/task_template_after_launch_strategies/test_scale_ai_task_template_after_launch_strategy.py
+++ b/walrus/tests/methods/task/task_template/task_template_after_launch_strategies/test_scale_ai_task_template_after_launch_strategy.py
@@ -47,7 +47,7 @@ class TestScaleAITaskTemplateAfterLaunchStrategy(testing_setup.DiffgramBaseTestC
         }, self.session)
 
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'status': 'active',
             'type': "Normal",

--- a/walrus/tests/methods/task/task_template/task_template_after_launch_strategies/test_standard_task_template_after_launch_strategy.py
+++ b/walrus/tests/methods/task/task_template/task_template_after_launch_strategies/test_standard_task_template_after_launch_strategy.py
@@ -40,7 +40,7 @@ class TestStandardTaskTemplateAfterLaunchStrategy(testing_setup.DiffgramBaseTest
             'files': [file]
         }, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'status': 'active',
             'type': "Normal",

--- a/walrus/tests/methods/task/task_template/test_task_template_launch_handler.py
+++ b/walrus/tests/methods/task/task_template/test_task_template_launch_handler.py
@@ -44,7 +44,7 @@ class TestTaskTemplateLaunchHandler(testing_setup.DiffgramBaseTestCase):
         }, self.session)
         file = data_mocking.create_file({'project_id': self.project.id}, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'type': "Normal",
         }, self.session)
@@ -58,7 +58,7 @@ class TestTaskTemplateLaunchHandler(testing_setup.DiffgramBaseTestCase):
 
     def test_task_template_new_normal(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'type': "Normal",
         }, self.session)
@@ -70,7 +70,7 @@ class TestTaskTemplateLaunchHandler(testing_setup.DiffgramBaseTestCase):
 
     def test_task_template_new_exam(self):
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'type': "Normal",
         }, self.session)
@@ -114,7 +114,7 @@ class TestTaskTemplateLauncherThread(testing_setup.DiffgramBaseTestCase):
             'files': [file]
         }, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'type': "Normal",
             'attached_directories': [
@@ -143,7 +143,7 @@ class TestTaskTemplateLauncherThread(testing_setup.DiffgramBaseTestCase):
             'files': [file]
         }, self.session)
         job = data_mocking.create_job({
-            'name': 'my-test-job-{}'.format(1),
+            'name': f"my-test-job-{1}",
             'project': self.project,
             'type': "Normal",
             'attached_directories': [


### PR DESCRIPTION
This PR will take care of almost all the old .format strings and string concats, I didn't count but if we leave the @routes.route() functions out there is at most 10 files with a few exceptions that need to be looked at so we probably got 95% or more with this change.

If this PR gets merged it will fix #632 I think. It might be a good idea to create a new issue then for the remaining files and the fixes for str() conversions within fstrings.


# Converted files
Most of the code files, test files and the installer.
Most fstrings have double quotes except for the few that use double quotes inside.

# Partially conversion
Some fstrings have a str() variable inside after conversion. Example:
```
kind = f"api_enable_{str(input['api_name'])}",
```
It probably won't hurt, and it can most likely be removed. Saving for next iteration.


# Not converted
All instances of @routes.route(). Updating them didn't really improve readability. These files should probably stay as they are, unless someone can think of a way to make these more readable.

```
# Old
@routes.route('/api/v1/project/<string:project_string_id>' +
              '/userscript/list',
              methods=['POST'])
# New
@routes.route(f"/api/v1/project/<string:project_string_id>/userscript/list",
              methods=['POST'])

```

Other files:

- default\methods\source_control\file\file_browser.py
- local_dispatcher\env_adapter.py
- shared\settings\env_adapter.py
- shared\helpers\performance.py

Reason:
No straightforward conversion


@PJEstrada I don't have time to build my docker containers and test right now so I am just creating the pull request.
I separated the commits to the code and test files so you could more easily run your tests without modifications if that would be needed.

Also do you agree on double quoted fstrings by default?
