### PR TITLE
Tiny fix settings

### DIFF
--- a/frontend/src/components/project/settings.vue
+++ b/frontend/src/components/project/settings.vue
@@ -57,24 +57,6 @@
           </v-card-text>
         </v-card>
       </v-container>
-      <v-container>
-        <v-card>
-          <v-container>
-
-            <h2> Resources </h2>
-
-              <v-btn color="blue darken-1"
-                      text
-                      @click="$router.push('/project/' + project_string_id + '/attributes')"
-                     >
-                <v-icon left>mdi-collage</v-icon>
-                Attributes
-              </v-btn>
-
-
-          </v-container>
-        </v-card>
-      </v-container>
 
 
       <v-container>

--- a/frontend/src/components/project/settings.vue
+++ b/frontend/src/components/project/settings.vue
@@ -15,7 +15,7 @@
             <v-card-text>
 
               <v-flex lg4>
-                <v-text-field label="Name"
+                <v-text-field label="Project Name"
                               v-model="project.name"
                               :rules="[rules.name]"
                               @change="save">
@@ -28,6 +28,21 @@
           </v-card>
 
         </v-container>
+
+
+        <v-container>
+
+          <v_collaborate_list_existing :project_string_id="project_string_id">
+          </v_collaborate_list_existing>
+
+        </v-container>
+        <v-container>
+
+          <v_collaborate_new :project_string_id="project_string_id">
+          </v_collaborate_new>
+
+        </v-container>
+
       <v-container>
 
         <v-card>
@@ -40,17 +55,6 @@
       </v-container>
 
 
-      <v-container>
-
-        <v_collaborate_new :project_string_id="project_string_id">
-        </v_collaborate_new>
-
-        <v_collaborate_list_existing :project_string_id="project_string_id">
-        </v_collaborate_list_existing>
-
-        <v-divider></v-divider>
-
-      </v-container>
 
         <v-container>
           <v-card>

--- a/frontend/src/components/project/settings.vue
+++ b/frontend/src/components/project/settings.vue
@@ -21,20 +21,6 @@
                 </v-text-field>
               </v-flex>
 
-              <v-flex lg4>
-                <v-layout>
-
-                  <tooltip_button
-                      tooltip_message="Video help"
-                      href="https://diffgram.readme.io/docs/video-specifications"
-                      icon="help"
-                      :icon_style="true"
-                      color="primary">
-                  </tooltip_button>
-
-                </v-layout>
-              </v-flex>
-
             </v-card-text>
             <v-card-actions>
               <v-btn @click="save"

--- a/frontend/src/components/project/settings.vue
+++ b/frontend/src/components/project/settings.vue
@@ -36,9 +36,11 @@
           </v_collaborate_list_existing>
 
         </v-container>
+
         <v-container>
 
-          <v_collaborate_new :project_string_id="project_string_id">
+          <v_collaborate_new :project_string_id="project_string_id"
+                             :enable_view_existing="false">
           </v_collaborate_new>
 
         </v-container>

--- a/frontend/src/components/project/settings.vue
+++ b/frontend/src/components/project/settings.vue
@@ -17,17 +17,12 @@
               <v-flex lg4>
                 <v-text-field label="Name"
                               v-model="project.name"
-                              :rules="[rules.name]">
+                              :rules="[rules.name]"
+                              @change="save">
                 </v-text-field>
               </v-flex>
 
             </v-card-text>
-            <v-card-actions>
-              <v-btn @click="save"
-                     color="primary">
-                Save settings
-              </v-btn>
-            </v-card-actions>
 
             </v-container>
           </v-card>

--- a/frontend/src/components/share/share_member_list.vue
+++ b/frontend/src/components/share/share_member_list.vue
@@ -1,21 +1,9 @@
 <template>
   <div id="members_list">
 
-    <v-card-title>
 
-      <h3 v-if="mode == 'project'"
-          class="headline">Members</h3>
-
-       <h3 v-if="mode == 'org'"
-          class="headline">Members in {{$store.state.org.current.name}} </h3>
-
-      <v-btn color="blue darken-1" text
-             href="https://diffgram.readme.io/docs/project"
-             target="_blank"
-             icon>
-        <v-icon>help</v-icon>
-      </v-btn>
-
+    <h3 v-if="mode == 'org'"
+      class="headline">Members in {{$store.state.org.current.name}} </h3>
       <!--
       <v-spacer></v-spacer>
       <v-text-field v-model="search"
@@ -25,19 +13,31 @@
                     hide-details></v-text-field>
           -->
 
-    </v-card-title>
-
     <!-- Only show in project mode till support for removeing from org. -->
 
-    <v-btn  v-if="mode == 'project'"
-            @click="api_member_update('REMOVE')"
-            color="red"
-            class="white--text"
-            :loading="api_member_update_loading"
-            :disabled="api_member_update_loading || selected.length == 0">
-          Remove
-        <v-icon right> mdi-shield-remove </v-icon>
-    </v-btn>
+    <v-layout>
+      <tooltip_button
+        tooltip_message="Remove User"
+        @click="api_member_update('REMOVE')"
+        icon="mdi-shield-remove"
+        :icon_style="true"
+        color="red"
+        :loading="api_member_update_loading"
+        :disabled="api_member_update_loading || selected.length == 0"
+      >
+      </tooltip_button>
+
+      <tooltip_button
+        tooltip_message="Help"
+        href="https://diffgram.readme.io/docs/project"
+        target="_blank"
+        icon="help"
+        :icon_style="true"
+        color="primary"
+      >
+      </tooltip_button>
+
+    </v-layout>
 
     <v_error_multiple :error="error">
     </v_error_multiple>
@@ -58,7 +58,9 @@
                   class="elevation-1"
                   v-model="selected"
                   item-key="member_id"
-                  ref="members_list_table">
+                  ref="members_list_table"
+                  :loading="loading"
+                  >
 
       <!-- appears to have to be item for vuetify syntax-->
       <template slot="item" slot-scope="props">
@@ -88,17 +90,10 @@
 
 
           <td v-if="props.item.member_kind == 'human'">
-            {{props.item.username}}
-          </td>
-          <td v-if="props.item.member_kind == 'api'">
-            {{props.item.client_id}}
-          </td>
-
-          <td v-if="props.item.member_kind == 'human'">
             {{props.item.first_name}} {{ props.item.last_name }}
           </td>
           <td v-if="props.item.member_kind == 'api'">
-              SDK/API Access User
+            {{props.item.client_id}}
           <td>
 
             <div v-if="mode=='project'">
@@ -177,12 +172,6 @@ import Vue from "vue"; export default Vue.extend( {
         align: 'left',
         sortable: true,
         value: 'email'
-      },
-      {
-        text: "Member ID",
-        align: 'left',
-        sortable: false,
-        value: "name"
       },
       {
         text: "Name",

--- a/frontend/src/components/share/share_new_member.vue
+++ b/frontend/src/components/share/share_new_member.vue
@@ -27,7 +27,7 @@
                 :loading="loading"
                 @click="member_kind = 'Developer Authentication (API/SDK)'"
                 :disabled="loading">
-            Developer Authentication (API/SDK)
+            Developer Key (API/SDK)
         </v-btn>
 
       </v-card-title>
@@ -38,9 +38,8 @@
           {{errors}}
         </v-alert>
 
-        <h2> <v-icon color="primary">mdi-plus</v-icon> Add members </h2>
-
-        <v-select :items="member_kind_list"
+        <v-select v-if="member_kind == 'Developer Authentication (API/SDK)'"
+                  :items="member_kind_list"
                   v-model="member_kind"
                   label="Member type"
                   item-value="text"

--- a/frontend/src/components/share/share_new_member.vue
+++ b/frontend/src/components/share/share_new_member.vue
@@ -18,17 +18,39 @@
         <v-spacer>
         </v-spacer>
 
+        <tooltip_button
+            v-if="enable_view_existing"
+            tooltip_message="View Existing"
+            @click="view_existing_open = true"
+            icon="mdi-account-multiple"
+            :icon_style="true"
+            color="primary">
+        </tooltip_button>
+
         <!-- All this button does is toggle the member_kind
             instead of user having to "know" to do it in select.
             -->
-         <v-btn v-if="member_kind == 'User' && show_sdk_share"
-               color="primary"
-               outlined
-                :loading="loading"
-                @click="member_kind = 'Developer Authentication (API/SDK)'"
-                :disabled="loading">
-            Developer Key (API/SDK)
-        </v-btn>
+        <tooltip_button
+          v-if="member_kind == 'User' && show_sdk_share"
+          tooltip_message="Developer Authentication (API/SDK)"
+          @click="member_kind = 'Developer Authentication (API/SDK)'"
+          icon="mdi-key-plus"
+          :icon_style="true"
+          color="primary"
+          :disabled="loading"
+                        >
+        </tooltip_button>
+
+        <tooltip_button
+          v-if="member_kind != 'User'"
+          tooltip_message="Invite User"
+          @click="member_kind = 'User'"
+          icon="mdi-account"
+          :icon_style="true"
+          color="primary"
+          :disabled="loading"
+                        >
+        </tooltip_button>
 
       </v-card-title>
 
@@ -38,6 +60,7 @@
           {{errors}}
         </v-alert>
 
+
         <v-select v-if="member_kind == 'Developer Authentication (API/SDK)'"
                   :items="member_kind_list"
                   v-model="member_kind"
@@ -45,6 +68,39 @@
                   item-value="text"
                   :disabled="loading"
                   prepend-icon="mdi-security-account"></v-select>
+
+        <v-dialog v-model="view_existing_open"
+                  id="view_existing_members"                  
+                  v-if="enable_view_existing"
+                  width="800px">
+          <v-card>
+            <v-container>
+
+              <v-card-title>
+                Existing
+
+                <v-spacer></v-spacer>
+                <tooltip_button
+                  tooltip_message="Close"
+                  @click="view_existing_open = !view_existing_open"
+                  icon="mdi-close"
+                  :icon_style="true"
+                  color="primary"
+                  :bottom="true"
+                  datacy="close-view_existing_open"
+                  class="text-right"
+                >
+                </tooltip_button>
+              </v-card-title>
+
+              <v_collaborate_list_existing :project_string_id="project_string_id">
+              </v_collaborate_list_existing>
+
+              Invited users not shown.
+
+            </v-container>
+          </v-card>
+        </v-dialog>
 
         <div v-if="member_kind=='Developer Authentication (API/SDK)'">
 
@@ -143,7 +199,10 @@ import Vue from "vue"; export default Vue.extend( {
     },
     'elevation':{
       default: 1
-    }
+    },
+    'enable_view_existing':{
+      default: true
+    },
   },
   data() {
     return {
@@ -153,6 +212,8 @@ import Vue from "vue"; export default Vue.extend( {
       errors: null,
       note: null,
       result: null,
+
+      view_existing_open: false,
 
       notify: true,
 

--- a/frontend/src/components/share/share_new_member.vue
+++ b/frontend/src/components/share/share_new_member.vue
@@ -50,7 +50,7 @@
 
           <auth_api_new :project_string_id="project_string_id"></auth_api_new>
 
-        </div>
+        </div> 
         <div v-else>
           <v-text-field label="Email"
                         v-model="email"
@@ -60,12 +60,24 @@
                         :disabled="loading">
           </v-text-field>
 
-          <v-select :items="permission_type_list"
-                    v-model="permission_type"
-                    label="Select permission"
-                    item-value="text"
-                    :disabled="loading"
-                    prepend-icon="security"></v-select>
+          <v-layout>
+            <v-select :items="permission_type_list"
+                      v-model="permission_type"
+                      label="Select permission"
+                      item-value="text"
+                      :disabled="loading"
+                      prepend-icon="security"></v-select>
+
+            <tooltip_button
+                tooltip_message="Help"
+                href="https://diffgram.readme.io/docs/project#project-roles"
+                target="_blank"
+                icon="help"
+                :icon_style="true"
+                color="primary">
+            </tooltip_button>
+
+          </v-layout>
 
           <v-layout>
             <v-text-field label="Optional: Include a personal message..."


### PR DESCRIPTION
[Add: View existing members from Share concept](https://github.com/diffgram/diffgram/commit/0157046fbd0ee59cc9afb40299d683d53ea9d3ec)

-> Add dialog to show existing users when inviting
-> Add extra button to jump back to user mode when in API creation (design intuition wise the button is in same place so the user doesn't have to think about the selector, otherwise if they view existing first then it feels confusing)
-> Upgrade and clean other buttons
-> Add flag to optionally not show the "existing users" e.g. on settings page
-> Clean username / move client ID to otherwise empty step
Thinking design perspective here, member_id maybe useful for debugging but not average user
-> Remove titles so parent component can set relevant title, or can completely remove it in cases where it's contextually obvious and a title is design clutter

Other small things:

- [Change on save to remove button](https://github.com/diffgram/diffgram/commit/2f9e8d59af3791f3f9ef8cb66e5ba176da43e796)[](https://github.com/anthony-sarkis) 
- [Reorder Members to be higher priority](https://github.com/diffgram/diffgram/commit/950b6b5c766af95be909bc7f376d43af73edd8af)[](https://github.com/anthony-sarkis) 
- [Hide user type and clean](https://github.com/diffgram/diffgram/commit/9b629f93c35c378e06d8ecdc270fa4406fb0a860)[](https://github.com/anthony-sarkis) 
- [Add contextual help button](https://github.com/diffgram/diffgram/commit/382ce9e42b57e64c26e7a0e13ea6fa3642254276)[](https://github.com/anthony-sarkis)

![share project](https://user-images.githubusercontent.com/18080164/160722853-287a5f45-fc3e-4ef7-a40a-fea517ec6377.PNG)
![show existing](https://user-images.githubusercontent.com/18080164/160722857-bfc5ad9d-9ba6-422e-aab4-13ec48ab6663.PNG)
![dev auth](https://user-images.githubusercontent.com/18080164/160722862-b99c7b62-bd1c-46f5-abbe-61f53455ef4f.PNG)
![new settings clean](https://user-images.githubusercontent.com/18080164/160722865-b214fc7d-bd52-4ffb-b409-b3eba567afb1.PNG)







