### PR TITLE
fix: Fix billing issue for users with no accounts.

### DIFF
--- a/default/methods/account/billing/billing_stripe_new.py
+++ b/default/methods/account/billing/billing_stripe_new.py
@@ -27,9 +27,30 @@ def stripe_new_customer_api(project_string_id):
         return jsonify(log = {'error': {'ALLOW_STRIPE_BILLING': 'Not Allowed for this version'}}), 400
 
     with sessionMaker.session_scope() as session:
+        member = get_member(session = session)
+        user = member.user
+        account_id = input.get('account_id')
+        if account_id is None and user:
+            account_list = Account.get_list(
+                session = session,
+                user_id = user.id,
+                mode_trainer_or_builder = "builder",
+                account_type = "billing",
+                by_primary_user = True)
+            if account_list:
+                account_id = account_list[0].id
+            else:
+                new_account = Account.account_new_core(
+                    session = session,
+                    primary_user = user,
+                    mode_trainer_or_builder = "builder",
+                    account_type = "billing",
+                    nickname = "My Account")
+                account_id = new_account.id
+
         result, log = stripe_new_customer_core(session = session,
                                                token = input['token'],
-                                               account_id = input['account_id'],
+                                               account_id = account_id,
                                                log = log)
         if result is False:
             return jsonify(log = log), 400

--- a/default/methods/account/billing/billing_stripe_new.py
+++ b/default/methods/account/billing/billing_stripe_new.py
@@ -39,6 +39,7 @@ def stripe_new_customer_api(project_string_id):
                 by_primary_user = True)
             if account_list:
                 account_id = account_list[0].id
+                logger.info(f'No account provided. Fallback to use Account ID: {new_account}')
             else:
                 new_account = Account.account_new_core(
                     session = session,
@@ -46,6 +47,8 @@ def stripe_new_customer_api(project_string_id):
                     mode_trainer_or_builder = "builder",
                     account_type = "billing",
                     nickname = "My Account")
+                logger.info(f'User has no billing accounts attached. Creating a new one...')
+                logger.info(f'New account created for payment: Account ID: {new_account}')
                 account_id = new_account.id
 
         result, log = stripe_new_customer_core(session = session,

--- a/default/methods/user/account/account_new.py
+++ b/default/methods/user/account/account_new.py
@@ -10,7 +10,7 @@ from shared.database import hashing_functions
 from methods.user.account import account_verify
 from methods.user.account import auth_code  # TODO rename this / put in Auth() class
 from shared.database import hashing_functions
-
+from shared.database.account.account import Account
 
 @routes.route('/api/v1/user/pro/new',
               methods = ['POST'])
@@ -301,6 +301,13 @@ def user_new_core(session,
     session.add(new_user)
 
     Event.identify_user(new_user)
+
+    Account.account_new_core(
+        session = session,
+        primary_user = new_user,
+        mode_trainer_or_builder = "builder",
+        account_type = "billing",
+        nickname = "My Account")
 
     Event.new(
         session = session,

--- a/frontend/src/components/account/billing/credit_card.vue
+++ b/frontend/src/components/account/billing/credit_card.vue
@@ -10,65 +10,60 @@
     </v_account_info>
 
 
-        </v-btn>
+    <v-alert type="success"
+             :value="stripe_success">
+      Card saved.
+    </v-alert>
 
+    <v-alert type="info"
+             outlined
+             :value="account.payment_method_on_file == true">
+      Card on file.
+    </v-alert>
 
-        <v-alert type="success"
-                 :value="stripe_success">
-          Card saved.
-        </v-alert>
+    <!-- Hard to use normal loading thing since
+   stripe wants to have the element loaded
+   in the DOM-->
 
-        <v-alert type="info"
-                 outlined
-                 :value="account.payment_method_on_file == true">
-          Card on file.
-        </v-alert>
-
-        <!-- Hard to use normal loading thing since
-       stripe wants to have the element loaded
-       in the DOM-->
-
-        <v-container v-if=" account.payment_method_on_file != true &&
+    <v-container v-if=" account.payment_method_on_file != true &&
                             !stripe_success">
 
-          <form method="post" id="payment-form">
-            <div class="form-row">
-              <label for="card-element">
-                Credit or debit card
-              </label>
-              <div id="card-element">
-                <!-- A Stripe Element will be inserted here. -->
-              </div>
+      <form method="post" id="payment-form">
+        <div class="form-row">
+          <label for="card-element">
+            Credit or debit card
+          </label>
+          <div id="card-element">
+            <!-- A Stripe Element will be inserted here. -->
+          </div>
 
-              <!-- Used to display form errors. -->
-              <div id="card-errors" role="alert"></div>
-            </div>
+          <!-- Used to display form errors. -->
+          <div id="card-errors" role="alert"></div>
+        </div>
 
-          </form>
-          <v-flex class="pa-3">
+      </form>
+      <v-flex class="pa-3">
 
-            <v-btn color="primary"
-                   @click="createToken"
-                   :disabled="loading">
-              Add Card
-            </v-btn>
-
-          </v-flex>
-
-          <v_error_multiple :error="error">
-          </v_error_multiple>
-
-        </v-container>
-
-        <!-- Disable for Jan release -->
-        <!--
         <v-btn color="primary"
-               @click="stripe_charge_account">
-          Charge
+               @click="createToken"
+               :disabled="loading">
+          Add Card
         </v-btn>
-        -->
 
+      </v-flex>
 
+      <v_error_multiple :error="error">
+      </v_error_multiple>
+
+    </v-container>
+
+    <!-- Disable for Jan release -->
+    <!--
+    <v-btn color="primary"
+           @click="stripe_charge_account">
+      Charge
+    </v-btn>
+    -->
 
 
   </div>
@@ -76,14 +71,19 @@
 
 <script lang="ts">
 
-  import axios from '../../../services/customInstance';
+import axios from '../../../services/customInstance';
+import account_info from "../account/account_info"
+import Vue from "vue";
 
-  import Vue from "vue"; export default Vue.extend( {
+export default Vue.extend({
     name: 'credit_card',
     props: {
-      'show_account_info' : {
+      'show_account_info': {
         default: true
       }
+    },
+    components:{
+      v_account_info: account_info
     },
     data() {
       return {
@@ -95,19 +95,17 @@
         stripe_success: false,
 
         account: {
-          id: 1,
+          id: null,
           payment_method_on_file: false
         },
 
-        error: {
-
-        },
+        error: {},
 
 
         stripe: null,
 
 
-        style : {
+        style: {
           base: {
             color: '#32325d',
             fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
@@ -126,9 +124,7 @@
       }
     },
 
-    computed: {
-
-    },
+    computed: {},
     mounted() {
 
       let stripe_script = document.createElement('script')
@@ -145,14 +141,13 @@
         if (self.account.payment_method_on_file != true) {
 
 
-
           // @ts-ignore
           //self.stripe = Stripe('pk_test_704Rwhx7wXhQUoPTfuqiN55i')
           // @ts-ignore
           self.stripe = Stripe('pk_live_QjJ0c5QXD4T61JLbNWN3m11F')
           self.elements = self.stripe.elements();
 
-          self.card = self.elements.create('card', { style: self.style });
+          self.card = self.elements.create('card', {style: self.style});
 
           self.card.mount('#card-element');
 
@@ -172,7 +167,6 @@
         self.loading = false
 
       }, 1000)
-
 
 
     },
@@ -212,8 +206,8 @@
 
         axios.post(`/api/v1/project/${String(this.$store.state.project.current.project_string_id)}/account/billing/stripe/token`, {
 
-            'account_id': this.account.id,
-            'token': token
+          'account_id': this.account.id,
+          'token': token
 
         }).then(response => {
 
@@ -268,5 +262,4 @@
       }
     }
   }
-
 ) </script>

--- a/frontend/src/components/account/billing/credit_card.vue
+++ b/frontend/src/components/account/billing/credit_card.vue
@@ -5,6 +5,12 @@
         but displaying info is optional,
         ie in case of order screen -->
 
+    <div style="border: 2px solid #e0e0e0; width: 35%" class="ma-4">
+      <h3 class="font-weight-light ml-4"><span class="font-weight-bold">Project: </span> {{$store.state.project.current.project_string_id}}</h3>
+      <h3 class="font-weight-light ml-4"><span class="font-weight-bold">User: </span> {{$store.state.user.current.email}}</h3>
+
+    </div>
+    <h3 class="font-weight-light ml-4">Credit Card Info: </h3>
     <v_account_info :show_account_info="show_account_info"
                     @account="account = $event">
     </v_account_info>
@@ -15,10 +21,11 @@
       Card saved.
     </v-alert>
 
-    <v-alert type="info"
+    <v-alert type="success"
+             class="ml-4 mr-4"
              outlined
              :value="account.payment_method_on_file == true">
-      Card on file.
+      Using Card on Saved file.
     </v-alert>
 
     <!-- Hard to use normal loading thing since
@@ -52,8 +59,14 @@
 
       </v-flex>
 
-      <v_error_multiple :error="error">
-      </v_error_multiple>
+      <div class="d-flex flex-column">
+        <v_error_multiple :error="error">
+        </v_error_multiple>
+        <div class="d-flex">
+          <v-btn @click="$router.push('/a/project/new/')" color="success" ><v-icon>mdi-plus</v-icon>Create Project</v-btn>
+          <v-btn @click="$router.push('/projects/')" color="secondary"><v-icon>mdi-folder</v-icon>Change Project</v-btn>
+        </div>
+      </div>
 
     </v-container>
 
@@ -203,8 +216,13 @@ export default Vue.extend({
 
         this.loading = true;
         this.error = {}
-
-        axios.post(`/api/v1/project/${String(this.$store.state.project.current.project_string_id)}/account/billing/stripe/token`, {
+        let project_string_id = this.$store.state.project.current.project_string_id;
+        console.log('asdasd', project_string_id)
+        if(!project_string_id){
+          this.error = {'no_projects_created': 'Please create a project or go to existing project to upgrade to a premium account.'}
+          return
+        }
+        axios.post(`/api/v1/project/${String(project_string_id)}/account/billing/stripe/token`, {
 
           'account_id': this.account.id,
           'token': token

--- a/frontend/src/components/account/billing/order_premium.vue
+++ b/frontend/src/components/account/billing/order_premium.vue
@@ -4,9 +4,9 @@
     <v-container>
 
       <v-card>
-        <h1 class="pa-4"> Order Premium Now </h1>
+        <h1 class="pa-4 text-center"> Order Premium Now </h1>
         <v-card-title>
-          How many users?
+          1. How many users?
         </v-card-title>
 
         <v-layout>
@@ -391,10 +391,39 @@
           </v-card>
         </div>
 
+
+
+        <div v-if="$store.state.user.logged_in == true && !install_fingerprint && !email">
+          <v-card>
+
+            <v-card-title>
+              2.Payment Details
+            </v-card-title>
+
+            <!-- CREDIT CARD -->
+            <credit_card :show_account_info="false">
+            </credit_card>
+
+            <br>
+            <br>
+          </v-card>
+        </div>
+
+        <div v-else-if="!$store.state.user.logged_in == true && !install_fingerprint && !email">
+          <v-alert type="info"
+                   prominent
+          >
+
+            Please <a style="color: white"
+                      href="/user/login?redirect=%2Forder%2Fpremium"> login</a>
+            to finish ordering.
+
+          </v-alert>
+        </div>
         <v-card class="mt-8 mb-4">
           <v-card-text class="text--primary">
             <h2 class="pt-4 pb-2">
-              You will be charged {{$format_money(calculated_charge)}}
+              3. You will be charged {{$format_money(calculated_charge)}}
               USD
               {{monthly_or_annual}}
               for {{premium_plan_user_count}} users
@@ -425,11 +454,13 @@
           <v-card-actions>
 
             <v-btn v-if="($store.state.user.logged_in == true) || (install_fingerprint && email)  "
-                   color="primary"
+                   color="success"
+                   x-large
                    :disabled="loading"
                    @click="order()"
                    block
             >
+              <v-icon>mdi-credit-card-outline</v-icon>
               Order
             </v-btn>
 
@@ -439,35 +470,6 @@
           </v_error_multiple>
 
         </v-card>
-
-        <div v-if="$store.state.user.logged_in == true && !install_fingerprint && !email">
-          <v-card>
-
-            <v-card-title>
-              Payment Method
-            </v-card-title>
-
-            <!-- CREDIT CARD -->
-            <credit_card :show_account_info="false">
-            </credit_card>
-
-            <br>
-            <br>
-          </v-card>
-        </div>
-
-        <div v-else-if="!$store.state.user.logged_in == true && !install_fingerprint && !email">
-          <v-alert type="info"
-                   prominent
-          >
-
-            Please <a style="color: white"
-                      href="/user/login?redirect=%2Forder%2Fpremium"> login</a>
-            to finish ordering.
-
-          </v-alert>
-        </div>
-
       </v-card>
 
 

--- a/frontend/src/components/account/billing/order_premium.vue
+++ b/frontend/src/components/account/billing/order_premium.vue
@@ -383,7 +383,7 @@
             </v-card-subtitle>
 
             <!-- CREDIT CARD -->
-            <credit_card show_account_info=false>
+            <credit_card :show_account_info="false">
             </credit_card>
 
             <br>
@@ -448,7 +448,7 @@
             </v-card-title>
 
             <!-- CREDIT CARD -->
-            <credit_card show_account_info=false>
+            <credit_card :show_account_info="false">
             </credit_card>
 
             <br>


### PR DESCRIPTION
This can happen if a new user gets invited to a project, or if a user tries to upgrade and has no accounts yet.

We are adding a fallback method to the credit card payment so that if the user does not provide an account, it will use the first one on the account list and if it does not have any accounts. It will create a new billing account for the user.

This a bug on the order_premium component where the account_info component was not getting properly imported and thus, it was not fetching the account data.