### PR TITLE
hotkey for tag creation

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -7944,6 +7944,10 @@ export default Vue.extend({
           !this.label_settings.show_ghost_instances;
       }
 
+      if (event.key === "t") {
+        this.insert_tag_type();
+      }
+
       if (event.keyCode === 13) {
         // enter
         if (this.instance_type == "polygon") {

--- a/frontend/src/components/annotation/hotkeys.vue
+++ b/frontend/src/components/annotation/hotkeys.vue
@@ -43,6 +43,9 @@
 
   <p> <kbd>Z</kbd> Pan Only </p>
 
+  <h2> Tag </h2>
+  <p> <kbd>T</kbd> Create a Tag </p>
+
   <h2> Keypoints:  </h2>
   <p> <kbd>O</kbd> Show/Hide Occluded Nodes  </p>
   <p>On Guided Mode: <b>Hold</b> <kbd>n</kbd> to draw a node as occluded.  </p>


### PR DESCRIPTION
Tag can be created without touching the mouse. It is a good candidate to have a hotkey.