### PR TITLE
Improve tags

### DIFF
--- a/default/methods/tag/tag.py
+++ b/default/methods/tag/tag.py
@@ -164,7 +164,7 @@ def apply_tag_to_object_api(project_string_id):
 @routes.route('/api/v1/project/<string:project_string_id>/tag/applied/remove', 
 			  methods=['POST'])
 @Project_permissions.user_has_project(["admin", "Editor"])
-def apply_tag_to_object_api(project_string_id):
+def remove_applied_tag_from_object_api(project_string_id):
     
     update_tags_specification = [
         {"tag_id": {

--- a/frontend/src/components/source_control/directory_list.vue
+++ b/frontend/src/components/source_control/directory_list.vue
@@ -198,8 +198,9 @@
                 :dataset="current_directory"
                 :object_id="current_directory.directory_id"
                 :object_type="'dataset'"
-                :apply_upon_selection="true"
+                :modify_upon_selection="true"
                 @tag_applied="tag_display_refresh_trigger=Date.now()"
+                @tag_prior_applied_removed="tag_display_refresh_trigger=Date.now()"
           >
           </tag_select>
 

--- a/frontend/src/components/tag/tag_display_and_select.vue
+++ b/frontend/src/components/tag/tag_display_and_select.vue
@@ -24,8 +24,9 @@
             :project_string_id="project_string_id"
             :object_id="object_id"
             :object_type="object_type"
-            :apply_upon_selection="true"
-            @tag_applied="new_tag_applied($event, object_id, object_type)"
+            :modify_upon_selection="true"
+            @tag_applied="get_applied_tags_api($event, object_id, object_type)"
+            @tag_prior_applied_removed="get_applied_tags_api($event, object_id, object_type)"
           >
           </tag_select>
 
@@ -91,7 +92,7 @@
       },
 
       methods: {
-         new_tag_applied: function (event, object_id, object_type){
+         get_applied_tags_api: function (event, object_id, object_type){
           if (this.$refs.tag_display_literal) {
             this.$refs.tag_display_literal.get_applied_tags_api(object_id, object_type)
           }

--- a/frontend/src/components/tag/tag_select.vue
+++ b/frontend/src/components/tag/tag_select.vue
@@ -183,7 +183,7 @@ Where is a dict in data() eg  tag: {}
           apply_tag_api_loading: false,
           new_tag_api_loading: false,
           error: {},
-          previous_tag_list_selected: []
+          previous_selected: []
         }
       },
 
@@ -309,13 +309,13 @@ Where is a dict in data() eg  tag: {}
           let user_wants_to_apply_tag = true
           let user_wants_to_remove_applied_tag = false
 
-          if (this.previous_tag_list_selected.length >
+          if (this.previous_selected.length >
               this.selected.length) {
             user_wants_to_remove_applied_tag = true
             user_wants_to_apply_tag = false
           }
 
-          this.previous_tag_list_selected = this.selected.slice()
+          this.previous_selected = this.selected.slice()
           if (!changed_tag) { return }
 
           if (user_wants_to_apply_tag){
@@ -344,7 +344,7 @@ Where is a dict in data() eg  tag: {}
             this.list_applied_tags_api_loading = false
 
             this.selected = response.data.tag_list
-
+            this.previous_selected = response.data.tag_list
           })
             .catch(error => {
               console.error(error);
@@ -356,14 +356,13 @@ Where is a dict in data() eg  tag: {}
         get_changed_tag(){
           // because veutify returns list with all elements
 
-          console.log(this.previous_tag_list_selected)
-
-          if (this.previous_tag_list_selected.length >
-              this.tag_list_internal.length) {
-            for (let previous_tag of this.previous_tag_list_selected){
-              let removed_tag = this.selected.find(x => x.id == previous_tag.id)
-              if (removed_tag) {
-                return removed_tag
+          if (this.previous_selected.length >
+              this.selected.length) {
+            for (let previous_tag of this.previous_selected){
+              
+              let does_tag_exist = this.selected.find(x => x.id === previous_tag.id)
+              if (!does_tag_exist) {
+                return previous_tag
               }
             }
           } else {
@@ -396,7 +395,7 @@ Where is a dict in data() eg  tag: {}
             this.new_tag_api_loading = false
 
             this.tag_list_internal.push(response.data.tag)
-            this.previous_tag_list_selected.push(response.data.tag) 
+            this.previous_selected.push(response.data.tag) 
             this.selected.push(response.data.tag)
             this.remove_string_from_internal(response.data.tag.name)
 

--- a/frontend/src/components/task/job/job_list.vue
+++ b/frontend/src/components/task/job/job_list.vue
@@ -158,6 +158,7 @@
               :label="'Search by tags'"
               @change="search_jobs()"
               @focus="tag_list_api()"
+              :clearable="true"
 
             >
             </tag_select>

--- a/shared/database/tag/tag.py
+++ b/shared/database/tag/tag.py
@@ -160,13 +160,19 @@ class Tag(Base):
         return tag
 
 
-    def add_to_junction_table(
-            self,
-            object_id,
-            object_type,
-            project_id,
-            session):
+    
+    def remove_applied_tag(
+            object_id: int,
+            object_type: str,
+            tag_list: list,
+            session,
+            project,
+            log):
 
+        pass
+
+
+    def get_junction_class(object_type):
         junction_class = None
 
         if object_type == "job":
@@ -174,6 +180,18 @@ class Tag(Base):
 
         if object_type == "dataset":
             junction_class = DatasetTag
+
+        return junction_class
+
+
+    def add_to_junction_table(
+            self,
+            object_id,
+            object_type,
+            project_id,
+            session):
+
+        junction_class = Tag.get_junction_class(object_type)
 
         junction_tag = junction_class.get(
             object_id,

--- a/shared/database/tag/tag.py
+++ b/shared/database/tag/tag.py
@@ -173,7 +173,7 @@ class Tag(Base):
         return tag
 
     
-    def remove_applied_tag(
+    def remove_applied(
             self,
             object_id: int,
             object_type: str,
@@ -185,13 +185,18 @@ class Tag(Base):
 
         junction_tag = junction_class.get(
             object_id,
-            project_id,
+            project.id,
             self,
             session
         )
         if junction_tag: 
+            print(junction_tag)
             session.delete(junction_tag)
             log['info']['tag'] = "success"
+            log['success'] = True
+
+        else:
+            log['info']['tag'] = "Nothing to delete"
 
         return log
 

--- a/shared/database/tag/tag.py
+++ b/shared/database/tag/tag.py
@@ -47,6 +47,19 @@ class Tag(Base):
         return tag
 
 
+    @staticmethod
+    def get_by_id(
+            id: int,
+            project_id: int,
+            session):
+        
+        tag = session.query(Tag).filter(
+            Tag.id == id,
+            Tag.project_id == project_id).first()
+
+        return tag
+
+
     def apply_tags(
             object_id: int,
             object_type: str,
@@ -159,17 +172,28 @@ class Tag(Base):
 
         return tag
 
-
     
     def remove_applied_tag(
+            self,
             object_id: int,
             object_type: str,
-            tag_list: list,
             session,
             project,
             log):
 
-        pass
+        junction_class = Tag.get_junction_class(object_type)
+
+        junction_tag = junction_class.get(
+            object_id,
+            project_id,
+            self,
+            session
+        )
+        if junction_tag: 
+            session.delete(junction_tag)
+            log['info']['tag'] = "success"
+
+        return log
 
 
     def get_junction_class(object_type):


### PR DESCRIPTION
(I have been merging into AI-3-support branch already so just using this more to highlight overall changes, issues, open questions etc)

### Adds tag improvements
1) Adds tag concept to datasets
2) Adds UI control (add/remove) of tags
3) Various helper and generics for dealing with tags
4) Adds ability to remove applied tags
5) Adds visual of tags on various places for datasets

![image](https://user-images.githubusercontent.com/18080164/183227753-2daecf8f-a550-4c70-8fb4-722095ca9441.png)
![image](https://user-images.githubusercontent.com/18080164/183227767-b3141208-5eb7-4a55-9f2d-f6c82239de49.png)
![image](https://user-images.githubusercontent.com/18080164/183227770-71c5873c-3b57-4ca7-8f2b-30b6996e9082.png)
![image](https://user-images.githubusercontent.com/18080164/183227774-014e41e7-ce3e-4213-8ce8-7e87f3dce321.png)
![image](https://user-images.githubusercontent.com/18080164/183227779-aa68d67b-38b4-478e-979e-aef01f97f93a.png)
![image](https://user-images.githubusercontent.com/18080164/183227795-55223484-ebca-46ab-bd4c-b38d4dae9562.png)


### Known issues
most likely all can be v2

[]unexpected behavior: if the tag exists, and the user uses the search and hits enter it (instead of selecting it), then it fails
feels like something with vuetify combobox
(Does not apply to new tag creation, or normal selection)

[]thoughts on deleting or editing tag names in general (not in Apply case which is already covered, but like global admin of tags)

[]should you be able to inherit tags from a dataset?
e.g. at time of creation it automatically adds tags to task based on attached dataset tags?
and/or how those tags "pass through" or get used...
I still think it's good to have tags on both but need to think about it more
[]some random console errors (more on vuetify side maybe?)

[]TESTS....

[]max width for tags e.g. in Dataset view

### Go generic?

The frontend is already pretty much generic to object type.
The backend, most of the functions are generic but the tables are concrete to each object.

Another option is to follow pattern we have been discussing for permissions, and make the Junction table itself generic with object type and object id. We would lose the foreign key validation, and some flexibility, but it would be less code, may be easier to add objects and maintain.

I think it really depends on how we want to use them in the system.  For example if we want to allow tags on individual files and tasks, then dedicated tables would probably be better. However, if we want to say allow it on "anything" e.g. for permissions reasons, then maybe generic. For example connections, etc. Again this pattern may depend on how we setup roles. If I can already assign a connection to a role, then the intersection with tags may be sort of redundant.  

Pablo maybe some you and I can talk about.

### Usage

On the frontend you can get basically everything by just doing

```
import tag_display_and_select from '@/components/tag/tag_display_and_select.vue'

            <tag_display_and_select
                :project_string_id="project_string_id"
                :object_id="job.id"
                :object_type="'job'"
            >
            </tag_display_and_select>
```

and if you want to seperate it out you can, directory_list is an example with

```
      <tag_display
            :object_id="data.item.directory_id"
            :object_type="'dataset'"
            :tag_display_refresh_trigger="tag_display_refresh_trigger"
                    >
      </tag_display>
```


