### PR TITLE
Fix instance being dragged without clicking bug

### DIFF
--- a/frontend/cypress/integration/diffgram/export_annotated_data/export_spec.js
+++ b/frontend/cypress/integration/diffgram/export_annotated_data/export_spec.js
@@ -15,9 +15,6 @@ describe('Export to Cloud Provider', () => {
 
     it('Correctly sends a Job export to AWS Connection', () => {
 
-
-
-      cy.visit('http://localhost:8085/');
       cy.get('#open_main_menu').click();
       cy.get('#export_section').click();
       cy.wait(4000);

--- a/frontend/cypress/integration/diffgram/export_annotated_data/export_spec.js
+++ b/frontend/cypress/integration/diffgram/export_annotated_data/export_spec.js
@@ -10,6 +10,7 @@ describe('Export to Cloud Provider', () => {
     beforeEach(function () {
       // login before each test
       cy.loginByForm(testUser.email, testUser.password)
+      cy.gotToProject(testUser.project_string_id);
     })
 
     it('Correctly sends a Job export to AWS Connection', () => {
@@ -20,6 +21,7 @@ describe('Export to Cloud Provider', () => {
       cy.get('#open_main_menu').click();
       cy.get('#export_section').click();
       cy.wait(4000);
+      cy.get('[data-cy=complete-files-only-checkbox]').click({force: true})
       cy.get('[data-cy=generate-export]').click()
 
       cy.wait(9000);

--- a/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
+++ b/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
@@ -3,7 +3,7 @@ import testLabels from "../../../fixtures/labels.json";
 
 describe("Correctly Submits Task to Review", () => {
   context("task review context", () => {
-    before(function () {
+    beforeEach(function () {
       Cypress.Cookies.debug(true, {verbose: true})
       Cypress.Cookies.defaults({preserve: ["session"]})
 
@@ -13,8 +13,9 @@ describe("Correctly Submits Task to Review", () => {
         .createSampleTasksUsingBackend(10)
     });
 
-    it("Submits a task to review", () => {
+    it("Submits and reviews a task", () => {
       const url = "/api/v1/task/*/complete";
+      const url_review = "/api/v1/task/*/review";
 
         cy.visit(`http://localhost:8085/job/list`)
         .wait(2000)
@@ -37,24 +38,13 @@ describe("Correctly Submits Task to Review", () => {
         .its("response")
         .should("have.property", "statusCode", 200)
         .wait(6000)
-        .get('[data-cy="go-to-task-list"]').click({force: true});
-    });
-
-    it("Reviews a task", () => {
-      const url = "/api/v1/task/*/review";
-      cy.visit(`http://localhost:8085/job/list`)
+        .get('[data-cy="go-to-task-list"]').click({force: true})
         .wait(2000)
-        .get(`.job-card`)
-        .first()
-        .find('.job-title')
-        .parent()
-        .click({force: true})
-        .wait(6000)
         .get("tbody > tr")
         .first()
         .click({force: true})
-        .wait(6000)
-        .intercept(url).as("review_task")
+        .wait(2000)
+        .intercept(url_review).as("review_task")
         .wait(2000)
         .get('[data-cy="submit-to-review"]').click({force: true})
         .wait(2000)
@@ -63,6 +53,7 @@ describe("Correctly Submits Task to Review", () => {
         .its("response")
         .should("have.property", "statusCode", 200);
     });
+
   });
 })
 ;

--- a/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
+++ b/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
@@ -6,6 +6,7 @@ describe("Correctly Submits Task to Review", () => {
     beforeEach(function () {
       Cypress.Cookies.debug(true, {verbose: true})
       Cypress.Cookies.defaults({preserve: ["session"]})
+
       cy.loginByForm(testUser.email, testUser.password)
         .createLabels(testLabels)
         .gotToProject(testUser.project_string_id)
@@ -14,7 +15,7 @@ describe("Correctly Submits Task to Review", () => {
 
     it("Submits a task to review", () => {
       const url = "/api/v1/task/*/complete";
-      cy.create_task_template()
+      cy.createSampleTasksUsingBackend(10)
         .visit(`http://localhost:8085/job/list`)
         .wait(2000)
         .get('@task_template_name')

--- a/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
+++ b/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
@@ -3,20 +3,20 @@ import testLabels from "../../../fixtures/labels.json";
 
 describe("Correctly Submits Task to Review", () => {
   context("task review context", () => {
-    beforeEach(function () {
+    before(function () {
       Cypress.Cookies.debug(true, {verbose: true})
       Cypress.Cookies.defaults({preserve: ["session"]})
 
       cy.loginByForm(testUser.email, testUser.password)
-        .createLabels(testLabels)
         .gotToProject(testUser.project_string_id)
-
+        .createLabels(testLabels)
+        .createSampleTasksUsingBackend(10)
     });
 
     it("Submits a task to review", () => {
       const url = "/api/v1/task/*/complete";
-      cy.createSampleTasksUsingBackend(10)
-        .visit(`http://localhost:8085/job/list`)
+
+        cy.visit(`http://localhost:8085/job/list`)
         .wait(2000)
         .get('@task_template_name')
         .then(task_template_name => {
@@ -50,11 +50,12 @@ describe("Correctly Submits Task to Review", () => {
         .parent()
         .click({force: true})
         .wait(6000)
-        .get(".image-preview")
+        .get("tbody > tr")
         .first()
         .click({force: true})
         .wait(6000)
         .intercept(url).as("review_task")
+        .wait(2000)
         .get('[data-cy="submit-to-review"]').click({force: true})
         .wait(2000)
         .get('[data-cy="review-the-task"]').click({force: true})

--- a/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
+++ b/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
@@ -1,4 +1,5 @@
 import testUser from "../../../fixtures/users.json";
+import testLabels from "../../../fixtures/labels.json";
 
 describe("Correctly Submits Task to Review", () => {
   context("task review context", () => {
@@ -6,6 +7,7 @@ describe("Correctly Submits Task to Review", () => {
       Cypress.Cookies.debug(true, {verbose: true})
       Cypress.Cookies.defaults({preserve: ["session"]})
       cy.loginByForm(testUser.email, testUser.password)
+        .createLabels(testLabels)
         .gotToProject(testUser.project_string_id)
 
     });
@@ -46,6 +48,7 @@ describe("Correctly Submits Task to Review", () => {
         .find('.job-title')
         .parent()
         .click({force: true})
+        .wait(6000)
         .get(".image-preview")
         .first()
         .click({force: true})

--- a/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
+++ b/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
@@ -3,7 +3,7 @@ import testLabels from "../../../fixtures/labels.json";
 
 describe("Correctly Submits Task to Review", () => {
   context("task review context", () => {
-    beforeEach(function () {
+    before(function () {
       Cypress.Cookies.debug(true, {verbose: true})
       Cypress.Cookies.defaults({preserve: ["session"]})
 

--- a/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
+++ b/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
@@ -11,6 +11,7 @@ describe("Correctly Submits Task to Review", () => {
         .gotToProject(testUser.project_string_id)
         .createLabels(testLabels)
         .createSampleTasksUsingBackend(10)
+        .wait(10000)
     });
 
     it("Submits and reviews a task", () => {

--- a/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
+++ b/frontend/cypress/integration/diffgram/task_template/02_task_submit_to_review_spec.js
@@ -11,7 +11,7 @@ describe("Correctly Submits Task to Review", () => {
         .gotToProject(testUser.project_string_id)
         .createLabels(testLabels)
         .createSampleTasksUsingBackend(10)
-        .wait(10000)
+        .createSampleTasksUsingBackend(10)
     });
 
     it("Submits and reviews a task", () => {

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -265,7 +265,6 @@ Cypress.Commands.add('signupPro', function () {
 })
 
 Cypress.Commands.add('createSampleTasksUsingBackend', function (num_files = 11) {
-  let task_template_name;
   cy.request({
     method: 'POST',
     url: `localhost:8085/api/walrus/test/gen-data`,

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -835,6 +835,7 @@ Cypress.Commands.add('create_task_template', function () {
     .get('[data-cy="task-template-step-name"] [data-cy="wizard_navigation_next"]').click()
 
     // Step 2 labels
+    .wait(2000)
     .get('[data-cy="select-all-labels"]')
     .click({force: true})
     .selectLabel(testLabels[0].name, 'label-select')

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -265,12 +265,14 @@ Cypress.Commands.add('signupPro', function () {
 })
 
 Cypress.Commands.add('createSampleTasksUsingBackend', function (num_files = 11) {
+  let task_template_name;
   cy.request({
     method: 'POST',
     url: `localhost:8085/api/walrus/test/gen-data`,
     body: {
       'data_type': 'task_template',
       'structure': '1_pass',
+      'name': 'sample_task_template',
       'num_files': num_files,
       'reviews': {
         allow_reviews: true,
@@ -283,7 +285,8 @@ Cypress.Commands.add('createSampleTasksUsingBackend', function (num_files = 11) 
     failOnStatusCode: true
   }).then((response) => {
     if (response.body.success) {
-      return true
+      cy.log(response.body.data.name)
+      cy.wrap(response.body.data.name).as('task_template_name');
     }
   })
 })

--- a/frontend/src/components/export/export_home.vue
+++ b/frontend/src/components/export/export_home.vue
@@ -56,6 +56,7 @@
 
             <div class="pl-4 pr-4">
               <v-checkbox v-model="ann_is_complete"
+                          data-cy="complete-files-only-checkbox"
                           label="Complete Files Only">
               </v-checkbox>
             </div>

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -215,7 +215,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       return true
     }
     else {
-
+      let moving = false;
       if(this.is_moving){
         this.stop_moving();
       }
@@ -225,7 +225,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       if(this.node_hover_index != undefined){
         if(this.start_index_occlusion != undefined){
           this.occlude_direction(this.node_hover_index)
-          return true
+          moving = true;
         }
         else{
           this.select();

--- a/walrus/methods/data_mocking/generate_data.py
+++ b/walrus/methods/data_mocking/generate_data.py
@@ -61,16 +61,22 @@ data_gen_spec_list = [
                 'required': False
             }
         }
+    },
+    {
+        'name': {
+            'kind': str,
+            'default': '',
+            'required': False
+        }
     }
 ]
 
-@routes.route('/api/walrus/v1/project/<string:project_string_id>/gen-data', 
-              methods=['POST'])
+
+@routes.route('/api/walrus/v1/project/<string:project_string_id>/gen-data', methods = ['POST'])
 @Project_permissions.user_has_project(["admin", "Editor"])
 def generate_data_api(project_string_id):
-
     log, input, untrusted_input = regular_input.master(
-        request=request, spec_list=data_gen_spec_list)
+        request = request, spec_list = data_gen_spec_list)
     if regular_log.log_has_error(log): return jsonify(log = log), 400
 
     with sessionMaker.session_scope() as session:
@@ -80,61 +86,63 @@ def generate_data_api(project_string_id):
     return jsonify({'message': 'OK.'})
 
 
-
-@routes.route('/api/walrus/v1/new_project/gen-data', 
-              methods=['POST'])
+@routes.route('/api/walrus/v1/new_project/gen-data',
+              methods = ['POST'])
 @General_permissions.grant_permission_for(
-    Roles=['normal_user'],
-    apis_user_list=["builder_or_trainer"])
+    Roles = ['normal_user'],
+    apis_user_list = ["builder_or_trainer"])
 def generate_data_new_project_api():
-
     with sessionMaker.session_scope() as session:
-        user = User.get(session=session)
-        data_mocker.generate_sample_project(user=user)
+        user = User.get(session = session)
+        data_mocker.generate_sample_project(user = user)
     return jsonify({'message': 'OK.'})
-
 
 
 @routes.route('/api/walrus/test/gen-data', methods = ['POST'])
 def mock_generate_data_api():
     if settings.DIFFGRAM_SYSTEM_MODE not in ['testing_e2e', 'testing', 'sandbox']:
-        return jsonify(message='Invalid System Mode'), 403
+        return jsonify(message = 'Invalid System Mode'), 403
 
     log, input, untrusted_input = regular_input.master(
-        request=request, spec_list=data_gen_spec_list)
+        request = request, spec_list = data_gen_spec_list)
     if regular_log.log_has_error(log): return jsonify(log = log), 400
 
     with sessionMaker.session_scope() as session:
         project = Project.get(session, "diffgram-testing-e2e")
-        shared_data_gen(session, project, input)
+        data = shared_data_gen(session, project, input)
 
-        out = jsonify(success = True)
+        out = jsonify(success = True, data = data)
 
         return out, 200
 
 
 def shared_data_gen(session, project, input):
-    data_mocker = DiffgramDataMocker(session=session)
+    data_mocker = DiffgramDataMocker(session = session)
     if input['data_type'] == 'dataset':
-        dataset = WorkingDir.get(session=session,
-                                    directory_id=input['dataset_id'], 
-                                    project_id=project.id)
-        data_mocker.generate_test_data_on_dataset(dataset=dataset)
-        
+        dataset = WorkingDir.get(session = session,
+                                 directory_id = input['dataset_id'],
+                                 project_id = project.id)
+        data_mocker.generate_test_data_on_dataset(dataset = dataset)
+
     elif input['data_type'] == 'label':
-        data_mocker.generate_sample_label_files(project=project)
+        data_mocker.generate_sample_label_files(project = project)
 
     elif input['data_type'] == 'task_template':
-        data_mocker.generate_test_data_for_task_templates(
-            project=project, structure=input.get('structure'), num_files=input.get('num_files'), reviews=input.get('reviews'), member=get_member(session))
-        
+        task_template = data_mocker.generate_test_data_for_task_templates(
+            project = project,
+            structure = input.get('structure'),
+            num_files = input.get('num_files'),
+            name = input.get('name'),
+            reviews = input.get('reviews'),
+            member = get_member(session))
+        return task_template.serialize_builder_info_default(session = session)
     elif input['data_type'] == 'annotations':
-        task_list = Task.list(session = session, project_id=project.id, limit_count=100)
+        task_list = Task.list(session = session, project_id = project.id, limit_count = 100)
         label_file_list = WorkingDirFileLink.file_list(
-            session=session,
-            working_dir_id=project.directory_default_id,
-            limit=1,
-            type="label"
+            session = session,
+            working_dir_id = project.directory_default_id,
+            limit = 1,
+            type = "label"
         )
         data_mocker.generate_instance_many(task_list, label_file_list, member_created_id = get_member(session).id)
 
@@ -145,32 +153,30 @@ class DiffgramDataMocker:
 
     NUM_IMAGES = 3
 
-    def generate_test_data_on_dataset(self, dataset, num_files=NUM_IMAGES):
+    def generate_test_data_on_dataset(self, dataset, num_files = NUM_IMAGES):
         inputs_data = []
         for i in range(0, num_files):
             diffgram_input = enqueue_packet(
-                project_string_id=dataset.project.project_string_id,
-                session=self.session,
-                media_url='https://picsum.photos/1000',
-                media_type='image',
-                original_filename="example.jpg",
-                directory_id=dataset.id,
-                commit_input=True,
-                task_id=None,
-                type='from_url',
-                task_action=None,
-                external_map_id=None,
-                external_map_action=None,
-                enqueue_immediately=True,
-                mode=None,
-                allow_duplicates=True)
+                project_string_id = dataset.project.project_string_id,
+                session = self.session,
+                media_url = 'https://picsum.photos/1000',
+                media_type = 'image',
+                original_filename = "example.jpg",
+                directory_id = dataset.id,
+                commit_input = True,
+                task_id = None,
+                type = 'from_url',
+                task_action = None,
+                external_map_id = None,
+                external_map_action = None,
+                enqueue_immediately = True,
+                mode = None,
+                allow_duplicates = True)
 
             inputs_data.append(diffgram_input)
         return inputs_data
 
-
-
-    def generate_instance_many(self, task_list, label_file_list, member_created_id=1, count_per_task=100):
+    def generate_instance_many(self, task_list, label_file_list, member_created_id = 1, count_per_task = 100):
 
         label_file_id = label_file_list[0].id
 
@@ -178,33 +184,33 @@ class DiffgramDataMocker:
         for task in task_list:
             print(task.id, task.project_id)
             for i in range(count_per_task):
-                self.generate_instance(task, member_created_id, instance_type="box", label_file_id=label_file_id)
+                self.generate_instance(task, member_created_id, instance_type = "box", label_file_id = label_file_id)
 
         print("Complete")
 
     def generate_instance(self, task, member_created_id, instance_type, label_file_id):
 
         new_instance = Instance(
-            file_id=task.file_id,
-            sequence_id=None,   #  Different
-            project_id=task.project_id,
-            task_id=task.id,
-            member_created_id=member_created_id,
-            x_min=random.randint(0, 100),
-            y_min=random.randint(0, 100),
-            x_max=random.randint(200, 300),
-            y_max=random.randint(200, 400),
-            width=None,
-            height=None,
-            label_file_id=label_file_id,
-            hash=None,
-            type=instance_type,
-            number=None,
-            frame_number=None,
+            file_id = task.file_id,
+            sequence_id = None,  # Different
+            project_id = task.project_id,
+            task_id = task.id,
+            member_created_id = member_created_id,
+            x_min = random.randint(0, 100),
+            y_min = random.randint(0, 100),
+            x_max = random.randint(200, 300),
+            y_max = random.randint(200, 400),
+            width = None,
+            height = None,
+            label_file_id = label_file_id,
+            hash = None,
+            type = instance_type,
+            number = None,
+            frame_number = None,
             global_frame_number = None,
-            machine_made=None,
-            points=None,
-            soft_delete=False,
+            machine_made = None,
+            points = None,
+            soft_delete = False,
             center_x = None,
             center_y = None,
             angle = None,
@@ -218,7 +224,7 @@ class DiffgramDataMocker:
         )
         self.session.add(new_instance)
 
-    def generate_test_data_on_dataset_copy_file(self, dataset, num_files=NUM_IMAGES):
+    def generate_test_data_on_dataset_copy_file(self, dataset, num_files = NUM_IMAGES):
 
         mock_dir_name = '$$_diffgram_working_dir_mock_dataset'
         mock_dataset = self.session.query(WorkingDir).filter(
@@ -230,32 +236,32 @@ class DiffgramDataMocker:
             self.session.flush()
             print(project)
             mock_dataset = WorkingDir.new_blank_directory(
-                self.session, project_id=project.id, nickname=mock_dir_name)
-            self.generate_test_data_on_dataset(dataset=mock_dataset, num_files=num_files)
+                self.session, project_id = project.id, nickname = mock_dir_name)
+            self.generate_test_data_on_dataset(dataset = mock_dataset, num_files = num_files)
 
         elif num_files > self.NUM_IMAGES:
             print("gen new ones")
-            self.generate_test_data_on_dataset(dataset=mock_dataset, num_files=num_files)
+            self.generate_test_data_on_dataset(dataset = mock_dataset, num_files = num_files)
 
         files_list = WorkingDirFileLink.file_list(
             self.session,
-            working_dir_id=mock_dataset.id,
-            root_files_only=True,
-            limit=num_files,
+            working_dir_id = mock_dataset.id,
+            root_files_only = True,
+            limit = num_files,
         )
 
         for file in files_list:
             new_file = file_transfer_core(
-                session=self.session,
-                source_directory=mock_dataset,
-                destination_directory=dataset,
-                transfer_action='copy',
-                copy_instances=False,
-                update_project_for_copy=True,
-                file=file,
-                log=regular_log.default(),
-                sync_event_manager=None,
-                log_sync_events=False,
+                session = self.session,
+                source_directory = mock_dataset,
+                destination_directory = dataset,
+                transfer_action = 'copy',
+                copy_instances = False,
+                update_project_for_copy = True,
+                file = file,
+                log = regular_log.default(),
+                sync_event_manager = None,
+                log_sync_events = False,
                 defer_copy = False
             )
             # Change the file project to the new project of the mock dataset
@@ -263,7 +269,6 @@ class DiffgramDataMocker:
             file = File.get_by_id(self.session, file_id)
             file.project = dataset.project
             self.session.add(file)
-
 
     def generate_sample_label_files(self, project):
         NUM_LABELS = 3
@@ -276,19 +281,19 @@ class DiffgramDataMocker:
 
         rand_int_0_255 = lambda: random.randint(0, 255)
         for i in range(0, NUM_LABELS):
-            r = rand_int_0_255()    # red
-            g = rand_int_0_255()    # green
-            b = rand_int_0_255()    # blue
+            r = rand_int_0_255()  # red
+            g = rand_int_0_255()  # green
+            b = rand_int_0_255()  # blue
             random_color = '#%02X%02X%02X' % (r, g, b)
             colour = {
                 "a": 1,
                 "hex": random_color,
-                "rgba" : {
-                    'r' : r,
-                    'g' : g,
-                    'b' : b,
-                    'a' : 1     # alpha
-                    }
+                "rgba": {
+                    'r': r,
+                    'g': g,
+                    'b': b,
+                    'a': 1  # alpha
+                }
             }
 
             label_name = 'Diffgram Sample Label {}'.format(i + 1)
@@ -299,7 +304,7 @@ class DiffgramDataMocker:
             if label:
                 existing_label_file = self.session.query(File).join(WorkingDirFileLink).filter(
                     File.type == "label",
-                    WorkingDirFileLink. working_dir_id == default_dir.id,
+                    WorkingDirFileLink.working_dir_id == default_dir.id,
                     File.label_id == label.id,
                     File.project_id == project.id,
                     File.state != 'removed'
@@ -308,11 +313,11 @@ class DiffgramDataMocker:
                     label_files.append(existing_label_file)
                     continue
             label_file = File.new_label_file(
-                session=self.session,
-                working_dir_id=default_dir.id,
-                name=label_name,
-                colour=colour,
-                project=project
+                session = self.session,
+                working_dir_id = default_dir.id,
+                name = label_name,
+                colour = colour,
+                project = project
             )
 
             if project.directory_default.label_file_colour_map is None:
@@ -330,23 +335,23 @@ class DiffgramDataMocker:
         ).first()
         if existing_dir:
             return existing_dir, True
-        
+
         # Reusing new blank directory.
         working_dir = WorkingDir.new_blank_directory(
             session = self.session,
             project = project,
-            project_id=project.id,
-            nickname=nickname
+            project_id = project.id,
+            nickname = nickname
         )
 
         self.session.add(working_dir)
         self.session.flush()
 
         Project_Directory_List.add(
-            session=self.session,
-            working_dir_id=working_dir.id,
-            project_id=project.id,
-            nickname=nickname
+            session = self.session,
+            working_dir_id = working_dir.id,
+            project_id = project.id,
+            nickname = nickname
         )
 
         project.set_cache_key_dirty('directory_list')
@@ -359,53 +364,53 @@ class DiffgramDataMocker:
         NUM_VIDEOS = 3
         files_list_count = WorkingDirFileLink.file_list(
             self.session,
-            working_dir_id=dataset.id,
-            root_files_only=True,  # TODO do we need to get child files too?
-            limit=None,
-            counts_only=True,
-            type=['image', 'video']
+            working_dir_id = dataset.id,
+            root_files_only = True,  # TODO do we need to get child files too?
+            limit = None,
+            counts_only = True,
+            type = ['image', 'video']
         )
         if files_list_count >= NUM_IMAGES:
             return
         for i in range(0, NUM_IMAGES):
             diffgram_input = Input(
-                project_id=dataset.project_id,
-                url='https://picsum.photos/1000',
-                media_type='image',
-                directory_id=dataset.id,
-                type='from_url'
+                project_id = dataset.project_id,
+                url = 'https://picsum.photos/1000',
+                media_type = 'image',
+                directory_id = dataset.id,
+                type = 'from_url'
 
             )
             self.session.add(diffgram_input)
             self.session.flush()
             process_media = Process_Media(
-                session=self.session,
-                input_id=diffgram_input.id,
-                input=diffgram_input,
-                item=None
+                session = self.session,
+                input_id = diffgram_input.id,
+                input = diffgram_input,
+                item = None
             )
             process_media.main_entry()
         # Commit right away for future querying.
         commit_with_rollback(self.session)
 
-    def create_tasks_for_sample_task_template(self, task_template, attached_dir=None, files=None):
+    def create_tasks_for_sample_task_template(self, task_template, attached_dir = None, files = None):
         if not files:
             files = WorkingDirFileLink.file_list(
                 self.session,
-                working_dir_id=attached_dir.id,
-                root_files_only=True,  # TODO do we need to get child files too?
-                limit=None,
-                type='image'
+                working_dir_id = attached_dir.id,
+                root_files_only = True,  # TODO do we need to get child files too?
+                limit = None,
+                type = 'image'
             )
 
         job_sync_manager = JobDirectorySyncManager(
-            session=self.session,
-            job=task_template,
-            log=regular_log.default(),
+            session = self.session,
+            job = task_template,
+            log = regular_log.default(),
             directory = attached_dir
         )
 
-        job_sync_manager.create_file_links_for_attached_dirs(create_tasks=True)
+        job_sync_manager.create_file_links_for_attached_dirs(create_tasks = True)
         return files
 
     def __create_sample_task_template(self, name, project, reviews, member = None):
@@ -422,15 +427,17 @@ class DiffgramDataMocker:
         task_template.stat_count_complete = 0
         task_template.allow_reviews = reviews['allow_reviews']
         task_template.review_chance = reviews['review_chance']
-        directory = WorkingDir.new_blank_directory(session=self.session)
+        directory = WorkingDir.new_blank_directory(session = self.session)
         task_template.directory = directory
-        label_files = self.generate_sample_label_files(project=project)
+        label_files = self.generate_sample_label_files(project = project)
         task_template.label_dict = {
             'label_file_list': [x.serialize_with_label_and_colour(self.session)['id'] for x in label_files]
         }
         if user:
-            task_template.update_reviewer_list(session = self.session, reviewer_list_ids = [user.id], log = regular_log.default())
-            task_template.update_member_list(session = self.session, member_list_ids = [user.id], log = regular_log.default())
+            task_template.update_reviewer_list(session = self.session, reviewer_list_ids = [user.id],
+                                               log = regular_log.default())
+            task_template.update_member_list(session = self.session, member_list_ids = [user.id],
+                                             log = regular_log.default())
 
         task_template.status = 'active'
         self.session.add(task_template)
@@ -438,42 +445,43 @@ class DiffgramDataMocker:
         task_template_label_attach(self.session, task_template)
         return task_template
 
-    def generate_sample_project(self, user=None):
+    def generate_sample_project(self, user = None):
         n = str(uuid.uuid4())
-        project = Project.new(session=self.session,
-                              name='Diffgram Sample Project',
-                              project_string_id='sample_project_{}'.format(n),
-                              goal='testing',
-                              user=user,
-                              member_created=user.member,
+        project = Project.new(session = self.session,
+                              name = 'Diffgram Sample Project',
+                              project_string_id = 'sample_project_{}'.format(n),
+                              goal = 'testing',
+                              user = user,
+                              member_created = user.member,
                               )
-        self.generate_test_data_for_task_templates(project, structure='1_pass')
+        self.generate_test_data_for_task_templates(project, structure = '1_pass')
 
-
-    def generate_test_data_for_task_templates(self, project, structure='1_pass', num_files=NUM_IMAGES, reviews={
-            "allow_reviews": False,
-            "review_chance": 0
-        }, member = None):
+    def generate_test_data_for_task_templates(self, project, structure = '1_pass', num_files = NUM_IMAGES, reviews = {
+        "allow_reviews": False,
+        "review_chance": 0
+    }, member = None, name = 'Sample Task Template [Diffgram]') -> Job:
 
         if structure == '1_pass':
-            task_template = self.__create_sample_task_template('Sample Task Template [Diffgram]', project, reviews, member)
+            task_template = self.__create_sample_task_template(name, project, reviews, member)
             # Try to get the default dataset.
-            input_dir, input_dir_exists = self.generate_sample_dataset('Pending [1st pass] ' + str(time.time())[-5:], project=project)
+            input_dir, input_dir_exists = self.generate_sample_dataset('Pending [1st pass] ' + str(time.time())[-5:],
+                                                                       project = project)
 
             if not input_dir_exists:
                 self.generate_test_data_on_dataset_copy_file(input_dir, num_files)
 
-            output_dir, output_dir_exists = self.generate_sample_dataset('Completed [1st pass]', project=project)
+            output_dir, output_dir_exists = self.generate_sample_dataset('Completed [1st pass]', project = project)
             task_template.output_dir_action = 'copy'
             task_template.completion_directory = output_dir
             rel_input = JobWorkingDir(
-                working_dir_id=input_dir.id,
-                job_id=task_template.id
+                working_dir_id = input_dir.id,
+                job_id = task_template.id
             )
             self.session.add(task_template)
             self.session.add(rel_input)
             self.session.flush()
-            self.create_tasks_for_sample_task_template(task_template, attached_dir=input_dir)
+            self.create_tasks_for_sample_task_template(task_template, attached_dir = input_dir)
+            return task_template
         elif structure == '2_pass':
             for i in range(0, 2):
                 task_template = self.__create_sample_task_template('Sample Task Template {} pass'.format(i + 1),
@@ -481,50 +489,52 @@ class DiffgramDataMocker:
                 # Try to get the default dataset.
                 if i == 0:
                     input_dir, input_dir_exists = self.generate_sample_dataset('Pending [{} pass]'.format(i + 1),
-                                                                               project=project)
+                                                                               project = project)
                     if not input_dir_exists:
                         self.generate_test_data_on_dataset_copy_file(input_dir)
                 else:
                     input_dir, input_dir_exists = self.generate_sample_dataset('Completed [{} pass]'.format(i),
-                                                                               project=project)
+                                                                               project = project)
 
                 output_dir, output_dir_exists = self.generate_sample_dataset('Completed [{} pass]'.format(i + 1),
-                                                                             project=project)
+                                                                             project = project)
                 task_template.output_dir_action = 'copy'
                 task_template.completion_directory = output_dir
                 rel_input = JobWorkingDir(
-                    working_dir_id=input_dir.id,
-                    job_id=task_template.id
+                    working_dir_id = input_dir.id,
+                    job_id = task_template.id
                 )
                 self.session.add(task_template)
                 self.session.add(rel_input)
                 self.session.flush()
-                self.create_tasks_for_sample_task_template(task_template, attached_dir=input_dir)
+                self.create_tasks_for_sample_task_template(task_template, attached_dir = input_dir)
+                return task_template
         elif structure == '2_input_1_output':
             task_template = self.__create_sample_task_template('Sample 2 Input Task Template', project, reviews, member)
             # Try to get the default dataset.
-            input_dir, input_dir_exists = self.generate_sample_dataset('Input Dataset 1', project=project)
-            input2_dir, input2_dir_exists = self.generate_sample_dataset('Input Dataset 2', project=project)
+            input_dir, input_dir_exists = self.generate_sample_dataset('Input Dataset 1', project = project)
+            input2_dir, input2_dir_exists = self.generate_sample_dataset('Input Dataset 2', project = project)
             if not input_dir_exists:
                 self.generate_test_data_on_dataset_copy_file(input_dir)
             if not input2_dir_exists:
                 self.generate_test_data_on_dataset_copy_file(input2_dir)
 
-            output_dir, output_dir_exists = self.generate_sample_dataset('Completed', project=project)
+            output_dir, output_dir_exists = self.generate_sample_dataset('Completed', project = project)
             task_template.output_dir_action = 'copy'
             task_template.completion_directory = output_dir
             rel_input = JobWorkingDir(
-                working_dir_id=input_dir.id,
-                job_id=task_template.id
+                working_dir_id = input_dir.id,
+                job_id = task_template.id
             )
             rel_input2 = JobWorkingDir(
-                working_dir_id=input2_dir.id,
-                job_id=task_template.id
+                working_dir_id = input2_dir.id,
+                job_id = task_template.id
             )
             self.session.add(task_template)
             self.session.add(rel_input)
             self.session.add(rel_input2)
             self.session.flush()
-            self.create_tasks_for_sample_task_template(task_template, attached_dir=input_dir)
+            self.create_tasks_for_sample_task_template(task_template, attached_dir = input_dir)
+            return task_template
         else:
             raise Exception('Invalid structure name')


### PR DESCRIPTION
After moving and occluding instances the UI got to a state where the instance was being dragged only by hovering it. The reason was a return statement that was not allowing the drag flag to be resetted