### PR TITLE
set to latest tag instead of specific version

### DIFF
--- a/install.py
+++ b/install.py
@@ -551,9 +551,7 @@ class DiffgramInstallTool:
     def set_diffgram_version(self):
         version = bcolors.inputcolor('Enter diffgram version: [Or Press Enter to Get The Latest Version]: ')
         if version == "":
-            response = requests.get("https://api.github.com/repos/diffgram/diffgram/releases/latest")
-            latest_release = response.json()['tag_name']
-            self.diffgram_version = latest_release
+            self.diffgram_version = 'latest'
         else:
             self.diffgram_version = version
 


### PR DESCRIPTION
Then we don't have to manually change the tag in order to upgrade
And it saves having multiple versions maybe in docker?
What do people think?

![image](https://user-images.githubusercontent.com/18080164/174405514-d6a447c7-4c75-401b-9ce1-4dcace85e137.png)
