### PR TITLE
Fix Expiration TImes For S3 Client Defaults

### DIFF
--- a/shared/data_tools_core_s3.py
+++ b/shared/data_tools_core_s3.py
@@ -243,7 +243,8 @@ class DataToolsS3:
         """
 
         if expiration_offset is None:
-            expiration_offset = 40368000
+            one_day = 86400
+            expiration_offset = settings.SIGNED_URL_CACHE_NEW_OFFSET_DAYS_VALID * one_day
 
         expiration_time = expiration_offset
 

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -1902,8 +1902,6 @@ class Process_Media():
                 content_type = "image/jpg",
             )
 
-            self.new_image.url_signed = data_tools.build_secure_url(self.new_image.url_signed_blob_path,
-                                                                    self.new_image.url_signed_expiry)
         except Exception as e:
             message = f'Error uploading to cloud storage: {traceback.format_exc()}'
             logger.error(message)

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -1994,12 +1994,6 @@ class Process_Media():
 
         imwrite(new_temp_filename, thumbnail_image, quality = 95)
 
-        # Build URL
-        url_signed_thumb = data_tools.build_secure_url(self.new_image.url_signed_thumb_blob_path,
-                                                       self.new_image.url_signed_expiry)
-
-        self.new_image.url_signed_thumb = url_signed_thumb
-
         data_tools.upload_to_cloud_storage(
             temp_local_path = new_temp_filename,
             blob_path = self.new_image.url_signed_thumb_blob_path,


### PR DESCRIPTION
New S3V4 Signatures seem to only allow 7 days max as regeneration time for signed urls.