### PR TITLE
Add: Smooth Canvas toggle

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -67,6 +67,7 @@
             @on_task_annotation_complete_and_save="
               on_task_annotation_complete_and_save
             "
+            @smooth_canvas_changed="update_smooth_canvas($event)"
           >
           </toolbar>
         </template>
@@ -1343,6 +1344,7 @@ export default Vue.extend({
         left_nav_width: 450,
         on_instance_creation_advance_sequence: true,
         ghost_instances_closed_by_open_view_edit_panel: false,
+        smooth_canvas: true
       },
 
       annotations_loading: false,
@@ -2172,8 +2174,13 @@ export default Vue.extend({
     },
 
     update_label_settings: function (event) {
-      this.label_settings = event;
+      // Add new events individually in toolbar, e.g. @change="$emit('update_something').
+      this.label_settings = event  // this is actually be reference once connected.
       this.refresh = Date.now();
+    },
+    update_smooth_canvas: function (event){
+      if (!this.canvas_element_ctx) { return }
+      this.canvas_element_ctx.imageSmoothingEnabled = event
     },
     cancel_merge: function () {
       this.$store.commit("set_instance_select_for_merge", false);
@@ -3290,10 +3297,9 @@ export default Vue.extend({
       }
     },
 
-    update_user_settings_from_store() {
-      if (this.$store.state.user.settings.studio_left_nav_width) {
-        this.label_settings.left_nav_width =
-          this.$store.state.user.settings.studio_left_nav_width;
+    update_user_settings_from_store() {   // label_settings
+      for (const [key, value] of Object.entries(this.$store.state.user.settings)) {
+        this.label_settings[key] = value
       }
     },
 
@@ -3423,7 +3429,9 @@ export default Vue.extend({
       }
 
       this.start_autosave(); // created() gets called again when the task ID changes eg "go to next"
+   
     },
+
     fetch_model_run_list: async function () {
       if (!this.$props.model_run_id_list) {
         return;
@@ -3488,6 +3496,8 @@ export default Vue.extend({
       this.refresh = new Date();
       this.canvas_element = document.getElementById("my_canvas");
       this.canvas_element_ctx = this.canvas_element.getContext("2d");
+
+      this.update_smooth_canvas(this.label_settings.smooth_canvas)
 
       this.$forceUpdate();
     },

--- a/frontend/src/components/annotation/toolbar.vue
+++ b/frontend/src/components/annotation/toolbar.vue
@@ -539,6 +539,15 @@
                       max="100"
                     ></v-slider>
 
+                    <v-checkbox
+                      class="pt-0"
+                      label="Smooth Canvas"
+                      v-model="label_settings_local.smooth_canvas"
+                      @change="trigger_smooth_canvas_events()"
+                    >
+                    </v-checkbox>
+
+
                     <v-btn icon @click="filter_reset()">
                       <v-icon color="primary"> autorenew </v-icon>
                     </v-btn>
@@ -1078,10 +1087,20 @@ export default Vue.extend({
         this.label_settings_local.canvas_scale_global_setting
       );
     },
+    trigger_smooth_canvas_events: function () {
+      this.$emit('smooth_canvas_changed', this.label_settings_local.smooth_canvas),
+      this.$store.commit('set_user_setting', [
+        'smooth_canvas',
+        this.label_settings_local.smooth_canvas,
+      ])
+    },
     filter_reset: function () {
       this.label_settings_local.filter_brightness = 100;
       this.label_settings_local.filter_contrast = 100;
       this.label_settings_local.filter_grayscale = 0;
+
+      this.label_settings_local.smooth_canvas = true
+      this.trigger_smooth_canvas_events()
     },
   },
 });

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -10,9 +10,8 @@ Vue.use(Vuex)
 const default_user_settings = {
 
       studio_box_info: true,
-      studio_canvas_size: null,
-      studio_right_nav_width: null,
-      studio_left_nav_width: 350
+      studio_left_nav_width: 350,
+      smooth_canvas: true
     }
 
 // TODO should we use a dic object here for some of user properties?


### PR DESCRIPTION
1) Add reminder: `Add new events individually in toolbar, e.g. @change="$emit('update_something').`   because I added a `prior_settings` comparison before recalling that pattern
2) Improve update_user_settings_from_store() to grab all values. I removed some old dead values. A small step towards a more universal settings saving
3) trick was that `update_smooth_canvas` needs to in the update after the canvas context loads. otherwise it gets squished by image change it appears.

This way the setting saves in veux and is retained on reload.

![not smoooth](https://user-images.githubusercontent.com/18080164/155684939-2f3340ff-c89f-4df0-8885-3e1df262c5c4.PNG)
![smooth](https://user-images.githubusercontent.com/18080164/155684941-2a92ad7b-7aac-4e0f-bafb-dd65f9797431.PNG)

