### PR TITLE
Cognito Token Storage Size & Login Optimizations

### DIFF
--- a/default/methods/auth/oidc/oidc_auth_callback.py
+++ b/default/methods/auth/oidc/oidc_auth_callback.py
@@ -51,8 +51,10 @@ def api_oidc_callback():
         oidc_client = oidc_provider.get_client()
         logger.info('OAuth2 Client Fetched')
         access_token_data = oidc_client.get_access_token_with_code_grant(code = code)
+
         if 'id_token' in access_token_data:
             access_token_data.pop('id_token')
+
         logger.info(f'OAuth2 access_token_data: {access_token_data}')
         if not access_token_data:
             log['error']['token'] = 'Failed to get access token. Please check authorization_code and client configuration.'

--- a/default/methods/user/login.py
+++ b/default/methods/user/login.py
@@ -188,5 +188,5 @@ def first_stage_login_success(log,
             'user_data_oidc': user_data_oidc,
             'install_fingerprint': settings.DIFFGRAM_INSTALL_FINGERPRINT
         }
-        logger.info(f'Log in success result {result}')
+        logger.debug(f'Log in success result {result}')
         return jsonify(result), 200

--- a/default/methods/user/logout.py
+++ b/default/methods/user/logout.py
@@ -8,9 +8,8 @@ from shared.helpers.permissions import get_decoded_jwt_from_session
 
 def oauth2_logout() -> [dict, int]:
     oauth2 = OAuth2Provider()
-    jwt_data = get_decoded_jwt_from_session()
+    refresh_token = get_decoded_jwt_from_session()
     oauth_client = oauth2.get_client()
-    refresh_token = oauth_client.get_refresh_token_from_jwt(jwt_data = jwt_data)
     login_session['jwt'] = None
     url_data = oauth_client.logout(refresh_token = refresh_token)
     return {"url_redirect": url_data}, 200

--- a/frontend/src/components/user/login.vue
+++ b/frontend/src/components/user/login.vue
@@ -109,15 +109,28 @@
                  <v-spacer></v-spacer>
 
                 <v-btn
+                  @click="route_oauth2_login"
+                  color="secondary"
+                  outlined
+                  class="mr-4"
+                  :loading="loading"
+                  :disabled="loading"
+                >
+                  <v-icon left>mdi-web</v-icon>
+                  Login with SSO
+                </v-btn>
+
+
+                <v-btn
                   @click="route_account_new"
-                  color="primary"
-                  text
+                  color="success"
+                  outlined
                   :loading="loading"
                   @click.native="loader = 'loading'"
                   :disabled="loading"
                 >
                   <v-icon left>mdi-plus</v-icon>
-                  Create
+                  Create User
                 </v-btn>
 
                 <tooltip_button
@@ -223,11 +236,13 @@ export default Vue.extend({
       render_default_login: false,
 
       e1: true,
+      show_oauth2: false,
 
       email: null,
       mailgun: undefined,
 
       mode: "loading",
+      oauth_login_url: null,
       show_logging_in_messsage: false,
 
       error: {
@@ -274,11 +289,12 @@ export default Vue.extend({
 
     window.addEventListener("keyup", this.keyboard_events);
     const { mailgun } = await is_mailgun_set();
-    console.log('AAAAAAAAAAAAAAAAAAAAAA')
     const { use_oauth2, login_url } = await is_oauth2_set();
     if(use_oauth2){
-      window.location.replace(login_url);
-      return
+      // window.location.replace();
+      // return
+      this.oauth_login_url = login_url
+      this.show_oauth2 = true
     }
     this.render_default_login = true;
     this.mailgun = mailgun;
@@ -295,6 +311,9 @@ export default Vue.extend({
     window.removeEventListener("keyup", this.keyboard_events);
   },
   methods: {
+    route_oauth2_login: function(){
+      this.$router.push("/user/oauth2-login");
+    },
     route_account_new: function () {
       this.$router.push("/user/new");
     },

--- a/frontend/src/components/user/login.vue
+++ b/frontend/src/components/user/login.vue
@@ -110,6 +110,7 @@
 
                 <v-btn
                   @click="route_oauth2_login"
+                  v-if="show_oauth2"
                   color="secondary"
                   outlined
                   class="mr-4"
@@ -312,7 +313,8 @@ export default Vue.extend({
   },
   methods: {
     route_oauth2_login: function(){
-      this.$router.push("/user/oauth2-login");
+      window.location.replace(this.oauth_login_url);
+      // this.$router.push(this.oauth_login_url);
     },
     route_account_new: function () {
       this.$router.push("/user/new");


### PR DESCRIPTION
* Optimizes token storage size to be less than 4Kb in  order to keep using client side cookies. As a sidenote, if we ever want to move away from client side cookies we might need to think about server side storage of the session (on DB, redis, memcached or filesystem) or  localstorage storage of the session (not as safe as cookies)

* Change the logout flow to now have a button in login screen instead of directly login with SSO provider.