### PR TITLE
fix: performance fixes for projects with large dirs list

### DIFF
--- a/default/methods/project/view_project.py
+++ b/default/methods/project/view_project.py
@@ -2,155 +2,151 @@
 from methods.regular.regular_api import *
 
 
-@routes.route('/api/project/<string:project_string_id>/view',  
-			  methods=['GET'])
+@routes.route('/api/project/<string:project_string_id>/view',
+              methods = ['GET'])
 @Project_permissions.user_has_project(["allow_if_project_is_public",
-									   "admin", 
-									   "Editor", 
-									   "Viewer"])
-def project_view(project_string_id):        
-	"""
+                                       "admin",
+                                       "Editor",
+                                       "Viewer"])
+def project_view(project_string_id):
+    """
 
-	"""
+    """
 
-	with sessionMaker.session_scope() as session:
-		project = Project.get_project(session, project_string_id)
+    with sessionMaker.session_scope() as session:
+        project = Project.get_project(session, project_string_id)
 
-		if project.deletion_pending == True:
-			return jsonify("Project scheduled for deletion"), 200
+        if project.deletion_pending == True:
+            return jsonify("Project scheduled for deletion"), 200
 
-		if project is not None:
-			# not super happy with permission thing being here
+        if project is not None:
+            # not super happy with permission thing being here
 
-			# If the project is public and use is not logged in
-			# there won't be a permission to attach here right?
-			user = User.get(session)
-			user_permission_level = None
-			if user:
-				user_permission_level = user.serialize_with_permission_only(project_string_id)
+            # If the project is public and use is not logged in
+            # there won't be a permission to attach here right?
+            user = User.get(session)
+            user_permission_level = None
+            if user:
+                user_permission_level = user.serialize_with_permission_only(project_string_id)
 
-			# TODO move this into Project class?
-			if project.is_public is True:
-				project_serialized = project.serialize_public(session)
-			else:
-				project_serialized = project.serialize()
-			###
+            # TODO move this into Project class?
+            if project.is_public is True:
+                project_serialized = project.serialize_public(session)
+            else:
+                project_serialized = project.serialize()
+            ###
 
-			out = jsonify( user_permission_level = user_permission_level,
-							project = project_serialized)
-		else:
-			out = jsonify({"none_found" : True})
+            out = jsonify(user_permission_level = user_permission_level,
+                          project = project_serialized)
+        else:
+            out = jsonify({"none_found": True})
 
-		return out, 200, {'ContentType':'application/json'}
+        return out, 200, {'ContentType': 'application/json'}
 
 
-@routes.route('/api/project/<string:project_string_id>/checks',  
-			  methods=['POST'])
+@routes.route('/api/project/<string:project_string_id>/checks',
+              methods = ['POST'])
 @Project_permissions.user_has_project(
-	["allow_if_project_is_public", "admin", "Editor", "Viewer"])
-def project_checks_view(project_string_id):        
-	"""
+    ["allow_if_project_is_public", "admin", "Editor", "Viewer"])
+def project_checks_view(project_string_id):
+    """
 
-	"""
-	spec_list = [{"directory_id" : int}]
-	log, input, untrusted_input = regular_input.master(request=request,
-													   spec_list=spec_list)
-	if len(log["error"].keys()) >= 1:
-		return jsonify(log=log), 400
+    """
+    spec_list = [{"directory_id": int}]
+    log, input, untrusted_input = regular_input.master(request = request,
+                                                       spec_list = spec_list)
+    if len(log["error"].keys()) >= 1:
+        return jsonify(log = log), 400
 
-	with sessionMaker.session_scope() as session:
+    with sessionMaker.session_scope() as session:
 
-		project = Project.get_project(session, project_string_id)
+        project = Project.get_project(session, project_string_id)
 
-		directory = WorkingDir.get_with_fallback(
-				session = session,
-				directory_id = input['directory_id'],
-				project = project)
+        directory = WorkingDir.get_with_fallback(
+            session = session,
+            directory_id = input['directory_id'],
+            project = project)
 
-		if directory is False:
-			log['error']['directory'] = "No directory found"
-			return jsonify(log=log), 400
+        if directory is False:
+            log['error']['directory'] = "No directory found"
+            return jsonify(log = log), 400
 
-		out = jsonify({})
+        out = jsonify({})
 
-		return out, 200
-
-
-@routes.route('/api/project/<string:project_string_id>/transaction/ml/training/estimate',  
-			  methods=['GET'])
-@Project_permissions.user_has_project(["admin", 
-									   "Editor", 
-									   "Viewer"])
-def project_ml_estimate_view(project_string_id):        
-	"""
-
-	"""
-
-	with sessionMaker.session_scope() as session:
-		project = Project.get_project(session, project_string_id)
-
-		if project is not None:
-
-			# Temp estimate here since we aren't using ml transactions
-
-			new_estimate = { 
-				 "costs" : {
-					"Standard" : 1
-					},
-					"time" : {
-					   "Standard" : 90
-					}
-				}
-			
-			out = jsonify(success = True,
-						  new_estimate = new_estimate)
-		else:
-			out = jsonify({"none_found" : True})
-
-		return out, 200, {'ContentType':'application/json'}
+        return out, 200
 
 
-@routes.route('/api/project/<string:project_string_id>/branch/list',  
-			  methods=['GET'])
+@routes.route('/api/project/<string:project_string_id>/transaction/ml/training/estimate',
+              methods = ['GET'])
+@Project_permissions.user_has_project(["admin",
+                                       "Editor",
+                                       "Viewer"])
+def project_ml_estimate_view(project_string_id):
+    """
+
+    """
+
+    with sessionMaker.session_scope() as session:
+        project = Project.get_project(session, project_string_id)
+
+        if project is not None:
+
+            # Temp estimate here since we aren't using ml transactions
+
+            new_estimate = {
+                "costs": {
+                    "Standard": 1
+                },
+                "time": {
+                    "Standard": 90
+                }
+            }
+
+            out = jsonify(success = True,
+                          new_estimate = new_estimate)
+        else:
+            out = jsonify({"none_found": True})
+
+        return out, 200, {'ContentType': 'application/json'}
+
+
+@routes.route('/api/project/<string:project_string_id>/branch/list',
+              methods = ['GET'])
 @Project_permissions.user_has_project(["allow_if_project_is_public",
-									   "admin", 
-									   "Editor", 
-									   "Viewer"])
-def branch_list_view(project_string_id):        
-	"""
-	
-	"""
+                                       "admin",
+                                       "Editor",
+                                       "Viewer"])
+def branch_list_view(project_string_id):
+    """
 
-	with sessionMaker.session_scope() as session:
-		project = Project.get_project(session, project_string_id)
+    """
 
-		if project is not None:
+    with sessionMaker.session_scope() as session:
+        project = Project.get_project(session, project_string_id)
 
-			out = jsonify(branch_list = project.serialize_branch_list())
-		else:
-			out = jsonify({"none_found" : True})
+        if project is not None:
 
-		return out, 200, {'ContentType':'application/json'}
+            out = jsonify(branch_list = project.serialize_branch_list())
+        else:
+            out = jsonify({"none_found": True})
+
+        return out, 200, {'ContentType': 'application/json'}
 
 
-@routes.route('/api/project/<string:project_string_id>/annotation_project/checks',  
-			  methods=['GET'])
+@routes.route('/api/project/<string:project_string_id>/annotation_project/checks',
+              methods = ['GET'])
 @Project_permissions.user_has_project(["admin"])
-def annotation_project_view(project_string_id):        
+def annotation_project_view(project_string_id):
+    with sessionMaker.session_scope() as s:
+        project = Project.get_project(s, project_string_id)
 
-	with sessionMaker.session_scope() as s:
-		project = Project.get_project(s, project_string_id)
+        if project is not None:
 
-		if project is not None:
+            # TODO get cost estimate
+            # new_estimate = # something
 
-			# TODO get cost estimate
-			# new_estimate = # something
+            out = jsonify(project = project.serialize())
+        else:
+            out = jsonify({"none_found": True})
 
-			out = jsonify(project = project.serialize())
-		else:
-			out = jsonify({"none_found" : True})
-
-		return out, 200, {'ContentType':'application/json'}
-
-
-
+        return out, 200, {'ContentType': 'application/json'}

--- a/default/methods/source_control/working_dir/directory_update.py
+++ b/default/methods/source_control/working_dir/directory_update.py
@@ -50,8 +50,7 @@ def update_directory_api(project_string_id):
 
         log['success'] = True
         return jsonify(
-            log=log,
-            project=project.serialize()), 200
+            log=log), 200
 
 
 def update_directory_core(

--- a/default/methods/source_control/working_dir/new_directory.py
+++ b/default/methods/source_control/working_dir/new_directory.py
@@ -102,13 +102,10 @@ def new_directory_api(project_string_id):
             project_id = project.id,
             email = user_email
         )
-
         ####
 
         session.flush()  # to get id
-
         log['success'] = True
         out = jsonify(log = log,
-                      new_directory = directory.serialize(),
-                      project = project.serialize())
+                      new_directory = directory.serialize())
         return out, 200

--- a/frontend/src/components/user/home/annotator_dashboard.vue
+++ b/frontend/src/components/user/home/annotator_dashboard.vue
@@ -162,14 +162,14 @@
       </v-card>
     </v-container>
 
-    <v-container>
-      <v-card>
-        <v-container>
-          <h2>My Visit History</h2>
-             <user_visit_history_list :project_string_id="project_string_id"></user_visit_history_list>
-          </v-container>
-      </v-card>
-    </v-container>
+<!--    <v-container>-->
+<!--      <v-card>-->
+<!--        <v-container>-->
+<!--          <h2>My Visit History</h2>-->
+<!--             <user_visit_history_list :project_string_id="project_string_id"></user_visit_history_list>-->
+<!--          </v-container>-->
+<!--      </v-card>-->
+<!--    </v-container>-->
 
     <v-snackbar v-model="no_task_snackbar" color="red">
       No tasks available

--- a/frontend/src/components/user/home/dashboard.vue
+++ b/frontend/src/components/user/home/dashboard.vue
@@ -116,15 +116,15 @@
 
         <v-layout>
           <v-row>
-            <v-col cols="3">
-              <v-card>
-                <v-card-title>Visit History:</v-card-title>
-                <v-card-text>
-                  <user_visit_history_list :project_string_id="project_string_id"></user_visit_history_list>
-                </v-card-text>
-              </v-card>
-            </v-col>
-            <v-col cols="9">
+<!--            <v-col cols="3">-->
+<!--              <v-card>-->
+<!--                <v-card-title>Visit History:</v-card-title>-->
+<!--                <v-card-text>-->
+<!--                  <user_visit_history_list :project_string_id="project_string_id"></user_visit_history_list>-->
+<!--                </v-card-text>-->
+<!--              </v-card>-->
+<!--            </v-col>-->
+            <v-col cols="12">
 
               <v-card >
                 <v-card-title>Reports: </v-card-title>

--- a/shared/alembic/versions_opencore/alembic_2022_10_13_06_51_61977555605b_new_indexes_for_dirs_and_events.py
+++ b/shared/alembic/versions_opencore/alembic_2022_10_13_06_51_61977555605b_new_indexes_for_dirs_and_events.py
@@ -1,0 +1,31 @@
+"""New Indexes for Dirs and Events
+
+Revision ID: 61977555605b
+Revises: 072c6491c0b5
+Create Date: 2022-10-13 06:51:09.963573
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '61977555605b'
+down_revision = '072c6491c0b5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.create_index('index__project_directory_list_project', 'project_directory_list', ['project_id'],
+                        postgresql_concurrently = True)
+        op.create_index('index__project_directory_list_dir', 'project_directory_list', ['working_dir_id'],
+                        postgresql_concurrently = True)
+        op.create_index('index__project_directory_dir_nickname', 'project_directory_list', ['project_id', 'working_dir_id', 'nickname'],
+                        postgresql_concurrently = True)
+
+
+def downgrade():
+    op.drop_index('index__project_directory_list_project', 'project_directory_list')
+    op.drop_index('index__project_directory_list_dir', 'project_directory_list')
+    op.drop_index('index__project_directory_dir_nickname', 'project_directory_list')

--- a/shared/database/project.py
+++ b/shared/database/project.py
@@ -399,7 +399,7 @@ class Project(Base, Caching):
     def regenerate_directory_list_cache(self):
         return self.regenerate_cache_by_key(
             'directory_list',
-            self.serialize_directory_list)
+            self.gen_initial_dir_list)
 
     def refresh_label_dict(self, session):
 
@@ -626,13 +626,15 @@ class Project(Base, Caching):
             'project_string_id': self.project_string_id
         }
 
-    def serialize_directory_list(self):
+    def gen_initial_dir_list(self):
 
         if not self.directory_list:
             return None
-
+        # Limiting to a max of 100 dirs. This code should be eventually removed from the project.
+        # The correct way should be calling the dir/list endpoint and use pagination.
+        limit = 100
         directory_list = []
-        for directory in self.directory_list:
+        for directory in self.directory_list[0:limit]:
 
             # TODO better to do in SQL
             if directory.archived is True:

--- a/shared/database/source_control/working_dir.py
+++ b/shared/database/source_control/working_dir.py
@@ -162,7 +162,10 @@ class WorkingDir(Base):
         from shared.database.project import Project
         project = Project.get_by_id(session = session, id = project_id)
         query = session.query(WorkingDir).filter(
-            WorkingDir.project_id == project_id)
+            WorkingDir.project_id == project_id,
+            or_(WorkingDir.archived == False, WorkingDir.archived.is_(None))
+
+        )
 
         from shared.database.permissions.roles import ValidObjectTypes
 


### PR DESCRIPTION
## Description
* Remove project serialization on endpoints to avoid rendering a full list of dirs.
* Limited the number of dirs to be added to project's cache

Eventually I think the best way to go is to completely remove the cache of dirs in project. The only reason for it's existence is for having a dir to get when changing projects. But the correct way should be to have a paginated dir list and then go to the first dir on that paginated list. That way the backend will not serialize huge jsons when there are 3K dirs on a project.

Other thing that was removed is the user visit history component. The query is now extremely slow due to the event table having no indexes. We cannot add indexes to this table since it is very write intensive. For now I'll remove it until we have the time to define a better way to store and query events.

### Author Checklist
_All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues._

I have...

* [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x]  added `!` to the type prefix if API or client breaking change
* [x]  provided a link to the relevant issue in JIRA or Github Link in PR.
* [x]  included the necessary unit and integration
* [x]  included comments & docs for new API Endpoints
* [x]  updated the relevant documentation or specification in readme.io
* [x]  reviewed "Files changed" and left comments if necessary
* [x]  confirmed all CI checks have passed

### Reviewers Checklist
_All items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items._

I have...

* [x]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x]  confirmed `!` in the type prefix if API or client breaking change
* [x]  confirmed all author checklist items have been addressed
* [x]  reviewed API design and naming
* [x]  reviewed documentation is accurate
* [x]  reviewed tests and test coverage
* [x]  manually tested (if applicable)