### PR TITLE
Upgrade dispatcher dependencies

### DIFF
--- a/local_dispatcher/requirements.txt
+++ b/local_dispatcher/requirements.txt
@@ -1,2 +1,3 @@
-Flask==1.1.0
+Flask==1.1.4
 requests==2.25.1
+markupsafe==2.0.1


### PR DESCRIPTION
Upgrade to new flask version and set correct version for `markupsafe` package.