### PR TITLE
Fix: Missing param

### DIFF
--- a/frontend/src/router/router.js
+++ b/frontend/src/router/router.js
@@ -212,7 +212,8 @@ const routerOptions = [
     alias: ['/project/:project_string_id'],
     component: 'annotation/annotation_ui_factory',
     props: (route) => ({
-      show_explorer_full_screen: true
+      show_explorer_full_screen: true,
+      project_string_id: route.params.project_string_id
     }),
     meta: {
       requiresAuth: true,


### PR DESCRIPTION
When we manually set props like this then it appears we need to also set default props. becuase it was not receiving a project string id the automatic project changer could not work

closes #799 