### PR TITLE
Add Basic Roles Creation for Keycloak Setup

### DIFF
--- a/default/methods/user/logout.py
+++ b/default/methods/user/logout.py
@@ -6,20 +6,24 @@ from shared.settings import settings
 from shared.auth.KeycloakDiffgramClient import KeycloakDiffgramClient
 
 
-@routes.route('/api/v1/user/logout', methods = ['GET'])
-def logout():
-    if settings.USE_OIDC:
-        jwt_data = login_session.get('jwt')
-        if jwt_data is None:
-            login_session['jwt'] = ''
-            return "Success", 200
+def oidc_logout():
+    jwt_data = login_session.get('jwt')
+    if jwt_data is None:
         login_session['jwt'] = ''
+        return "Success", 200
+
+    login_session['jwt'] = ''
+    if type(jwt_data) == dict:
         access_token = jwt_data.get('access_token')
         refresh_token = jwt_data.get('refresh_token')
         kc_client = KeycloakDiffgramClient()
         kc_client.logout(refresh_token = refresh_token)
 
 
+@routes.route('/api/v1/user/logout', methods = ['GET'])
+def logout():
+    if settings.USE_OIDC:
+        oidc_logout()
     else:
         login_session['user_id'] = ''
     return "Success", 200

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
       RABBITMQ_PORT: ${RABBITMQ_PORT}
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
-      DIFFGRAM_SERVICE_NAME: ${DIFFGRAM_SERVICE_NAME}
+      DIFFGRAM_SERVICE_NAME: eventhandlers
     entrypoint: ["python3", "-u", "/app/main.py"]
   walrus:
     image: gcr.io/diffgram-open-core/walrus:${DIFFGRAM_VERSION_TAG}
@@ -107,7 +107,7 @@ services:
       RABBITMQ_PORT: ${RABBITMQ_PORT}
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
-      DIFFGRAM_SERVICE_NAME: ${DIFFGRAM_SERVICE_NAME}
+      DIFFGRAM_SERVICE_NAME: walrus
     entrypoint: ["python3", "-u", "/app/main.py"]
 
   default:
@@ -158,7 +158,7 @@ services:
       RABBITMQ_PORT: ${RABBITMQ_PORT}
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
-      DIFFGRAM_SERVICE_NAME: ${DIFFGRAM_SERVICE_NAME}
+      DIFFGRAM_SERVICE_NAME: default
     command: ["/app/db-init.sh", "${DATABASE_HOST}", "python3", "-u", "/app/main.py"]
   db:
     image: ${POSTGRES_IMAGE}

--- a/eventhandlers/main.py
+++ b/eventhandlers/main.py
@@ -2,8 +2,12 @@ from shared.shared_logger import get_shared_logger
 from ConsumersCreator import ConsumerCreator
 from shared.settings import settings
 from shared.database_setup_supporting import *
+from startup.system_startup_checker import EventHandlerSystemStartupChecker
 import traceback
 logger = get_shared_logger()
+
+startup_checker = EventHandlerSystemStartupChecker()
+startup_checker.execute_startup_checks()
 
 consumer_creator = ConsumerCreator()
 logger.info(f'Queue Consumers Started. Waiting for new messages...')

--- a/eventhandlers/startup/system_startup_checker.py
+++ b/eventhandlers/startup/system_startup_checker.py
@@ -1,13 +1,15 @@
 from shared.database.system_events.system_events import SystemEvents
 from shared.system_startup.system_startup_base import SystemStartupBase
-from methods.regular.regular_api import logger
-from shared.settings import settings
+from shared.shared_logger import get_shared_logger
 from shared.queueclient.QueueClient import QueueClient
+from shared.settings import settings
 from shared.auth.KeycloakDiffgramClient import check_keycloak_setup
 import traceback
 
+logger = get_shared_logger()
 
-class DefaultServiceSystemStartupChecker(SystemStartupBase):
+
+class EventHandlerSystemStartupChecker(SystemStartupBase):
 
     def __init__(self):
         self.service_name = settings.DIFFGRAM_SERVICE_NAME
@@ -24,7 +26,7 @@ class DefaultServiceSystemStartupChecker(SystemStartupBase):
             logger.error(data)
             logger.error(f'Error connecting to rabbit MQ')
             raise (Exception('Error connecting to RabbitMQ'))
+        if not result:
+            raise Exception('System Startup Check Failed.')
 
         check_keycloak_setup()
-
-        return result

--- a/shared/permissions/KeycloakPolicyEnforcer.py
+++ b/shared/permissions/KeycloakPolicyEnforcer.py
@@ -1,0 +1,7 @@
+from shared.auth.KeycloakDiffgramClient import KeycloakDiffgramClient
+
+class KeycloakPolicyEnforcer:
+
+    def __init__(self):
+        self.keycloak_client = KeycloakDiffgramClient()
+

--- a/shared/settings/settings.py
+++ b/shared/settings/settings.py
@@ -189,6 +189,8 @@ OIDC_PROVIDER_CLIENT_ID = os.getenv('OIDC_PROVIDER_CLIENT_ID', 'diffgram')
 OIDC_PROVIDER_PUBLIC_KEY = os.getenv('OIDC_PROVIDER_PUBLIC_KEY', 'diffgram_public_key')
 OIDC_PROVIDER_SECRET = os.getenv('OIDC_PROVIDER_SECRET', 'diffgram_secret_key')
 OIDC_PROVIDER_REALM = os.getenv('OIDC_PROVIDER_REALM', 'mydiffgramrealm')
+KEY_CLOAK_USER = os.getenv('KEY_CLOAK_USER', 'admin')
+KEY_CLOAK_PASSWORD = os.getenv('KEY_CLOAK_PASSWORD', 'admin')
 
 
 # Minio Only Allow Expiry time is less than 7 days (value in seconds).

--- a/shared/settings/settings.py
+++ b/shared/settings/settings.py
@@ -184,13 +184,17 @@ SIGNED_URL_CACHE_NEW_OFFSET_DAYS_VALID = int(os.getenv('SIGNED_URL_CACHE_NEW_OFF
 
 # Keycloak / OIDC Settings
 USE_OIDC = env_adapter.bool(os.getenv('USE_OIDC', False))
+USE_KEYCLOAK_AUTHORIZATION = env_adapter.bool(os.getenv('USE_KEYCLOAK_AUTHORIZATION', False))
 OIDC_PROVIDER_HOST = os.getenv('OIDC_PROVIDER_HOST', 'http://localhost:8099/auth/')
 OIDC_PROVIDER_CLIENT_ID = os.getenv('OIDC_PROVIDER_CLIENT_ID', 'diffgram')
 OIDC_PROVIDER_PUBLIC_KEY = os.getenv('OIDC_PROVIDER_PUBLIC_KEY', 'diffgram_public_key')
 OIDC_PROVIDER_SECRET = os.getenv('OIDC_PROVIDER_SECRET', 'diffgram_secret_key')
-OIDC_PROVIDER_REALM = os.getenv('OIDC_PROVIDER_REALM', 'mydiffgramrealm')
-KEY_CLOAK_USER = os.getenv('KEY_CLOAK_USER', 'admin')
-KEY_CLOAK_PASSWORD = os.getenv('KEY_CLOAK_PASSWORD', 'admin')
+OIDC_PROVIDER_REALM = os.getenv('OIDC_PROVIDER_REALM', 'diffgram-realm')
+KEY_CLOAK_MASTER_USER = os.getenv('KEY_CLOAK_MASTER_USER', 'admin')
+KEY_CLOAK_MASTER_PASSWORD = os.getenv('KEY_CLOAK_MASTER_PASSWORD', 'admin')
+
+KEY_CLOAK_DIFFGRAM_USER = os.getenv('KEY_CLOAK_DIFFGRAM_USER', 'diffgram')
+KEY_CLOAK_DIFFGRAM_PASSWORD = os.getenv('KEY_CLOAK_DIFFGRAM_PASSWORD', 'diffgram')
 
 
 # Minio Only Allow Expiry time is less than 7 days (value in seconds).

--- a/shared/settings/settings.py
+++ b/shared/settings/settings.py
@@ -188,7 +188,6 @@ USE_KEYCLOAK_AUTHORIZATION = env_adapter.bool(os.getenv('USE_KEYCLOAK_AUTHORIZAT
 OIDC_PROVIDER_HOST = os.getenv('OIDC_PROVIDER_HOST', 'http://localhost:8099/auth/')
 OIDC_PROVIDER_CLIENT_ID = os.getenv('OIDC_PROVIDER_CLIENT_ID', 'diffgram')
 OIDC_PROVIDER_PUBLIC_KEY = os.getenv('OIDC_PROVIDER_PUBLIC_KEY', 'diffgram_public_key')
-OIDC_PROVIDER_SECRET = os.getenv('OIDC_PROVIDER_SECRET', 'diffgram_secret_key')
 OIDC_PROVIDER_REALM = os.getenv('OIDC_PROVIDER_REALM', 'diffgram-realm')
 KEY_CLOAK_MASTER_USER = os.getenv('KEY_CLOAK_MASTER_USER', 'admin')
 KEY_CLOAK_MASTER_PASSWORD = os.getenv('KEY_CLOAK_MASTER_PASSWORD', 'admin')

--- a/walrus/methods/startup/system_startup_checker.py
+++ b/walrus/methods/startup/system_startup_checker.py
@@ -3,7 +3,9 @@ from shared.system_startup.system_startup_base import SystemStartupBase
 from methods.regular.regular_api import logger
 from shared.queueclient.QueueClient import QueueClient
 from shared.settings import settings
-import  traceback
+from shared.auth.KeycloakDiffgramClient import check_keycloak_setup
+import traceback
+
 
 class WalrusServiceSystemStartupChecker(SystemStartupBase):
 
@@ -24,3 +26,5 @@ class WalrusServiceSystemStartupChecker(SystemStartupBase):
             raise (Exception('Error connecting to RabbitMQ'))
         if not result:
             raise Exception('System Startup Check Failed.')
+
+        check_keycloak_setup()


### PR DESCRIPTION
- Adds automatic creation of key cloak realm and client.
- Creates client roles based on existing diffgram roles. For now there is no integration between these roles.
- Adds startup checks when Keycloak is enabled.
