### PR TITLE
Rescale Keypoints Snapping to Corners

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -274,7 +274,7 @@
             :instance="selected_instance_for_history"
           >
           </instance_history_sidepanel>
-          
+
           <v-divider></v-divider>
 
         <v-expansion-panels
@@ -6807,7 +6807,7 @@ export default Vue.extend({
             point.y += y_diff;
           });
         }
-        this.add_instance_to_file(
+         this.add_instance_to_file(
           new_instance,
           frame_number
         );
@@ -6839,12 +6839,18 @@ export default Vue.extend({
             this.current_instance_template
           )
         ) {
-          this.instance_template_draw_started = true;
-          this.is_actively_drawing = true;
+
+
           this.instance_template_start_point = {
             x: this.mouse_position.x,
             y: this.mouse_position.y,
           };
+          this.current_instance_template.instance_list[0].save_original_nodes();
+          this.current_instance_template.instance_list[0].width = 1;
+          this.current_instance_template.instance_list[0].height = 1;
+
+          this.instance_template_draw_started = true;
+          this.is_actively_drawing = true;
         } else {
           this.add_instance_template_to_instance_list(frame_number);
           this.instance_template_draw_started = undefined;

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6846,8 +6846,7 @@ export default Vue.extend({
             y: this.mouse_position.y,
           };
           this.current_instance_template.instance_list[0].save_original_nodes();
-          this.current_instance_template.instance_list[0].set_nodes_coords_based_on_size(300, 300, this.instance_template_start_point);
-          this.current_instance_template.instance_list[0].calculate_min_max_points();
+          this.current_instance_template.instance_list[0].set_nodes_coords_based_on_size(10, 10, this.instance_template_start_point);
 
           this.current_instance_template.instance_list[0].width = 1;
           this.current_instance_template.instance_list[0].height = 1;

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6846,7 +6846,7 @@ export default Vue.extend({
             y: this.mouse_position.y,
           };
           this.current_instance_template.instance_list[0].save_original_nodes();
-          this.current_instance_template.instance_list[0].set_nodes_coords_based_on_size(1, 1, this.instance_template_start_point);
+          this.current_instance_template.instance_list[0].set_nodes_coords_based_on_size(10, 10, this.instance_template_start_point);
 
           this.current_instance_template.instance_list[0].width = 1;
           this.current_instance_template.instance_list[0].height = 1;

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -679,7 +679,7 @@
               </canvas_current_instance>
               <current_instance_template
                 :ord="6"
-                :current_instance_template="current_instance_template"
+                :current_instance_template="actively_drawing_instance_template"
                 :vertex_size="label_settings.vertex_size"
                 :instance_template_start_point="instance_template_start_point"
                 :instance_template_draw_started="instance_template_draw_started"
@@ -1165,6 +1165,7 @@ export default Vue.extend({
       go_to_keyframe_loading: false,
       show_snackbar_occlude_direction: false,
       instance_rotate_control_mouse_hover: null,
+      actively_drawing_instance_template: null,
       video_parent_file_instance_list: [],
       video_global_attribute_changed: false,
       snapped_to_instance: undefined,
@@ -6840,16 +6841,16 @@ export default Vue.extend({
           )
         ) {
 
-
+          this.actively_drawing_instance_template = {...this.current_instance_template}
           this.instance_template_start_point = {
             x: this.mouse_position.x,
             y: this.mouse_position.y,
           };
-          this.current_instance_template.instance_list[0].save_original_nodes();
-          this.current_instance_template.instance_list[0].set_nodes_coords_based_on_size(10, 10, this.instance_template_start_point);
+          this.actively_drawing_instance_template.instance_list[0].save_original_nodes();
+          this.actively_drawing_instance_template.instance_list[0].set_nodes_coords_based_on_size(10, 10, this.instance_template_start_point);
 
-          this.current_instance_template.instance_list[0].width = 1;
-          this.current_instance_template.instance_list[0].height = 1;
+          this.actively_drawing_instance_template.instance_list[0].width = 1;
+          this.actively_drawing_instance_template.instance_list[0].height = 1;
 
           this.instance_template_draw_started = true;
           this.is_actively_drawing = true;

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -5214,11 +5214,17 @@ export default Vue.extend({
         return;
       }
       if (["polygon", "point"].includes(instance.type)) {
+        if(!instance.points){
+          return
+        }
         instance.x_min = Math.min(...instance.points.map((p) => p.x));
         instance.y_min = Math.min(...instance.points.map((p) => p.y));
         instance.x_max = Math.max(...instance.points.map((p) => p.x));
         instance.y_max = Math.max(...instance.points.map((p) => p.y));
       } else if (["cuboid"].includes(instance.type)) {
+        if(!instance.front_face || !instance.rear_face){
+          return
+        }
         instance.x_min = Math.min(
           instance.front_face["top_right"]["x"],
           instance.front_face["bot_right"]["x"],
@@ -5260,18 +5266,22 @@ export default Vue.extend({
           instance.rear_face["bot_right"]["y"]
         );
       } else if (["ellipse"].includes(instance.type)) {
+        if(!instance.center_x || !instance.center_y || !instance.width || !instance.height){
+          return
+        }
         instance.x_min = instance.center_x - instance.width;
         instance.y_min = instance.center_y - instance.height;
         instance.x_max = instance.center_x + instance.width;
         instance.y_max = instance.center_y + instance.height;
       } else if (["curve"].includes(instance.type)) {
+        if(!instance.p1 || !instance.p2){
+          return
+        }
         instance.x_min = Math.min(instance.p1.x, instance.p2.x);
         instance.x_max = Math.max(instance.p1.x, instance.p2.x);
         instance.y_min = Math.min(instance.p1.y, instance.p2.y);
         instance.y_max = Math.max(instance.p1.y, instance.p2.y);
-      } else if (["keypoints"].includes(instance.type)) {
-        // instance.calculate_min_max_points()
-      } else {
+      }  else {
         instance.x_min = parseInt(instance.x_min);
         instance.y_min = parseInt(instance.y_min);
         instance.x_max = parseInt(instance.x_max);

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6846,7 +6846,8 @@ export default Vue.extend({
             y: this.mouse_position.y,
           };
           this.current_instance_template.instance_list[0].save_original_nodes();
-          this.current_instance_template.instance_list[0].set_nodes_coords_based_on_size(10, 10, this.instance_template_start_point);
+          this.current_instance_template.instance_list[0].set_nodes_coords_based_on_size(300, 300, this.instance_template_start_point);
+          this.current_instance_template.instance_list[0].calculate_min_max_points();
 
           this.current_instance_template.instance_list[0].width = 1;
           this.current_instance_template.instance_list[0].height = 1;

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -6846,6 +6846,8 @@ export default Vue.extend({
             y: this.mouse_position.y,
           };
           this.current_instance_template.instance_list[0].save_original_nodes();
+          this.current_instance_template.instance_list[0].set_nodes_coords_based_on_size(1, 1, this.instance_template_start_point);
+
           this.current_instance_template.instance_list[0].width = 1;
           this.current_instance_template.instance_list[0].height = 1;
 

--- a/frontend/src/components/vue_canvas/current_instance_template.vue
+++ b/frontend/src/components/vue_canvas/current_instance_template.vue
@@ -69,46 +69,53 @@
 
         let x_min = Math.min(this.$props.mouse_position.x, this.$props.instance_template_start_point.x)
         let y_min = Math.min(this.$props.mouse_position.y, this.$props.instance_template_start_point.y)
-        let x_max = Math.max(this.$props.mouse_position.x, this.$props.instance_template_start_point.x)
-        let y_max = Math.max(this.$props.mouse_position.y, this.$props.instance_template_start_point.y)
         ctx.textAlign = "start";
         ctx.lineWidth = '2'
         let fixed_point = this.$props.instance_template_start_point;
         this.draw_instance_template_bounds(ctx, x_min, y_min);
 
         for (let instance of instance_template.instance_list) {
+          instance.calculate_min_max_points()
+          instance.width = instance.x_max - instance.x_min
+          instance.height = instance.y_max - instance.y_min
           // Just keypoints are supported for now
           let height = instance.height;
           let width = instance.width;
           if (instance.type === "keypoints") {
-            let new_height = Math.abs(this.$props.mouse_position.y - fixed_point.y);
-            let new_width = Math.abs(this.$props.mouse_position.x - fixed_point.x);
+            let new_height = Math.round(Math.abs(this.$props.mouse_position.y - fixed_point.y));
+            let new_width = Math.round(Math.abs(this.$props.mouse_position.x - fixed_point.x));
             let ry = new_height / height
             let rx = new_width / width
             if(new_height === 0 || new_width === 0){
               done()
               return
             }
+            let c = 0;
             for (let node of instance.nodes){
-              if(this.mouse_position.x >= fixed_point.x){
-                node.x = fixed_point.x + rx * ( node.x - fixed_point.x)
+              let new_x, new_y;
+              new_x = fixed_point.x + rx * ( node.x - fixed_point.x)
+              new_y = fixed_point.y + ry * ( node.y - fixed_point.y)
+              if(isNaN(new_x) || isNaN(new_y)){
+                return
               }
-              else{
-                node.x = fixed_point.x - rx * ( node.x - fixed_point.x)
-              }
-              if(this.mouse_position.y >= fixed_point.y){
-                node.y = fixed_point.y + ry * ( node.y - fixed_point.y)
-              }
-              else{
-                node.y = fixed_point.y - ry * ( node.y - fixed_point.y)
-              }
+              node.x = Math.round(new_x);
+              node.y = Math.round(new_y);
+              if(c === 0){
+                console.log('width, height', width, height)
+                console.log('new_width, height', new_height, new_height)
+                console.log('RX, RY', rx, ry)
+                console.log('fixed_point', fixed_point.x, fixed_point.y)
+                console.log('mouse', this.mouse_position.x, this.mouse_position.y)
 
-
+                console.log('NEW NODE VALUE', node.x, node.y)
+              }
+              c += 1;
             }
             instance.calculate_min_max_points()
             instance.vertex_size = 2;
             instance.line_width = 2;
-            // instance.draw(ctx);
+            console.log('current draw sstart')
+            instance.draw(ctx);
           }
         }
         done();

--- a/frontend/src/components/vue_canvas/current_instance_template.vue
+++ b/frontend/src/components/vue_canvas/current_instance_template.vue
@@ -81,14 +81,13 @@
           let height = instance.height;
           let width = instance.width;
           if (instance.type === "keypoints") {
-            for(let node of instance.nodes){
-              let new_height = this.$props.mouse_position.y - this.$props.instance_template_start_point.y;
-              let new_width = this.$props.mouse_position.x - this.$props.instance_template_start_point.x;
-              let ry = new_height / height
-              let rx = new_width / width
-              console.log('new point', fixed_point.x, rx, node.x)
-              node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+            let new_height = this.$props.mouse_position.y - this.$props.instance_template_start_point.y;
+            let new_width = this.$props.mouse_position.x - this.$props.instance_template_start_point.x;
+            let ry = new_height / height
+            let rx = new_width / width
+            for (let node of instance.nodes){
               node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
+              node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
             }
             instance.calculate_min_max_points()
             instance.vertex_size = 2;

--- a/frontend/src/components/vue_canvas/current_instance_template.vue
+++ b/frontend/src/components/vue_canvas/current_instance_template.vue
@@ -80,11 +80,17 @@
           // Just keypoints are supported for now
           let height = instance.height;
           let width = instance.width;
+          console.log('INSTANCE WIDHT HIEGHT', instance.width, instance.height)
           if (instance.type === "keypoints") {
-            let new_height = this.$props.mouse_position.y - this.$props.instance_template_start_point.y;
-            let new_width = this.$props.mouse_position.x - this.$props.instance_template_start_point.x;
+            let new_height = Math.abs(this.$props.mouse_position.y - fixed_point.y);
+            let new_width = Math.abs(this.$props.mouse_position.x - fixed_point.x);
             let ry = new_height / height
             let rx = new_width / width
+            if(new_height === 0 || new_width === 0){
+              done()
+              return
+            }
+            console.log('AAA', rx, ry, new_width, new_height)
             for (let node of instance.nodes){
               node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
               node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)

--- a/frontend/src/components/vue_canvas/current_instance_template.vue
+++ b/frontend/src/components/vue_canvas/current_instance_template.vue
@@ -80,24 +80,22 @@
           // Just keypoints are supported for now
           let height = instance.height;
           let width = instance.width;
-          console.log('INSTANCE WIDHT HIEGHT', instance.width, instance.height)
           if (instance.type === "keypoints") {
-            // let new_height = Math.abs(this.$props.mouse_position.y - fixed_point.y);
-            // let new_width = Math.abs(this.$props.mouse_position.x - fixed_point.x);
-            // let ry = new_height / height
-            // let rx = new_width / width
-            // if(new_height === 0 || new_width === 0){
-            //   done()
-            //   return
-            // }
-            // console.log('AAA', rx, ry, new_width, new_height)
-            // for (let node of instance.nodes){
-            //   node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
-            //   node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
-            // }
-            // instance.calculate_min_max_points()
-            // instance.vertex_size = 2;
-            // instance.line_width = 2;
+            let new_height = Math.abs(this.$props.mouse_position.y - fixed_point.y);
+            let new_width = Math.abs(this.$props.mouse_position.x - fixed_point.x);
+            let ry = new_height / height
+            let rx = new_width / width
+            if(new_height === 0 || new_width === 0){
+              done()
+              return
+            }
+            for (let node of instance.nodes){
+              node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
+              node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+            }
+            instance.calculate_min_max_points()
+            instance.vertex_size = 2;
+            instance.line_width = 2;
             instance.draw(ctx);
           }
         }

--- a/frontend/src/components/vue_canvas/current_instance_template.vue
+++ b/frontend/src/components/vue_canvas/current_instance_template.vue
@@ -73,14 +73,24 @@
         let y_max = Math.max(this.$props.mouse_position.y, this.$props.instance_template_start_point.y)
         ctx.textAlign = "start";
         ctx.lineWidth = '2'
+        let fixed_point = this.$props.instance_template_start_point;
         this.draw_instance_template_bounds(ctx, x_min, y_min);
+
         for (let instance of instance_template.instance_list) {
           // Just keypoints are supported for now
-          if (instance.type == "keypoints") {
-            instance.scale_width = Math.abs(this.$props.instance_template_start_point.x - this.$props.mouse_position.x)
-            instance.scale_height = Math.abs(this.$props.instance_template_start_point.y - this.$props.mouse_position.y)
-            instance.translate_x = x_min;
-            instance.translate_y = y_min;
+          let height = instance.height;
+          let width = instance.width;
+          if (instance.type === "keypoints") {
+            for(let node of instance.nodes){
+              let new_height = this.$props.mouse_position.y - this.$props.instance_template_start_point.y;
+              let new_width = this.$props.mouse_position.x - this.$props.instance_template_start_point.x;
+              let ry = new_height / height
+              let rx = new_width / width
+              console.log('new point', fixed_point.x, rx, node.x)
+              node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+              node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
+            }
+            instance.calculate_min_max_points()
             instance.vertex_size = 2;
             instance.line_width = 2;
             instance.draw(ctx);

--- a/frontend/src/components/vue_canvas/current_instance_template.vue
+++ b/frontend/src/components/vue_canvas/current_instance_template.vue
@@ -90,13 +90,25 @@
               return
             }
             for (let node of instance.nodes){
-              node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
-              node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+              if(this.mouse_position.x >= fixed_point.x){
+                node.x = fixed_point.x + rx * ( node.x - fixed_point.x)
+              }
+              else{
+                node.x = fixed_point.x - rx * ( node.x - fixed_point.x)
+              }
+              if(this.mouse_position.y >= fixed_point.y){
+                node.y = fixed_point.y + ry * ( node.y - fixed_point.y)
+              }
+              else{
+                node.y = fixed_point.y - ry * ( node.y - fixed_point.y)
+              }
+
+
             }
             instance.calculate_min_max_points()
             instance.vertex_size = 2;
             instance.line_width = 2;
-            instance.draw(ctx);
+            // instance.draw(ctx);
           }
         }
         done();

--- a/frontend/src/components/vue_canvas/current_instance_template.vue
+++ b/frontend/src/components/vue_canvas/current_instance_template.vue
@@ -75,9 +75,6 @@
         this.draw_instance_template_bounds(ctx, x_min, y_min);
 
         for (let instance of instance_template.instance_list) {
-          instance.calculate_min_max_points()
-          instance.width = instance.x_max - instance.x_min
-          instance.height = instance.y_max - instance.y_min
           // Just keypoints are supported for now
           let height = instance.height;
           let width = instance.width;
@@ -93,28 +90,51 @@
             let c = 0;
             for (let node of instance.nodes){
               let new_x, new_y;
-              new_x = fixed_point.x + rx * ( node.x - fixed_point.x)
-              new_y = fixed_point.y + ry * ( node.y - fixed_point.y)
+              if(this.mouse_position.x >= fixed_point.x){
+                if(node.x >= fixed_point.x){
+                  new_x = fixed_point.x + rx * ( node.x - fixed_point.x)
+                }
+                else{
+                  new_x = fixed_point.x - rx * ( node.x - fixed_point.x)
+                }
+              }
+              else{
+                if(node.x >= fixed_point.x){
+                  new_x = fixed_point.x - rx * ( node.x - fixed_point.x)
+                }
+                else{
+                  new_x = fixed_point.x + rx * ( node.x - fixed_point.x)
+                }
+              }
+
+              if(this.mouse_position.y >= fixed_point.y){
+                if(node.y >= fixed_point.y){
+                  new_y = fixed_point.y + ry * ( node.y - fixed_point.y)
+                }
+                else{
+                  new_y = fixed_point.y - ry * ( node.y - fixed_point.y)
+                }
+              }
+              else{
+                if(node.y >= fixed_point.y){
+                  new_y = fixed_point.y - ry * ( node.y - fixed_point.y)
+                }
+                else{
+                  new_y = fixed_point.y + ry * ( node.y - fixed_point.y)
+                }
+              }
+
+
               if(isNaN(new_x) || isNaN(new_y)){
                 return
               }
               node.x = Math.round(new_x);
               node.y = Math.round(new_y);
-              if(c === 0){
-                console.log('width, height', width, height)
-                console.log('new_width, height', new_height, new_height)
-                console.log('RX, RY', rx, ry)
-                console.log('fixed_point', fixed_point.x, fixed_point.y)
-                console.log('mouse', this.mouse_position.x, this.mouse_position.y)
-
-                console.log('NEW NODE VALUE', node.x, node.y)
-              }
               c += 1;
             }
             instance.calculate_min_max_points()
             instance.vertex_size = 2;
             instance.line_width = 2;
-            console.log('current draw sstart')
             instance.draw(ctx);
           }
         }

--- a/frontend/src/components/vue_canvas/current_instance_template.vue
+++ b/frontend/src/components/vue_canvas/current_instance_template.vue
@@ -82,22 +82,22 @@
           let width = instance.width;
           console.log('INSTANCE WIDHT HIEGHT', instance.width, instance.height)
           if (instance.type === "keypoints") {
-            let new_height = Math.abs(this.$props.mouse_position.y - fixed_point.y);
-            let new_width = Math.abs(this.$props.mouse_position.x - fixed_point.x);
-            let ry = new_height / height
-            let rx = new_width / width
-            if(new_height === 0 || new_width === 0){
-              done()
-              return
-            }
-            console.log('AAA', rx, ry, new_width, new_height)
-            for (let node of instance.nodes){
-              node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
-              node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
-            }
-            instance.calculate_min_max_points()
-            instance.vertex_size = 2;
-            instance.line_width = 2;
+            // let new_height = Math.abs(this.$props.mouse_position.y - fixed_point.y);
+            // let new_width = Math.abs(this.$props.mouse_position.x - fixed_point.x);
+            // let ry = new_height / height
+            // let rx = new_width / width
+            // if(new_height === 0 || new_width === 0){
+            //   done()
+            //   return
+            // }
+            // console.log('AAA', rx, ry, new_width, new_height)
+            // for (let node of instance.nodes){
+            //   node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
+            //   node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+            // }
+            // instance.calculate_min_max_points()
+            // instance.vertex_size = 2;
+            // instance.line_width = 2;
             instance.draw(ctx);
           }
         }

--- a/frontend/src/components/vue_canvas/instance_list.vue
+++ b/frontend/src/components/vue_canvas/instance_list.vue
@@ -556,7 +556,6 @@
             instance.strokeColor = color_data.strokeColor;
             instance.lineWidth = this.get_spatial_line_size();
             instance.vertex_size = this.$props.vertex_size;
-            console.log('instance list draw')
             instance.draw(ctx);
             if(instance.is_hovered || instance.hovered_scale_control_points){
               this.instance_hover_index = i

--- a/frontend/src/components/vue_canvas/instance_list.vue
+++ b/frontend/src/components/vue_canvas/instance_list.vue
@@ -556,6 +556,7 @@
             instance.strokeColor = color_data.strokeColor;
             instance.lineWidth = this.get_spatial_line_size();
             instance.vertex_size = this.$props.vertex_size;
+            console.log('instance list draw')
             instance.draw(ctx);
             if(instance.is_hovered || instance.hovered_scale_control_points){
               this.instance_hover_index = i

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -15,6 +15,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   public hovered_scale_control_points: boolean = false;
   public original_nodes: any = [];
   public hovered_control_point_key: string = undefined;
+  public current_fixed_point: {x:number, y:number} = undefined;
+  public current_control_point: {x:number, y:number} = undefined;
   public start_index_occlusion: number = undefined;
   public occluded: boolean = false;
   public is_rescaling: boolean = false;
@@ -189,6 +191,9 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   }
   public start_rescale(){
     this.is_rescaling = true;
+    this.current_fixed_point = this.get_fixed_point(this.hovered_control_point_key)
+    let control_points = this.get_scale_control_points()
+    this.current_control_point = control_points[this.hovered_control_point_key]
   }
   public start_movement(): void{
     if (this.node_hover_index != undefined) {
@@ -281,61 +286,39 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   public stop_rescaling(){
     this.is_rescaling = false;
     this.hovered_control_point_key = undefined;
+    this.current_fixed_point = undefined;
+    this.current_control_point = undefined;
 
   }
   public stop_moving(){
     this.is_moving = false;
   }
   private get_fixed_point(key:string){
-    let min_max_points = this.get_rotated_min_max()
+    let control_points = this.get_scale_control_points();
     let result;
     if(key === 'right'){
-      result = {
-        x: Math.round(min_max_points.min_x),
-        y: Math.round((min_max_points.max_y + min_max_points.min_y) / 2)
-      }
+      result = control_points.left;
     }
     else if(key === 'left'){
-      result = {
-        x: Math.round(min_max_points.max_x),
-        y: Math.round((min_max_points.max_y + min_max_points.min_y) / 2)
-      }
+      result = control_points.right;
     }
     else if(key === 'top'){
-      result = {
-        x: Math.round((min_max_points.max_x + min_max_points.min_x) / 2),
-        y: Math.round(min_max_points.max_y)
-      }
+      result = control_points.bottom
     }
     else if(key === 'bottom'){
-      result = {
-        x: Math.round(min_max_points.max_y),
-        y: Math.round(min_max_points.min_y)
-      }
+      result = control_points.top
     }
     else if(key === 'bottom_right'){
-      result = {
-        x: Math.round(min_max_points.min_x),
-        y: Math.round(min_max_points.min_y)
-      }
+      result = control_points.top_left
     }
     else if(key === 'bottom_left'){
-      result = {
-        x: Math.round(min_max_points.max_x),
-        y: Math.round(min_max_points.min_y)
-      }
+      result = control_points.top_right
     }
     else if(key === 'top_right'){
-      result = {
-        x: Math.round(min_max_points.min_x),
-        y: Math.round(min_max_points.max_y)
-      }
+      result = control_points.bottom_left
     }
     else if(key === 'top_left'){
-      result = {
-        x: Math.round(min_max_points.max_x),
-        y: Math.round(min_max_points.max_y)
-      }
+      result = control_points.bottom_right
     }
     else{
       result = this.get_center_point_rotated();
@@ -347,13 +330,10 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       return
     }
     let mouse = this.mouse_position;
-    let control_points = this.get_scale_control_points();
-    let points = this.get_rotated_min_max();
     let width = this.width;
     let height = this.height;
-    let x_move = this.mouse_down_delta_event.x;
-    let y_move = this.mouse_down_delta_event.y;
-    let fixed_point = this.get_fixed_point(this.hovered_control_point_key)
+    let fixed_point = this.current_fixed_point;
+    let control_points = this.get_scale_control_points()
     let control_point = control_points[this.hovered_control_point_key]
     let rescaled = true;
     var new_width, rx, new_height, ry;
@@ -376,6 +356,11 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       case "top":
         new_height = Math.round(height + (control_point.y - this.mouse_position.y));
         ry = new_height / height
+        console.log('fixed', fixed_point.y)
+        console.log('new_height', new_height)
+        console.log('height', height)
+        console.log('control_point.y', control_point.y)
+        console.log('this.mouse_position.y.y', this.mouse_position.y)
         for (let node of this.nodes){
           node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
         }

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -219,7 +219,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       return true
     }
     else {
-      console.log('mouse up', this.node_hover_index, this.selected, this.is_hovered)
       if(this.is_moving){
         this.stop_moving();
       }
@@ -261,7 +260,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   }
 
   private move_single_node(node) {
-    console.log('move_single_node')
     let x_move = this.mouse_down_delta_event.x;
     let y_move = this.mouse_down_delta_event.y;
     let old = {...node}
@@ -345,7 +343,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     return result
   }
   public rescale(){
-    console.log('rescale')
     if(!this.hovered_control_point_key){
       return
     }
@@ -356,79 +353,78 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     let height = this.height;
     let x_move = this.mouse_down_delta_event.x;
     let y_move = this.mouse_down_delta_event.y;
-
     let fixed_point = this.get_fixed_point(this.hovered_control_point_key)
-
+    let control_point = control_points[this.hovered_control_point_key]
     let rescaled = true;
     var new_width, rx, new_height, ry;
 
     switch (this.hovered_control_point_key){
       case "right":
-        new_width = width + x_move;
+        new_width = Math.round(width + (this.mouse_position.x - control_point.x));
         rx = new_width / width
         for (let node of this.nodes){
-          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+          node.x = Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
         }
         break;
       case "left":
-        new_width = width - x_move;
+        new_width = Math.round(width + (control_point.x - this.mouse_position.x));
         rx = new_width / width
         for (let node of this.nodes){
-          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+          node.x = Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
         }
         break;
       case "top":
-        new_height = height - y_move;
+        new_height = Math.round(height + (control_point.y - this.mouse_position.y));
         ry = new_height / height
         for (let node of this.nodes){
-          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
+          node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
         }
         break;
       case "bottom":
-        new_height = height + y_move;
+        new_height = Math.round(height + (this.mouse_position.y - control_point.y));
         ry = new_height / height
         for (let node of this.nodes){
-          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
+          node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
         }
         break;
       case "top_right":
-        new_height = height - y_move;
+        new_height = Math.round(height + (control_point.y - this.mouse_position.y));
         ry = new_height / height
-        new_width = width + x_move;
+        new_width = Math.round(width + (this.mouse_position.x - control_point.x));
         rx = new_width / width
         for (let node of this.nodes){
-          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
-          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+          node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
+          node.x = Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
         }
         break;
       case "top_left":
-        new_height = height - y_move;
+        new_height = Math.round(height + (control_point.y - this.mouse_position.y));
         ry = new_height / height
-        new_width = width - x_move;
+        new_width = Math.round(width + (control_point.x - this.mouse_position.x));
         rx = new_width / width
         for (let node of this.nodes){
-          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
-          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+          node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
+          node.x = Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
         }
         break;
       case "bottom_right":
-        new_height = height + y_move;
+        new_height = Math.round(height + (this.mouse_position.y - control_point.y));
         ry = new_height / height
-        new_width = width + x_move;
+        new_width = Math.round(width + (this.mouse_position.x - control_point.x));
         rx = new_width / width
         for (let node of this.nodes){
-          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
-          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+          node.y =  Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
+          node.x =  Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
         }
         break;
       case "bottom_left":
-        new_height = height + y_move;
+        new_height = Math.round(height + (this.mouse_position.y - control_point.y));
         ry = new_height / height
-        new_width = width - x_move;
+        new_width = Math.round(width + (control_point.x - this.mouse_position.x));
         rx = new_width / width
         for (let node of this.nodes){
-          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
-          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
+          node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
+          node.x = Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
         }
         break;
       default:
@@ -498,7 +494,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
     let node = this.nodes[this.node_hover_index]
     if (node) {
-      console.log('move_node')
       node.x = this.get_rotated_point(this.mouse_position, -this.angle).x
       node.y = this.get_rotated_point(this.mouse_position, -this.angle).y
 
@@ -712,7 +707,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     return result
   }
   public set_nodes_coords_based_on_size(width: number, height: number, ref_point: {x: number, y:number}){
-    console.log('set_nodes_coords_based_on_size')
     let original_nodes = this.original_nodes;
     let normalized_nodes = this.normalize_nodes(original_nodes);
     let min_x = Math.min(...normalized_nodes.map(n => n.x)) - this.vertex_size;
@@ -738,9 +732,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       this.label_settings.show_occluded_keypoints == false &&
       node.occluded == true) {
       return
-    }
-    if(!i){
-      console.log('node', node.x, node.y)
     }
     if (node.occluded == true) {
       ctx.globalAlpha = 0.3;

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -4,6 +4,7 @@ import {v4 as uuidv4} from 'uuid';
 
 export class KeypointInstance extends Instance implements InstanceBehaviour {
   public mouse_position: any;
+  private CONTROL_POINTS_DISPLACEMENT: number = 3
   public ctx: CanvasRenderingContext2D;
   private vertex_size: number = 5;
   private line_width: number = 2;
@@ -15,8 +16,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   public hovered_scale_control_points: boolean = false;
   public original_nodes: any = [];
   public hovered_control_point_key: string = undefined;
-  public current_fixed_point: {x:number, y:number} = undefined;
-  public current_control_point: {x:number, y:number} = undefined;
+  public current_fixed_point: { x: number, y: number } = undefined;
+  public current_control_point: { x: number, y: number } = undefined;
   public start_index_occlusion: number = undefined;
   public occluded: boolean = false;
   public is_rescaling: boolean = false;
@@ -50,6 +51,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     const result = super.get_instance_data();
     return result;
   }
+
   constructor(mouse_position = undefined,
               ctx = undefined,
               instance_context = undefined,
@@ -86,7 +88,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
   }
 
-  public duplicate_for_undo(){
+  public duplicate_for_undo() {
     /*
     * This is used just in the context of undo. Duplicates the entire instance
     * we reference ID version number. This is different from copy/paste as in this context
@@ -105,13 +107,14 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     );
     let instance_data_to_keep = {
       ...this,
-      nodes: this.nodes.map(n => ({...n}) ),
-      edges: this.edges.map(e => ({...e}) ),
+      nodes: this.nodes.map(n => ({...n})),
+      edges: this.edges.map(e => ({...e})),
     };
     duplicate_instance.populate_from_instance_obj(instance_data_to_keep);
     return duplicate_instance
   }
-  public toggle_occluded(node_index){
+
+  public toggle_occluded(node_index) {
     // The intial state may be null that's why not using !value
     if (this.nodes[node_index].occluded == true) {
       this.nodes[node_index].occluded = false
@@ -120,16 +123,16 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
   }
 
-  public occlude_all_children(node_index){
+  public occlude_all_children(node_index) {
     let node = this.nodes[node_index];
     let edges_from = this.edges.filter(edge => edge.from === node.id);
     let edges_to = this.edges.filter(edge => edge.to === node.id);
     let children_ids_from = edges_from.map(edge => edge.to);
     let children_ids_to = edges_to.map(edge => edge.from);
     let children_ids = [...children_ids_from, ...children_ids_to]
-    for(let id of children_ids){
+    for (let id of children_ids) {
       let current_node = this.nodes.find(n => n.id === id);
-      if(current_node){
+      if (current_node) {
         if (current_node.occluded == true) {
           current_node.occluded = false
         } else {
@@ -144,8 +147,9 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       node.occluded = true
     }
   }
-  public  set_new_xy_to_scaled_values(): void{
-    for(let node of this.nodes){
+
+  public set_new_xy_to_scaled_values(): void {
+    for (let node of this.nodes) {
       if (node.x < 300) {
         node.left_or_right = 'left'
       } else {
@@ -183,29 +187,32 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     this.edges = new_edges;
     this.current_node_connection = []
   }
-  public save_original_nodes(): void{
+
+  public save_original_nodes(): void {
     this.original_nodes = [];
-    for(let node of this.nodes){
+    for (let node of this.nodes) {
       this.original_nodes.push({...node})
     }
   }
-  public start_rescale(){
+
+  public start_rescale() {
     this.is_rescaling = true;
     this.current_fixed_point = this.get_fixed_point(this.hovered_control_point_key)
     let control_points = this.get_scale_control_points()
     this.current_control_point = control_points[this.hovered_control_point_key]
   }
-  public start_movement(): void{
+
+  public start_movement(): void {
     if (this.node_hover_index != undefined) {
       this.is_moving = true;
     }
-    if(this.hovered_scale_control_points){
+    if (this.hovered_scale_control_points) {
       this.start_rescale()
     }
-    if(this.selected || (this.is_bounding_box_hovered && this.node_hover_index == undefined && !this.hovered_scale_control_points)){
+    if (this.selected || (this.is_bounding_box_hovered && this.node_hover_index == undefined && !this.hovered_scale_control_points)) {
       this.start_dragging();
     }
-    if(this.instance_rotate_control_mouse_hover == true){
+    if (this.instance_rotate_control_mouse_hover == true) {
 
       this.is_rotating = true
     }
@@ -213,45 +220,42 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
   public process_mouse_up(): boolean {
     if (this.instance_context.draw_mode
-    && this.template_creation_mode) {
-      if(this.is_node_hovered){
+      && this.template_creation_mode) {
+      if (this.is_node_hovered) {
         this.add_edge_to_instance();
-      }
-      else{
+      } else {
         this.add_node_to_instance();
       }
 
       return true
-    }
-    else {
-      if(this.is_moving){
+    } else {
+      if (this.is_moving) {
         this.stop_moving();
       }
-      if(this.is_rescaling){
+      if (this.is_rescaling) {
         this.stop_rescaling()
       }
-      if(this.node_hover_index != undefined){
-        if(this.start_index_occlusion != undefined){
+      if (this.node_hover_index != undefined) {
+        if (this.start_index_occlusion != undefined) {
           this.occlude_direction(this.node_hover_index)
           return true
-        }
-        else{
+        } else {
           this.select();
         }
 
       }
-      if(this.node_hover_index == undefined && !this.selected && this.is_hovered){
+      if (this.node_hover_index == undefined && !this.selected && this.is_hovered) {
         this.select();
       }
 
-      if(this.is_dragging_instance){
+      if (this.is_dragging_instance) {
         this.stop_dragging()
       }
 
-      if(this.is_rotating == true) {
+      if (this.is_rotating == true) {
         this.stop_rotating()
       }
-      if(this.selected && !this.is_hovered){
+      if (this.selected && !this.is_hovered) {
         this.unselect();
       }
 
@@ -268,9 +272,9 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     let x_move = this.mouse_down_delta_event.x;
     let y_move = this.mouse_down_delta_event.y;
     let old = {...node}
-    let old_x =  old.x
+    let old_x = old.x
     let old_y = old.y
-    let new_point = {x: 0, y:0};
+    let new_point = {x: 0, y: 0};
     new_point.x = old_x + x_move;
     new_point.y = old_y + y_move;
     node.x = new_point.x
@@ -278,55 +282,51 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     return node
   }
 
-  private drag_instance(event): void{
-    for(let node of this.nodes){
+  private drag_instance(event): void {
+    for (let node of this.nodes) {
       node = this.move_single_node(node)
     }
   }
-  public stop_rescaling(){
+
+  public stop_rescaling() {
     this.is_rescaling = false;
     this.hovered_control_point_key = undefined;
     this.current_fixed_point = undefined;
     this.current_control_point = undefined;
 
   }
-  public stop_moving(){
+
+  public stop_moving() {
     this.is_moving = false;
   }
-  private get_fixed_point(key:string){
+
+  private get_fixed_point(key: string) {
     let control_points = this.get_scale_control_points();
     let result;
-    if(key === 'right'){
+    if (key === 'right') {
       result = control_points.left;
-    }
-    else if(key === 'left'){
+    } else if (key === 'left') {
       result = control_points.right;
-    }
-    else if(key === 'top'){
+    } else if (key === 'top') {
       result = control_points.bottom
-    }
-    else if(key === 'bottom'){
+    } else if (key === 'bottom') {
       result = control_points.top
-    }
-    else if(key === 'bottom_right'){
+    } else if (key === 'bottom_right') {
       result = control_points.top_left
-    }
-    else if(key === 'bottom_left'){
+    } else if (key === 'bottom_left') {
       result = control_points.top_right
-    }
-    else if(key === 'top_right'){
+    } else if (key === 'top_right') {
       result = control_points.bottom_left
-    }
-    else if(key === 'top_left'){
+    } else if (key === 'top_left') {
       result = control_points.bottom_right
-    }
-    else{
+    } else {
       result = this.get_center_point_rotated();
     }
     return result
   }
-  public rescale(){
-    if(!this.hovered_control_point_key){
+
+  public rescale() {
+    if (!this.hovered_control_point_key) {
       return
     }
     let mouse = this.mouse_position;
@@ -338,38 +338,45 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     let rescaled = true;
     var new_width, rx, new_height, ry;
 
-    switch (this.hovered_control_point_key){
+    switch (this.hovered_control_point_key) {
       case "right":
         new_width = Math.round(width + (this.mouse_position.x - control_point.x));
         rx = new_width / width
-        for (let node of this.nodes){
-          node.x = Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
+        for (let node of this.nodes) {
+          if (node.x - this.vertex_size === fixed_point.x) {
+            continue
+          }
+          node.x = Math.round(fixed_point.x + rx * (node.x - fixed_point.x))
         }
         break;
       case "left":
         new_width = Math.round(width + (control_point.x - this.mouse_position.x));
         rx = new_width / width
-        for (let node of this.nodes){
-          node.x = Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
+        for (let node of this.nodes) {
+          if (node.x + this.vertex_size === fixed_point.x - this.CONTROL_POINTS_DISPLACEMENT) {
+            continue
+          }
+          node.x = Math.round(fixed_point.x + rx * (node.x - fixed_point.x))
         }
         break;
       case "top":
         new_height = Math.round(height + (control_point.y - this.mouse_position.y));
         ry = new_height / height
-        console.log('fixed', fixed_point.y)
-        console.log('new_height', new_height)
-        console.log('height', height)
-        console.log('control_point.y', control_point.y)
-        console.log('this.mouse_position.y.y', this.mouse_position.y)
-        for (let node of this.nodes){
-          node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
+        for (let node of this.nodes) {
+          if (node.y + this.vertex_size === fixed_point.y - this.CONTROL_POINTS_DISPLACEMENT) {
+            continue
+          }
+          node.y = Math.round(fixed_point.y + ry * (node.y - fixed_point.y))
         }
         break;
       case "bottom":
         new_height = Math.round(height + (this.mouse_position.y - control_point.y));
         ry = new_height / height
-        for (let node of this.nodes){
-          node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
+        for (let node of this.nodes) {
+          if (node.y - this.vertex_size === fixed_point.y) {
+            continue
+          }
+          node.y = Math.round(fixed_point.y + ry * (node.y - fixed_point.y))
         }
         break;
       case "top_right":
@@ -377,9 +384,14 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
         ry = new_height / height
         new_width = Math.round(width + (this.mouse_position.x - control_point.x));
         rx = new_width / width
-        for (let node of this.nodes){
-          node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
-          node.x = Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
+        for (let node of this.nodes) {
+          if (node.y + this.vertex_size !== fixed_point.y - this.CONTROL_POINTS_DISPLACEMENT) {
+            node.y = Math.round(fixed_point.y + ry * (node.y - fixed_point.y))
+          }
+          if (node.x - this.vertex_size !== fixed_point.x) {
+            node.x = Math.round(fixed_point.x + rx * (node.x - fixed_point.x))
+          }
+
         }
         break;
       case "top_left":
@@ -387,9 +399,14 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
         ry = new_height / height
         new_width = Math.round(width + (control_point.x - this.mouse_position.x));
         rx = new_width / width
-        for (let node of this.nodes){
-          node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
-          node.x = Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
+        for (let node of this.nodes) {
+          if (node.y + this.vertex_size !== fixed_point.y - this.CONTROL_POINTS_DISPLACEMENT) {
+            node.y = Math.round(fixed_point.y + ry * (node.y - fixed_point.y))
+          }
+          if (node.x + this.vertex_size !== fixed_point.x - this.CONTROL_POINTS_DISPLACEMENT) {
+            node.x = Math.round(fixed_point.x + rx * (node.x - fixed_point.x))
+          }
+
         }
         break;
       case "bottom_right":
@@ -397,9 +414,14 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
         ry = new_height / height
         new_width = Math.round(width + (this.mouse_position.x - control_point.x));
         rx = new_width / width
-        for (let node of this.nodes){
-          node.y =  Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
-          node.x =  Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
+        for (let node of this.nodes) {
+          if (node.y - this.vertex_size !== fixed_point.y) {
+            node.y = Math.round(fixed_point.y + ry * (node.y - fixed_point.y))
+          }
+          if (node.x - this.vertex_size !== fixed_point.x) {
+            node.x = Math.round(fixed_point.x + rx * (node.x - fixed_point.x))
+          }
+
         }
         break;
       case "bottom_left":
@@ -407,44 +429,44 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
         ry = new_height / height
         new_width = Math.round(width + (control_point.x - this.mouse_position.x));
         rx = new_width / width
-        for (let node of this.nodes){
-          node.y = Math.round(fixed_point.y  + ry * ( node.y - fixed_point.y))
-          node.x = Math.round(fixed_point.x  + rx * ( node.x - fixed_point.x))
+        for (let node of this.nodes) {
+          if (node.y - this.vertex_size !== fixed_point.y) {
+            node.y = Math.round(fixed_point.y + ry * (node.y - fixed_point.y))
+          }
+          if (node.x + this.vertex_size !== fixed_point.x - this.CONTROL_POINTS_DISPLACEMENT) {
+            node.x = Math.round(fixed_point.x + rx * (node.x - fixed_point.x))
+          }
         }
         break;
       default:
         rescaled = false
     }
-    if(rescaled){
+    if (rescaled) {
       this.get_rotate_point_control_location();
     }
     return rescaled
   }
 
-  public move(){
-    if(this.is_rotating == true){
+  public move() {
+    if (this.is_rotating == true) {
       this.do_rotation_movement()
       this.calculate_min_max_points();
       return true
-    }
-    else if(this.is_rescaling){
+    } else if (this.is_rescaling) {
       return this.rescale();
-    }
-    else if (this.is_moving) {
+    } else if (this.is_moving) {
       this.move_node(event)
       return true;
-    }
-    else if(this.is_dragging_instance){
+    } else if (this.is_dragging_instance) {
       this.drag_instance(event);
       this.calculate_min_max_points();
       return true
-    }
-    else{
+    } else {
       return false;
     }
   }
 
-  public get_rotated_min_max(){
+  public get_rotated_min_max() {
     let rotated_nodes = this.nodes.map(node => this.get_rotated_point(node, this.angle))
     let min_x = Math.min(...rotated_nodes.map(n => n.x)) - this.vertex_size;
     let max_x = Math.max(...rotated_nodes.map(n => n.x)) + this.vertex_size;
@@ -457,22 +479,24 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       max_y
     }
   }
-  public get_center_point_rotated(){
+
+  public get_center_point_rotated() {
     let min_max_obj = this.get_rotated_min_max()
 
-    let center_x = (min_max_obj.max_x  + min_max_obj.min_x) / 2;
+    let center_x = (min_max_obj.max_x + min_max_obj.min_x) / 2;
     let center_y = (min_max_obj.min_y + min_max_obj.max_y) / 2;
     return {
       x: center_x, y: center_y
     }
   }
 
-  public calculate_center(){
+  public calculate_center() {
     // This is the unrotated center.
     this.center_x = Math.round((this.x_max + this.x_min) / 2)
     this.center_y = Math.round((this.y_max + this.y_min) / 2)
     this.center = {x: this.center_x, y: this.center_y};
   }
+
   private move_node(event): void {
     if (this.node_hover_index == undefined) {
       return
@@ -486,7 +510,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
   }
 
-  private calculate_min_max_points(){
+  private calculate_min_max_points() {
     if (this.nodes) {
       //TODO handle for case where it's rotated and user pushes bounds (causes whole object to move)
       let x_node_unrotated_list = [...this.nodes.map(p => p.x)]
@@ -498,38 +522,50 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
   }
 
-  private get_scaled_and_rotated_point(point){
+  private get_scaled_and_rotated_point(point) {
     let x = this.get_scaled_x(point)
     let y = this.get_scaled_y(point)
-    return {'x' : x, 'y' : y}
+    return {'x': x, 'y': y}
   }
 
-  private get_scaled_x(point){
+  private get_scaled_x(point) {
 
     // Origin is center of shape
     let x = this.get_rotated_point(point).x
 
-    if(this.scale_width == undefined){return x }
-    if(this.reference_width == undefined){return x}
-    if(this.translate_x == undefined){return x}
-    return this.translate_x +  (this.scale_width / this.reference_width) * x
+    if (this.scale_width == undefined) {
+      return x
+    }
+    if (this.reference_width == undefined) {
+      return x
+    }
+    if (this.translate_x == undefined) {
+      return x
+    }
+    return this.translate_x + (this.scale_width / this.reference_width) * x
   }
 
-  private get_scaled_y(point){
+  private get_scaled_y(point) {
     let y = point.y;
     //let degrees = 90;
     //let angle =  degrees * (Math.PI/180)
 
     y = this.get_rotated_point(point).y
 
-    if(this.scale_height == undefined){return y}
-    if(this.reference_height == undefined){return y}
-    if(this.translate_y == undefined){return y}
+    if (this.scale_height == undefined) {
+      return y
+    }
+    if (this.reference_height == undefined) {
+      return y
+    }
+    if (this.translate_y == undefined) {
+      return y
+    }
 
-    return this.translate_y + (this.scale_height/ this.reference_height) * y
+    return this.translate_y + (this.scale_height / this.reference_height) * y
   }
 
-  private get_rotate_point_control_location(): {x: number, y: number}{
+  private get_rotate_point_control_location(): { x: number, y: number } {
     // TODO
     let x_node_unrotated_list = [...this.nodes.map(p => p.x)]
     let y_node_unrotated_list = [...this.nodes.map(p => p.y)]
@@ -539,9 +575,9 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     let y_max = Math.round(Math.max(...y_node_unrotated_list))
 
     let center_x = (x_max + x_min) / 2;
-    let center_y = (y_max +  y_min) / 2;
+    let center_y = (y_max + y_min) / 2;
     let max_y = this.get_scale_control_points().bottom.y
-    let center_point =  {
+    let center_point = {
       x: center_x,
       y: max_y + (this.height / 4)
     }
@@ -550,12 +586,12 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   }
 
   private get_rotated_point(
-      point,
-      angle = undefined,
-      origin = undefined): { x: number, y: number }{
+    point,
+    angle = undefined,
+    origin = undefined): { x: number, y: number } {
 
     // https://stackoverflow.com/questions/2259476/rotating-a-point-about-another-point-2d
-    if (angle === undefined){
+    if (angle === undefined) {
       angle = this.angle
     }
 
@@ -575,7 +611,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     return {x: qx, y: qy}
   }
 
-  private get_angle_of_from_rotation_control_movement () {
+  private get_angle_of_from_rotation_control_movement() {
     // Read: https://math.stackexchange.com/questions/361412/finding-the-angle-between-three-points
     let center = {x: this.center_x, y: this.center_y}
 
@@ -594,14 +630,14 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
 
   public draw_rotate_point(
-      ctx): boolean {
+    ctx): boolean {
 
-    if(this.template_creation_mode){
+    if (this.template_creation_mode) {
       return
     }
     let rotate_point = this.get_rotate_point_control_location()
 
-    if(!rotate_point){
+    if (!rotate_point) {
       return this.instance_rotate_control_mouse_hover
     }
     ctx.beginPath();
@@ -611,12 +647,11 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     ctx.arc(rotate_point.x, rotate_point.y, (this.vertex_size + 3) / this.zoom_value, 0, 2 * Math.PI);
     ctx.fill()
     ctx.stroke()
-    if(this.is_mouse_in_path(ctx)){
+    if (this.is_mouse_in_path(ctx)) {
       this.is_hovered = true
       this.instance_rotate_control_mouse_hover = true
-    }
-    else if(!this.is_rotating){
-      if(!this.is_bounding_box_hovered){
+    } else if (!this.is_rotating) {
+      if (!this.is_bounding_box_hovered) {
         this.is_hovered = false
       }
       this.instance_rotate_control_mouse_hover = null
@@ -625,7 +660,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     return this.instance_rotate_control_mouse_hover
   }
 
-  private draw_node_label(ctx, node){
+  private draw_node_label(ctx, node) {
     // label draw_label
 
     if (this.label_settings.show_text == false) {
@@ -634,10 +669,10 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     if (this.label_settings.show_label_text == false) {
       return
     }
-    if(!node.name){
+    if (!node.name) {
       return
     }
-    if(!(this.is_hovered || this.selected) && !this.template_creation_mode) {
+    if (!(this.is_hovered || this.selected) && !this.template_creation_mode) {
       return
     }
 
@@ -657,7 +692,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     let padding = 2 / this.zoom_value
     let padding_from_point = 5 / this.zoom_value
     let point_text = this.get_scaled_and_rotated_point(
-      {x: node.x + padding_from_point, y: node.y + padding_from_point  });
+      {x: node.x + padding_from_point, y: node.y + padding_from_point});
     ctx.fillRect(
       point_text.x,
       point_text.y - text_height - padding,
@@ -668,20 +703,19 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     ctx.fillText(message, point_text.x, point_text.y);
 
 
-
     ctx.fillStyle = prevfillStyle
 
 
-
   }
-  public normalize_nodes(node_list){
+
+  public normalize_nodes(node_list) {
     /*
     * Make node list coords start from (0,0)
     * */
     let result = [];
     let min_x = Math.min(...node_list.map(n => n.x)) - this.vertex_size;
     let min_y = Math.min(...node_list.map(n => n.y)) - this.vertex_size;
-    for(let node of node_list){
+    for (let node of node_list) {
       let new_node = {
         ...node,
         x: node.x - min_x,
@@ -691,7 +725,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
     return result
   }
-  public set_nodes_coords_based_on_size(width: number, height: number, ref_point: {x: number, y:number}){
+
+  public set_nodes_coords_based_on_size(width: number, height: number, ref_point: { x: number, y: number }) {
     let original_nodes = this.original_nodes;
     let normalized_nodes = this.normalize_nodes(original_nodes);
     let min_x = Math.min(...normalized_nodes.map(n => n.x)) - this.vertex_size;
@@ -700,7 +735,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     let max_y = Math.max(...normalized_nodes.map(n => n.y)) + this.vertex_size;
     let original_width = Math.abs(max_x - min_x)
     let original_height = Math.abs(max_y - min_y)
-    for(let i = 0; i < normalized_nodes.length; i++){
+    for (let i = 0; i < normalized_nodes.length; i++) {
       let node = normalized_nodes[i]
       let rx = width / original_width;
       let ry = height / original_height;
@@ -712,7 +747,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     this.width = this.x_max - this.x_min
     this.height = this.y_max - this.y_min
   }
-  private draw_node(node, ctx, i){
+
+  private draw_node(node, ctx, i) {
     if (this.label_settings &&
       this.label_settings.show_occluded_keypoints == false &&
       node.occluded == true) {
@@ -740,44 +776,52 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     ctx.globalAlpha = 1;
   }
 
-  private other_instance_hovered(){
-    if(!this.instance_context){
+  private other_instance_hovered() {
+    if (!this.instance_context) {
       return
     }
-    if(!this.instance_context.instance_list){
+    if (!this.instance_context.instance_list) {
       return
     }
 
-    for(let inst  of this.instance_context.instance_list){
+    for (let inst of this.instance_context.instance_list) {
       let instance = (inst as KeypointInstance);
-      if(instance.is_hovered && instance.creation_ref_id !== this.creation_ref_id){
+      if (instance.is_hovered && instance.creation_ref_id !== this.creation_ref_id) {
         return true
       }
     }
   }
-  private get_scale_control_points(){
+
+  private get_scale_control_points() {
     let result = [];
     let points = this.get_rotated_min_max()
 
     return {
-      bottom_left: {x: points.min_x - 3, y: points.max_y + 3},
-      bottom_right: {x: points.max_x + 3, y: points.max_y + 3},
-      top_right: {x: points.max_x + 3, y: points.min_y},
-      top_left: {x: points.min_x + 3, y: points.min_y},
+      bottom_left: {
+        x: points.min_x + this.CONTROL_POINTS_DISPLACEMENT,
+        y: points.max_y + this.CONTROL_POINTS_DISPLACEMENT
+      },
+      bottom_right: {
+        x: points.max_x + this.CONTROL_POINTS_DISPLACEMENT,
+        y: points.max_y + this.CONTROL_POINTS_DISPLACEMENT
+      },
+      top_right: {x: points.max_x + this.CONTROL_POINTS_DISPLACEMENT, y: points.min_y},
+      top_left: {x: points.min_x + this.CONTROL_POINTS_DISPLACEMENT, y: points.min_y},
       top: {x: (points.min_x + points.max_x) / 2, y: points.min_y},
-      bottom: {x: (points.min_x + points.max_x) / 2, y: points.max_y + 3},
-      left: {x: points.min_x -2 , y: (points.max_y + points.min_y) / 2},
-      right: {x: points.max_x + 3 , y: (points.max_y + points.min_y) / 2},
+      bottom: {x: (points.min_x + points.max_x) / 2, y: points.max_y + this.CONTROL_POINTS_DISPLACEMENT},
+      left: {x: points.min_x, y: (points.max_y + points.min_y) / 2},
+      right: {x: points.max_x + this.CONTROL_POINTS_DISPLACEMENT, y: (points.max_y + points.min_y) / 2},
     }
   }
-  private draw_scale_control_points(ctx){
-    if(!this.selected){
+
+  private draw_scale_control_points(ctx) {
+    if (!this.selected) {
       return
     }
     let control_points = this.get_scale_control_points();
     let hovered_scale_point = false;
     let hover_key = undefined;
-    for(let key of Object.keys(control_points)){
+    for (let key of Object.keys(control_points)) {
       let point = control_points[key];
       ctx.beginPath();
       ctx.fillStyle = 'white'
@@ -785,24 +829,28 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       ctx.arc(point.x, point.y, this.vertex_size + 4 / this.zoom_value, 0, 2 * Math.PI);
       ctx.stroke();
       ctx.fill();
-      if(this.is_mouse_in_path(ctx) && !hovered_scale_point){
+      ctx.arc(point.x, point.y, this.vertex_size + 8 / this.zoom_value, 0, 2 * Math.PI);
+      ctx.strokeStyle="#000000";
+      ctx.fillStyle="#FFFFFF";
+      ctx.fillStyle = 'rgba(0, 0, 0, 0)';
+      if (this.is_mouse_in_path(ctx) && !hovered_scale_point) {
         hovered_scale_point = true;
         hover_key = key;
       }
     }
-    if(hovered_scale_point){
+    if (hovered_scale_point) {
       this.hovered_scale_control_points = true
       this.is_hovered = true
       this.hovered_control_point_key = hover_key
-    }
-    else{
-      if(!this.is_rescaling){
+    } else {
+      if (!this.is_rescaling) {
         this.hovered_scale_control_points = false;
         this.hovered_control_point_key = undefined;
       }
 
     }
   }
+
   public draw(ctx): void {
     this.ctx = ctx;
 
@@ -829,7 +877,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     for (let node of this.nodes) {
       // order of operations
       this.draw_node(node, ctx, i);
-      i+=1
+      i += 1
     }
 
     this.draw_rotate_point(ctx)
@@ -841,35 +889,36 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
 
 
-
-    if(this.num_hovered_paths > 0 || this.is_bounding_box_hovered){
-      if(!this.other_instance_hovered()){
+    if (this.num_hovered_paths > 0 || this.is_bounding_box_hovered) {
+      if (!this.other_instance_hovered()) {
         this.is_hovered = true;
       }
 
     }
-    if(this.num_hovered_paths === 0 && !this.is_bounding_box_hovered){
-      if(this.is_hovered){
+    if (this.num_hovered_paths === 0 && !this.is_bounding_box_hovered) {
+      if (this.is_hovered) {
         this.is_hovered = false;
       }
     }
   }
 
-  private determine_and_set_nearest_node_hovered(ctx){
-    const sorted_keys = Object.keys(this.nearest_points_dict).map(elm => parseFloat(elm)).sort(function(a,b) { return a - b;})
-    const sorted: any[] =  sorted_keys.reduce(
-        (obj, key): any => {
-          obj[key.toString()] = this.nearest_points_dict[key.toString()];
-          return obj;
-        },
-        {}
+  private determine_and_set_nearest_node_hovered(ctx) {
+    const sorted_keys = Object.keys(this.nearest_points_dict).map(elm => parseFloat(elm)).sort(function (a, b) {
+      return a - b;
+    })
+    const sorted: any[] = sorted_keys.reduce(
+      (obj, key): any => {
+        obj[key.toString()] = this.nearest_points_dict[key.toString()];
+        return obj;
+      },
+      {}
     );
 
-    if(!sorted || sorted.length === 0){
+    if (!sorted || sorted.length === 0) {
       return
     }
     let index = parseInt(this.nearest_points_dict[Object.keys(sorted)[0]])
-    if(this.nodes[index] == undefined){
+    if (this.nodes[index] == undefined) {
       return
     }
     let point = {'x': this.nodes[index].x, 'y': this.nodes[index].y}
@@ -878,41 +927,44 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     if (this.point_is_intersecting_circle(
       this.get_scaled_and_rotated_point(point),
       this.mouse_position,
-      radius))
-    {
+      radius)) {
       this.set_node_hovered(ctx, index)
     }
   }
-  private draw_left_right_arrows(ctx, node, x, y){
+
+  private draw_left_right_arrows(ctx, node, x, y) {
     if (this.label_settings &&
-        this.label_settings.show_left_right_arrows == false) {
+      this.label_settings.show_left_right_arrows == false) {
       return
     }
     let size = (this.vertex_size * 4) / this.zoom_value
-    if(node.left_or_right == 'left') {
-      this.draw_icon(ctx, x - (10/this.zoom_value), y, 'arrow_left', size, 'rgb(255,0,0)')
+    if (node.left_or_right == 'left') {
+      this.draw_icon(ctx, x - (10 / this.zoom_value), y, 'arrow_left', size, 'rgb(255,0,0)')
     }
-    if(node.left_or_right=='right') {
-      this.draw_icon(ctx, x + (10/this.zoom_value), y, 'arrow_right', size, 'rgb(0,255,0)')
+    if (node.left_or_right == 'right') {
+      this.draw_icon(ctx, x + (10 / this.zoom_value), y, 'arrow_right', size, 'rgb(0,255,0)')
     }
   }
 
 
-  public stop_dragging(){
+  public stop_dragging() {
     this.is_dragging_instance = false;
 
   }
 
-  public stop_rotating(){
+  public stop_rotating() {
     this.is_rotating = false
   }
 
-  public start_dragging(){
+  public start_dragging() {
     this.is_dragging_instance = true;
   }
-  public add_edge_to_instance(){
+
+  public add_edge_to_instance() {
     if (this.current_node_connection.length === 1) {
-      if(this.node_hover_index == undefined){return}
+      if (this.node_hover_index == undefined) {
+        return
+      }
       let node = this.nodes[this.node_hover_index];
       this.current_node_connection.push(node);
       this.is_drawing_edge = false
@@ -923,12 +975,15 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       this.current_node_connection = [];
       this.is_drawing_edge = false;
     } else if (this.current_node_connection.length === 0) {
-      if(this.node_hover_index == undefined){return}
+      if (this.node_hover_index == undefined) {
+        return
+      }
       let node = this.nodes[this.node_hover_index];
       this.current_node_connection.push(node);
       this.is_drawing_edge = true;
     }
   }
+
   public add_node_to_instance() {
     if (this.is_drawing_edge) {
       return
@@ -947,11 +1002,11 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   }
 
   private draw_icon(
-        ctx, x, y, icon='arrow_left',
-        font_size=24, fillStyle='rgb(255,175,0)'){
+    ctx, x, y, icon = 'arrow_left',
+    font_size = 24, fillStyle = 'rgb(255,175,0)') {
     // CAUTION if icon is invalid it won't render anything
     // use `arrow_left` as an example that works
-    if(!ctx.material_icons_loaded){
+    if (!ctx.material_icons_loaded) {
       return
     }
     const old_color = ctx.fillStyle;
@@ -992,7 +1047,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   }
 
   private is_mouse_in_path(ctx) {
-    if(!this.mouse_position || !this.mouse_position.raw){
+    if (!this.mouse_position || !this.mouse_position.raw) {
       return false
     }
     if (ctx.isPointInPath(
@@ -1003,7 +1058,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     return false
 
   }
-  private draw_instance_bounding_box(ctx){
+
+  private draw_instance_bounding_box(ctx) {
     let min_max_obj = this.get_rotated_min_max();
     let width = Math.abs(min_max_obj.max_x - min_max_obj.min_x);
     let height = Math.abs(min_max_obj.max_y - min_max_obj.min_y);
@@ -1012,22 +1068,21 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     ctx.beginPath();
 
     ctx.rect(min_max_obj.min_x, min_max_obj.min_y, width + this.vertex_size, height + this.vertex_size);
-    if(this.selected){
+    if (this.selected) {
       ctx.stroke()
       ctx.fill()
     }
-    if(this.is_mouse_in_path(ctx) && !this.instance_context.draw_mode && !this.other_instance_hovered()){
+    if (this.is_mouse_in_path(ctx) && !this.instance_context.draw_mode && !this.other_instance_hovered()) {
       this.is_bounding_box_hovered = true;
       this.is_hovered = true;
       // Draw helper bounding box
-      if(!this.selected){
+      if (!this.selected) {
         ctx.fillStyle = 'white'
         ctx.globalAlpha = 0.2;
         ctx.stroke()
         ctx.fill()
       }
-    }
-    else{
+    } else {
       this.is_bounding_box_hovered = false;
     }
     ctx.globalAlpha = 1;
@@ -1035,15 +1090,15 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
   private get_square_delta_point_mouse(point, mouse): number {
     return Math.sqrt(
-              (point.x - mouse.x) ** 2
-            + (mouse.y - point.y) ** 2)
+      (point.x - mouse.x) ** 2
+      + (mouse.y - point.y) ** 2)
   }
 
   private point_is_intersecting_circle(point, mouse, radius): boolean {
 
-      return Math.sqrt(
-          (point.x - mouse.x) ** 2
-        + (mouse.y - point.y) ** 2) < radius
+    return Math.sqrt(
+      (point.x - mouse.x) ** 2
+      + (mouse.y - point.y) ** 2) < radius
   }
 
   private set_node_hovered(ctx, i): void {
@@ -1056,7 +1111,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
   private draw_point_and_set_node_hover_index(x, y, i, ctx): void {
     ctx.beginPath();
-    if(this.node_hover_index === i){
+    if (this.node_hover_index === i) {
       ctx.fillStyle = 'green'
     }
     ctx.lineWidth = 2 / this.zoom_value
@@ -1089,32 +1144,33 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     ctx.fill();
 
   }
-  public occlude_direction(end_index){
+
+  public occlude_direction(end_index) {
     let start_node = this.nodes[this.start_index_occlusion]
     let end_node = this.nodes[end_index]
     let edge_from = this.edges.find(e => e.from === start_node.id && e.to === end_node.id);
     let edge_to = this.edges.find(e => e.to === start_node.id && e.from === end_node.id);
 
     let edge = edge_from;
-    if(!edge){
+    if (!edge) {
       edge = edge_to;
-      if(!edge){
+      if (!edge) {
         return
       }
     }
     start_node.occluded = true;
     let pending_nodes = [end_node]
-    while(pending_nodes.length > 0){
+    while (pending_nodes.length > 0) {
       let next_node = pending_nodes.shift();
       let adjacent = this.edges.filter(edge => edge.from === next_node.id || edge.to === next_node.id);
-      for (let adj_edge of adjacent){
+      for (let adj_edge of adjacent) {
         let node_from = this.nodes.find(n => n.id === adj_edge.from);
         let node_to = this.nodes.find(n => n.id === adj_edge.to);
-        if(node_from && !node_from.occluded){
+        if (node_from && !node_from.occluded) {
           node_from.occluded = true;
           pending_nodes.push(node_from)
         }
-        if(node_to && !node_to.occluded){
+        if (node_to && !node_to.occluded) {
           node_to.occluded = true;
           pending_nodes.push(node_to)
         }
@@ -1123,12 +1179,14 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
   }
 
-  public stop_occlude_direction(){
+  public stop_occlude_direction() {
     this.start_index_occlusion = undefined;
   }
-  public activate_select_edge_occlusion(node_index: number){
+
+  public activate_select_edge_occlusion(node_index: number) {
     this.start_index_occlusion = node_index;
   }
+
   private draw_edges(ctx) {
     ctx.lineWidth = this.label_settings.spatial_line_size / this.zoom_value;
     ctx.setLineDash([])
@@ -1142,8 +1200,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       let node2 = this.nodes.filter(n => n.id === edge.to)[0];
 
       if (this.label_settings &&
-          this.label_settings.show_occluded_keypoints == false &&
-          node2.occluded == true) {
+        this.label_settings.show_occluded_keypoints == false &&
+        node2.occluded == true) {
         continue
       }
 
@@ -1151,7 +1209,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       if (edge.is_hovered) {
         ctx.strokeStyle = 'green'
       }
-      if(node1 && node2){
+      if (node1 && node2) {
         if (node2.occluded == true || node1.occluded == true) {
           ctx.globalAlpha = 0.3;
         }

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -149,8 +149,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       } else {
         node.left_or_right = 'right'
       }
-      node.x = this.get_scaled_x(node);
-      node.y = this.get_scaled_y(node);
     }
     this.calculate_min_max_points();
     this.scale_height = undefined;
@@ -221,7 +219,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       return true
     }
     else {
-
+      console.log('mouse up', this.node_hover_index, this.selected, this.is_hovered)
       if(this.is_moving){
         this.stop_moving();
       }
@@ -263,6 +261,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   }
 
   private move_single_node(node) {
+    console.log('move_single_node')
     let x_move = this.mouse_down_delta_event.x;
     let y_move = this.mouse_down_delta_event.y;
     let old = {...node}
@@ -346,6 +345,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     return result
   }
   public rescale(){
+    console.log('rescale')
     if(!this.hovered_control_point_key){
       return
     }
@@ -498,7 +498,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     }
     let node = this.nodes[this.node_hover_index]
     if (node) {
-
+      console.log('move_node')
       node.x = this.get_rotated_point(this.mouse_position, -this.angle).x
       node.y = this.get_rotated_point(this.mouse_position, -this.angle).y
 
@@ -712,6 +712,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     return result
   }
   public set_nodes_coords_based_on_size(width: number, height: number, ref_point: {x: number, y:number}){
+    console.log('set_nodes_coords_based_on_size')
     let original_nodes = this.original_nodes;
     let normalized_nodes = this.normalize_nodes(original_nodes);
     let min_x = Math.min(...normalized_nodes.map(n => n.x)) - this.vertex_size;
@@ -738,7 +739,9 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
       node.occluded == true) {
       return
     }
-
+    if(!i){
+      console.log('node', node.x, node.y)
+    }
     if (node.occluded == true) {
       ctx.globalAlpha = 0.3;
     } else {

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -13,6 +13,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   public is_hovered: boolean = false; // Is true if any of the nodes or bounding box is being hovered.
   public is_node_hovered: boolean = false;
   public hovered_scale_control_points: boolean = false;
+  public original_nodes: any = [];
   public hovered_control_point_key: string = undefined;
   public start_index_occlusion: number = undefined;
   public occluded: boolean = false;
@@ -181,6 +182,12 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     this.nodes.splice(this.node_hover_index, 1);
     this.edges = new_edges;
     this.current_node_connection = []
+  }
+  public save_original_nodes(): void{
+    this.original_nodes = [];
+    for(let node of this.nodes){
+      this.original_nodes.push({...node})
+    }
   }
   public start_rescale(){
     this.is_rescaling = true;
@@ -633,8 +640,16 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
 
   }
-
+  public set_nodes_coords_based_on_size(width: number, height: number){
+    let original_width = 800;
+    let original_height = 800;
+    let original_nodes = this.original_nodes;
+    for(let node of original_nodes){
+      
+    }
+  }
   private draw_node(node, ctx, i){
+    console.log('draw node', node.x, node.y)
     if (this.label_settings &&
       this.label_settings.show_occluded_keypoints == false &&
       node.occluded == true) {

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -329,7 +329,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     if (!this.hovered_control_point_key) {
       return
     }
-    let mouse = this.mouse_position;
     let width = this.width;
     let height = this.height;
     let fixed_point = this.current_fixed_point;
@@ -575,7 +574,6 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     let y_max = Math.round(Math.max(...y_node_unrotated_list))
 
     let center_x = (x_max + x_min) / 2;
-    let center_y = (y_max + y_min) / 2;
     let max_y = this.get_scale_control_points().bottom.y
     let center_point = {
       x: center_x,

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -293,7 +293,7 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   public stop_moving(){
     this.is_moving = false;
   }
-  public rescale(){
+  public rescale(fixed_point = undefined){
     if(!this.hovered_control_point_key){
       return
     }
@@ -304,7 +304,9 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
     let height = this.height;
     let x_move = this.mouse_down_delta_event.x;
     let y_move = this.mouse_down_delta_event.y;
-    let center = this.get_center_point_rotated()
+    if(!fixed_point){
+      fixed_point = this.get_center_point_rotated()
+    }
     let rescaled = true;
     var new_width, rx, new_height, ry;
 
@@ -313,28 +315,28 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
         new_width = width + x_move;
         rx = new_width / width
         for (let node of this.nodes){
-          node.x = center.x  + rx * ( node.x - center.x)
+          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
         }
         break;
       case "left":
         new_width = width - x_move;
         rx = new_width / width
         for (let node of this.nodes){
-          node.x = center.x  + rx * ( node.x - center.x)
+          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
         }
         break;
       case "top":
         new_height = height - y_move;
         ry = new_height / height
         for (let node of this.nodes){
-          node.y = center.y  + ry * ( node.y - center.y)
+          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
         }
         break;
       case "bottom":
         new_height = height + y_move;
         ry = new_height / height
         for (let node of this.nodes){
-          node.y = center.y  + ry * ( node.y - center.y)
+          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
         }
         break;
       case "top_right":
@@ -343,8 +345,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
         new_width = width + x_move;
         rx = new_width / width
         for (let node of this.nodes){
-          node.y = center.y  + ry * ( node.y - center.y)
-          node.x = center.x  + rx * ( node.x - center.x)
+          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
+          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
         }
         break;
       case "top_left":
@@ -353,8 +355,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
         new_width = width - x_move;
         rx = new_width / width
         for (let node of this.nodes){
-          node.y = center.y  + ry * ( node.y - center.y)
-          node.x = center.x  + rx * ( node.x - center.x)
+          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
+          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
         }
         break;
       case "bottom_right":
@@ -363,8 +365,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
         new_width = width + x_move;
         rx = new_width / width
         for (let node of this.nodes){
-          node.y = center.y  + ry * ( node.y - center.y)
-          node.x = center.x  + rx * ( node.x - center.x)
+          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
+          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
         }
         break;
       case "bottom_left":
@@ -373,8 +375,8 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
         new_width = width - x_move;
         rx = new_width / width
         for (let node of this.nodes){
-          node.y = center.y  + ry * ( node.y - center.y)
-          node.x = center.x  + rx * ( node.x - center.x)
+          node.y = fixed_point.y  + ry * ( node.y - fixed_point.y)
+          node.x = fixed_point.x  + rx * ( node.x - fixed_point.x)
         }
         break;
       default:
@@ -640,13 +642,19 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
 
   }
-  public set_nodes_coords_based_on_size(width: number, height: number){
+  public set_nodes_coords_based_on_size(width: number, height: number, ref_point: {x: number, y:number}){
     let original_width = 800;
     let original_height = 800;
     let original_nodes = this.original_nodes;
-    for(let node of original_nodes){
-      
+    for(let i = 0; i < original_nodes.length; i++){
+      let node = original_nodes[i]
+      let rx = width / original_width;
+      let ry = height / original_height;
+      node.x = ref_point.x + rx * (node.x - ref_point.x)
+      node.y = ref_point.y + ry * (node.y - ref_point.y)
+      this.nodes[i] = {...node}
     }
+
   }
   private draw_node(node, ctx, i){
     console.log('draw node', node.x, node.y)

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -291,57 +291,59 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
   }
   private get_fixed_point(key:string){
     let min_max_points = this.get_rotated_min_max()
+    let result;
     if(key === 'right'){
-      return {
-        x: min_max_points.min_x,
-        y: (min_max_points.max_y + min_max_points.min_y) / 2
+      result = {
+        x: Math.round(min_max_points.min_x),
+        y: Math.round((min_max_points.max_y + min_max_points.min_y) / 2)
       }
     }
     else if(key === 'left'){
-      return {
-        x: min_max_points.max_x,
-        y: (min_max_points.max_y + min_max_points.min_y) / 2
+      result = {
+        x: Math.round(min_max_points.max_x),
+        y: Math.round((min_max_points.max_y + min_max_points.min_y) / 2)
       }
     }
     else if(key === 'top'){
-      return {
-        x: (min_max_points.max_x + min_max_points.min_x) / 2,
-        y: min_max_points.max_y
+      result = {
+        x: Math.round((min_max_points.max_x + min_max_points.min_x) / 2),
+        y: Math.round(min_max_points.max_y)
       }
     }
     else if(key === 'bottom'){
-      return {
-        x: (min_max_points.max_x + min_max_points.min_x) / 2,
-        y: min_max_points.min_y
+      result = {
+        x: Math.round(min_max_points.max_y),
+        y: Math.round(min_max_points.min_y)
       }
     }
     else if(key === 'bottom_right'){
-      return {
-        x: min_max_points.min_x,
-        y: min_max_points.min_y
+      result = {
+        x: Math.round(min_max_points.min_x),
+        y: Math.round(min_max_points.min_y)
       }
     }
     else if(key === 'bottom_left'){
-      return {
-        x: min_max_points.max_x,
-        y: min_max_points.min_y
+      result = {
+        x: Math.round(min_max_points.max_x),
+        y: Math.round(min_max_points.min_y)
       }
     }
     else if(key === 'top_right'){
-      return {
-        x: min_max_points.min_x,
-        y: min_max_points.max_y
+      result = {
+        x: Math.round(min_max_points.min_x),
+        y: Math.round(min_max_points.max_y)
       }
     }
     else if(key === 'top_left'){
-      return {
-        x: min_max_points.max_x,
-        y: min_max_points.max_y
+      result = {
+        x: Math.round(min_max_points.max_x),
+        y: Math.round(min_max_points.max_y)
       }
     }
     else{
-      return this.get_center_point_rotated();
+      result = this.get_center_point_rotated();
     }
+    return result
   }
   public rescale(){
     if(!this.hovered_control_point_key){

--- a/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
+++ b/frontend/src/components/vue_canvas/instances/KeypointInstance.ts
@@ -643,15 +643,22 @@ export class KeypointInstance extends Instance implements InstanceBehaviour {
 
   }
   public set_nodes_coords_based_on_size(width: number, height: number, ref_point: {x: number, y:number}){
-    let original_width = 800;
-    let original_height = 800;
     let original_nodes = this.original_nodes;
+    let min_x = Math.min(...original_nodes.map(n => n.x)) - this.vertex_size;
+    let max_x = Math.max(...original_nodes.map(n => n.x)) + this.vertex_size;
+    let min_y = Math.min(...original_nodes.map(n => n.y)) - this.vertex_size;
+    let max_y = Math.max(...original_nodes.map(n => n.y)) + this.vertex_size;
+    let original_width = Math.abs(max_x - min_x)
+    let original_height = Math.abs(max_y - min_y)
+    console.log('original_width', original_width)
+    console.log('original_height', original_height)
+    console.log('ref_point', ref_point.x, ref_point.y)
     for(let i = 0; i < original_nodes.length; i++){
       let node = original_nodes[i]
       let rx = width / original_width;
       let ry = height / original_height;
-      node.x = ref_point.x + rx * (node.x - ref_point.x)
-      node.y = ref_point.y + ry * (node.y - ref_point.y)
+      node.x = Math.round(ref_point.x + rx * (node.x - ref_point.x))
+      node.y = Math.round(ref_point.y + ry * (node.y - ref_point.y))
       this.nodes[i] = {...node}
     }
 

--- a/frontend/src/utils/instance_utils.js
+++ b/frontend/src/utils/instance_utils.js
@@ -2,6 +2,58 @@ import {KeypointInstance} from "../components/vue_canvas/instances/KeypointInsta
 import Cuboid3DInstance from "../components/vue_canvas/instances/Cuboid3DInstance";
 import CuboidDrawerTool from "../components/3d_annotation/CuboidDrawerTool";
 
+export const duplicate_instance = function(instance_to_copy, component_ctx){
+  let points = [];
+  let nodes = [];
+  let edges = [];
+  if (instance_to_copy.points) {
+    points = [...instance_to_copy.points.map((p) => ({ ...p }))];
+  }
+  if (instance_to_copy.nodes) {
+    nodes = [...instance_to_copy.nodes.map((node) => ({ ...node }))];
+  }
+  if (instance_to_copy.edges) {
+    edges = [...instance_to_copy.edges.map((edge) => ({ ...edge }))];
+  }
+  let result = {
+    ...instance_to_copy,
+    id: undefined,
+    initialized: false,
+    points: points,
+    nodes: nodes,
+    edges: edges,
+    version: undefined,
+    root_id: undefined,
+    previous_id: undefined,
+    action_type: undefined,
+    next_id: undefined,
+    creation_ref_id: undefined,
+    attribute_groups: instance_to_copy.attribute_groups
+      ? { ...instance_to_copy.attribute_groups }
+      : null,
+  };
+
+  if (result.type === "cuboid") {
+    result.rear_face = {
+      ...instance_to_copy.rear_face,
+      top_right: { ...instance_to_copy.rear_face.top_right },
+      top_left: { ...instance_to_copy.rear_face.top_left },
+      bot_left: { ...instance_to_copy.rear_face.bot_left },
+      bot_right: { ...instance_to_copy.rear_face.bot_right },
+    };
+
+    result.front_face = {
+      ...instance_to_copy.front_face,
+      top_right: { ...instance_to_copy.front_face.top_right },
+      top_left: { ...instance_to_copy.front_face.top_left },
+      bot_left: { ...instance_to_copy.front_face.bot_left },
+      bot_right: { ...instance_to_copy.front_face.bot_right },
+    };
+  }
+
+  result = initialize_instance_object(result, component_ctx);
+  return result;
+}
 
 export const initialize_instance_object = function(instance, component_ctx, scene_controller_3d = undefined){
   let initialized_instance;
@@ -61,5 +113,13 @@ export const create_instance_list_with_class_types = function(instance_list, com
     let initialized_instance = initialize_instance_object(current_instance, component_ctx, scene_controller_3d)
     result.push(initialized_instance);
   }
+  return result;
+}
+
+export const duplicate_instance_template = function(instance_template, component_ctx){
+  let result = {...instance_template}
+  result.instance_list = instance_template.instance_list.map(inst => {
+    return duplicate_instance(inst, component_ctx);
+  })
   return result;
 }


### PR DESCRIPTION
Now we can draw and edit the keypoints instances rescaling based on fixed point.

Logic is as follow:
-  We scale fixing the point on the opposite direction of the control point.
- Example: we rescale on the right control point => the left control point stays fixed.
- We rescale the top right point => the bottom left point is fixed.

