### PR TITLE
Login new assumptions

### DIFF
--- a/frontend/cypress/integration/diffgram/user/user_login_spec.js
+++ b/frontend/cypress/integration/diffgram/user/user_login_spec.js
@@ -15,7 +15,6 @@ describe('Login Flow tests', function () {
       'ai',
       'alert',
       'public_project',
-      'annotation_assignment',
       'annotation_project',
       'annotation_state',
       'attribute',

--- a/frontend/cypress/integration/diffgram/user/user_login_spec.js
+++ b/frontend/cypress/integration/diffgram/user/user_login_spec.js
@@ -1,6 +1,5 @@
 
 
-
 describe('Login Flow tests', function () {
 
   beforeEach(() => {
@@ -15,7 +14,6 @@ describe('Login Flow tests', function () {
       'ai',
       'alert',
       'public_project',
-      'annotation_project',
       'annotation_state',
       'attribute',
       'project_list',

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -1488,8 +1488,6 @@ export default Vue.extend({
         label: {},
       },
 
-      Annotation_assignments: [],
-
       html_image: new Image(), // our canvas expects an image at init
 
       save_on_change: true,

--- a/frontend/src/components/annotation/labels_view.vue
+++ b/frontend/src/components/annotation/labels_view.vue
@@ -426,7 +426,6 @@
           default: false
         },
         'current_video_file_id': {},
-        'annotation_assignment_on': {},
         'render_mode': {
           default: 'own_page'
         },

--- a/frontend/src/components/main_menu/menu_project.vue
+++ b/frontend/src/components/main_menu/menu_project.vue
@@ -2,10 +2,27 @@
   <div>
 
 
-    <v-menu  v-model="project_menu"
+    <v-flex v-if="!$store.state.project.current.project_string_id
+                && $store.state.user.current.security_email_verified == true
+                && $store.state.project_list.user_projects_list
+                && $store.state.project_list.user_projects_list.length > 0">
+      <v-btn color="primary"
+              text
+              style="text-transform: none !important;"
+              @click="$router.push('/projects')">
+        <span>
+          <v-icon left>folder</v-icon>
+          Change Project
+        </span>
+      </v-btn>
+    </v-flex>
+
+    <v-menu v-model="project_menu"
             :nudge-width="150"
             offset-y
-            :disabled="false">
+            :disabled="false"
+            v-if="$store.state.project.current.project_string_id"
+            >
 
       <template v-slot:activator="{ on }">
         <v-btn  v-on="on"
@@ -13,7 +30,8 @@
                 id="open_main_menu"
                 data-cy="project_menu_dropdown_toggle"
                 text
-                :disabled="!$store.state.project.current.project_string_id || $store.state.user.current.security_email_verified != true">
+                v-if="$store.state.project.current.project_string_id"
+                :disabled="$store.state.user.current.security_email_verified != true">
           <v-icon left> mdi-lightbulb </v-icon>
           Project
           <v-icon right> mdi-chevron-down</v-icon>

--- a/frontend/src/components/main_menu/menu_tasks.vue
+++ b/frontend/src/components/main_menu/menu_tasks.vue
@@ -5,12 +5,13 @@
     <v-menu v-model="tasks_menu"
             :nudge-width="150"
             offset-y
-            :disabled="false">
+            :disabled="false"
+            v-if="$store.state.project.current.project_string_id"
+            >
 
       <template v-slot:activator="{ on }">
-        <v-btn v-if="$store.state.builder_or_trainer.mode == 'builder'"
+        <v-btn v-if="$store.state.project.current.project_string_id"
                v-on="on"
-               :disabled="!$store.state.project || !$store.state.project.current.project_string_id"
                text
         >
           <v-icon left>mdi-brush</v-icon>

--- a/frontend/src/components/report/report.vue
+++ b/frontend/src/components/report/report.vue
@@ -704,7 +704,7 @@ export default Vue.extend({
         ],
 
         date_period_unit_list: ['day', 'month', 'year'],
-        //group_by_list: ['user', 'project', 'job', 'label', 'date'],
+        group_by_list: ['user', 'project', 'job', 'label', 'date'],
 
         group_by_list_default: [
 

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -116,7 +116,6 @@ export const user_module = {
       commit('clear_ai')
       commit('clear_annotation')
       commit('clear_labels')
-      commit('clear_annotation_project')
       commit('clear_video_current')
       commit('builder_or_trainer_clear')
       commit('clear_alert')
@@ -568,19 +567,6 @@ const auth = {
 
 
 
-const annotation_project = {
-  state: {
-    current: {}
-  },
-  mutations: {
-    set_annotation_project(state, current) {
-      state.current = current
-    },
-    clear_annotation_project(state) {
-      state.current = {}
-    }
-  }
-}
 
 const builder_or_trainer = {
   state: {
@@ -783,7 +769,6 @@ const my_store = new Vuex.Store({
     project_list: project_list,
     ai: ai,
     labels: labels,
-    annotation_project: annotation_project,
     video: video,
     job: job,
     connection: connection,

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -116,7 +116,6 @@ export const user_module = {
       commit('clear_ai')
       commit('clear_annotation')
       commit('clear_labels')
-      commit('clear_annotation_assignment')
       commit('clear_annotation_project')
       commit('clear_video_current')
       commit('builder_or_trainer_clear')
@@ -125,6 +124,7 @@ export const user_module = {
       commit('clear_job')
       commit('clear_connection')
       commit('clear_ui_schema')
+      commit('clear_userProjects_list')
 
     },
 
@@ -167,6 +167,9 @@ export const project_list = {
   mutations: {
     set_userProjects_list(state, fetched_projects_list) {
       state.user_projects_list = fetched_projects_list
+    },
+    clear_userProjects_list(state) {
+      state.user_projects_list = undefined
     }
   }
 }
@@ -262,13 +265,7 @@ const org = {
 }
 
 
-/* Feb 14, 2020
- * Example context
- * of wanting to easily access values of counts from different
- * components and context that current media core is kind buried.
- *
- *
- */
+
 const job = {
 
   state: {
@@ -786,7 +783,6 @@ const my_store = new Vuex.Store({
     project_list: project_list,
     ai: ai,
     labels: labels,
-    annotation_assignment: annotation_assignment,
     annotation_project: annotation_project,
     video: video,
     job: job,

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -570,23 +570,6 @@ const auth = {
 }
 
 
-const annotation_assignment = {
-  state: {
-    assignment: {},
-    on: false,
-  },
-  mutations: {
-    annotation_assignment_on: state => state.on = true,
-    annotation_assignment_off: state => state.on = false,
-    set_annotation_assignment(state, assignment) {
-      state.assignment = assignment
-    },
-    clear_annotation_assignment(state) {
-      state.on = false,
-        state.assignment = {}
-    }
-  }
-}
 
 const annotation_project = {
   state: {

--- a/shared/settings/settings.py
+++ b/shared/settings/settings.py
@@ -112,7 +112,7 @@ _ANALYTICS_WRITE_KEY = os.environ.get('_ANALYTICS_WRITE_KEY')
 
 
 # Other Misc Settings
-SANDBOX_BYPASS_LOGIN = os.getenv('SANDBOX_BYPASS_LOGIN', False)  # True or False
+SANDBOX_BYPASS_LOGIN = env_adapter.bool(os.getenv('SANDBOX_BYPASS_LOGIN', False))  # True or False
 URL_SIGNED_REFRESH = int(os.getenv('URL_SIGNED_REFRESH', 1548450398))
 ML_JOB_DIR = "job/"
 


### PR DESCRIPTION
[Add dedicated change project button for rare contexts](https://github.com/diffgram/diffgram/commit/abc75715b9ac800c23bfd29c9b1aa06cb0432668) 

Keeping in mind the context that we normally set the project when the user logins in, in the rare event that there is no project:
![image](https://user-images.githubusercontent.com/18080164/163900100-779068a1-f08b-45d3-b781-b6cf57368393.png)

1) The part that was confusing was that change project was within the project menu.
This meant that various conditions that made sense for most of the menu did not make sense for change project.

2) Now there is a dedicated change project, that will only show up when there is no active project, the user's email is verified, and there is a project available
3) Now the project and task menus only shows when there's an active project.
While there's some UI trade offs for now that seems simpler then the disabled

while we could "get smart" about some of the other resume onboarding, change, new project etc. there are so many contextual things for now feels better to keep that screen open - again keeping in mind it's a fallback that users should rarely get to

this iteration should close #817 