### PR TITLE
Fix Task List Fetching

### DIFF
--- a/frontend/src/components/source_control/file_preview.vue
+++ b/frontend/src/components/source_control/file_preview.vue
@@ -42,6 +42,7 @@
     <v-card-text class="pa-0 ma-0" v-if="file.video">
       <video_drawable_canvas
         :allow_zoom="false"
+        :preview_mode="true"
         :project_string_id="project_string_id"
         :filtered_instance_by_model_runs="filtered_instance_list"
         :video="file.video"

--- a/frontend/src/components/task/task/task_list.vue
+++ b/frontend/src/components/task/task/task_list.vue
@@ -1149,6 +1149,7 @@ export default Vue.extend({
     },
     async task_list_api() {
       this.loading = true;
+      await this.$nextTick();
       try {
         const response = await axios.post(
           `/api/v1/job/${this.job_id}/task/list`,

--- a/frontend/src/components/vue_canvas/video_drawable_canvas.vue
+++ b/frontend/src/components/vue_canvas/video_drawable_canvas.vue
@@ -88,6 +88,9 @@ import {KeypointInstance} from "./instances/KeypointInstance";
       canvas_wrapper_id:{
         default: undefined
       },
+      preview_mode:{
+        default: false
+      },
       project_string_id: {
         default: undefined
       },
@@ -172,6 +175,9 @@ import {KeypointInstance} from "./instances/KeypointInstance";
     },
     beforeDestroy(){
       //console.debug("Destroyed")
+      if(this.preview_mode){
+        return
+      }
       document.removeEventListener('focusin', this.focus_in)
       document.removeEventListener('focusout', this.focus_out)
       if(window.stop !== undefined) {
@@ -291,8 +297,13 @@ import {KeypointInstance} from "./instances/KeypointInstance";
           return
         }
         let url = `/api/project/${this.$props.project_string_id}/video/${String(this.$props.file.id)}`
+        if(!this.preview_mode){
+          url += `/instance/buffer/start/${this.current_frame}/end/${(this.current_frame + this.instance_buffer_size)}/list`
+        }
+        else{
+          url += `/instance/buffer/start/${this.current_frame}/end/${(this.current_frame + 1)}/list`
+        }
 
-        url += `/instance/buffer/start/${this.current_frame}/end/${(this.current_frame + this.instance_buffer_size)}/list`
         try{
           const response = await axios.post(url, {
             directory_id : this.$store.state.project.current_directory.directory_id


### PR DESCRIPTION
Since requests get cancelled on the on_destroy method of the video preview canvas, we need to await next tick before doing the task list request, otherwise the task list request will also get cancelled.