### PR TITLE
fix: target reticle display on template creation

### DIFF
--- a/frontend/cypress/integration/diffgram/task/task/task_list_user_assign_spec.js
+++ b/frontend/cypress/integration/diffgram/task/task/task_list_user_assign_spec.js
@@ -2,7 +2,7 @@ import testUser from "../../../../fixtures/users.json";
 
 describe("manual_user_assignment", () => {
   context("manual_user_assignment", () => {
-    beforeEach(function() {
+    before(function() {
       cy.createSampleTasksUsingBackend(10);
 
       Cypress.Cookies.debug(true, { verbose: true });

--- a/frontend/src/components/instance_templates/instance_template_creation_dialog.vue
+++ b/frontend/src/components/instance_templates/instance_template_creation_dialog.vue
@@ -308,9 +308,11 @@ export default Vue.extend({
       this.instance_context.draw_mode = draw_mode;
       if (draw_mode) {
         this.$refs.instance_template_canvas.canvas_element.style.cursor = 'none';
+        this.instance.hovered_control_point_key = undefined;
       } else {
         this.$refs.instance_template_canvas.canvas_element.style.cursor = 'auto';
         this.instance.selected = false
+        this.instance.is_drawing_edge = false;
       }
 
       if (this.instance_context.draw_mode) {
@@ -370,6 +372,7 @@ export default Vue.extend({
       if (!this.show_context_menu) {
         this.instance.double_click(event);
         this.hide_context_menu()
+        this.$forceUpdate();
       }
 
     },

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -181,6 +181,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     this.nodes.splice(this.node_hover_index, 1);
     this.edges = new_edges;
     this.current_node_connection = []
+    this.is_drawing_edge = false
   }
   public start_rescale(){
     this.is_rescaling = true;
@@ -300,7 +301,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     let center = this.get_center_point_rotated()
     let rescaled = true;
     var new_width, rx, new_height, ry;
-
+    console.log('XMOVE', x_move, width)
     switch (this.hovered_control_point_key){
       case "right":
         new_width = width + x_move;
@@ -635,6 +636,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   }
 
   private draw_node(node, ctx, i){
+    console.log('draw node', node, node.x, node.y, node.occluded)
     if (this.label_settings &&
       this.label_settings.show_occluded_keypoints == false &&
       node.occluded == true) {
@@ -866,7 +868,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     };
     this.nodes.push(node)
     node.name = this.nodes.length.toString();
-
+    this.calculate_min_max_points()
   }
 
   private draw_icon(
@@ -1001,6 +1003,9 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       return
     }
     if (this.current_node_connection.length === 0) {
+      return
+    }
+    if(!this.current_node_connection[0]){
       return
     }
     ctx.beginPath();


### PR DESCRIPTION
Target reticle was disappearing when deleting a node while drawing a relation. This behaviour is now fixed.