### PR TITLE
Fix: Optimize Signed URL Fetch on task context

### DIFF
--- a/default/methods/source_control/file/file_get_signed_url.py
+++ b/default/methods/source_control/file/file_get_signed_url.py
@@ -21,6 +21,8 @@ def api_file_get_signed_url(project_string_id, file_id):
        """
     # For now, no filters needed. But might add in the future.
     log = regular_log.default()
+    create_thumbnails = request.args['create_thumbnails']
+    create_thumbnails = False if create_thumbnails == 'false' else False
     with sessionMaker.session_scope() as session:
         project = Project.get_by_string_id(session, project_string_id)
         member = get_member(session)
@@ -29,7 +31,8 @@ def api_file_get_signed_url(project_string_id, file_id):
             log = log,
             project = project,
             member = member,
-            file_id = file_id
+            file_id = file_id,
+            create_thumbnails = create_thumbnails,
         )
         if len(log["error"].keys()) >= 1:
             return jsonify(log = log), 400
@@ -41,7 +44,8 @@ def get_file_signed_url_core(session: Session,
                              project: Project,
                              file_id: int,
                              member: Member,
-                             log: dict = regular_log.default()):
+                             log: dict = regular_log.default(),
+                             create_thumbnails: bool = True):
     """
         List comments of the discussion. At this point we assume data has been validated so no extra checks are
         done to the input data.
@@ -67,7 +71,8 @@ def get_file_signed_url_core(session: Session,
                                                                            connection_id = file.connection_id,
                                                                            bucket_name = file.bucket_name,
                                                                            reference_file = file,
-                                                                           regen_url = True)
+                                                                           regen_url = True,
+                                                                           create_thumbnails = True)
     elif file.type == "video":
         if file.video:
             file_data[file.type] = file.video.serialize_list_view(session = session,
@@ -79,21 +84,24 @@ def get_file_signed_url_core(session: Session,
             file_data[file.type] = file.text_file.serialize(session = session,
                                                             connection_id = file.connection_id,
                                                             bucket_name = file.bucket_name,
-                                                            regen_url = True)
+                                                            regen_url = True,
+                                                            create_thumbnails = True)
 
     elif file.type == "geospatial":
         file_data[file.type] = {
             'layers': file.serialize_geospatial_assets(session = session,
                                                        connection_id = file.connection_id,
                                                        bucket_name = file.bucket_name,
-                                                       regen_url = True)
+                                                       regen_url = True,
+                                                       create_thumbnails = True)
         }
     if file.type == "audio":
         if file.audio_file:
             file_data[file.type] = file.audio_file.serialize(session = session,
                                                              connection_id = file.connection_id,
                                                              bucket_name = file.bucket_name,
-                                                             regen_url = True)
+                                                             regen_url = True,
+                                                             create_thumbnails = True)
 
     elif file.type == "sensor_fusion":
         point_cloud_file = file.get_child_point_cloud_file(session = session)
@@ -101,6 +109,7 @@ def get_file_signed_url_core(session: Session,
             file_data['point_cloud'] = point_cloud_file.point_cloud.serialize(session = session,
                                                                               connection_id = file.connection_id,
                                                                               bucket_name = file.bucket_name,
-                                                                              regen_url = True)
+                                                                              regen_url = True,
+                                                                              create_thumbnails = True)
     
     return file_data, log

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -1129,6 +1129,7 @@ export default Vue.extend({
     },
     task: {
       handler(newVal, oldVal) {
+        console.log('WATCHER TASK', newVal, oldVal)
         if (newVal != oldVal) {
           this.on_change_current_task();
         }
@@ -3437,6 +3438,7 @@ export default Vue.extend({
       if (this.$props.file) {
         this.on_change_current_file();
       } else if (this.$props.task) {
+        console.log('CREATED TASK ANN CORE')
         this.on_change_current_task();
       }
 
@@ -7270,58 +7272,6 @@ export default Vue.extend({
     trigger_refresh_with_delay: function () {
       setTimeout(() => (this.refresh = Date.now()), 80);
     },
-    get_parent_instance_list_for_video: async function(){
-      let url = undefined;
-      let file = this.$props.file;
-      let payload = {}
-      if (this.$store.getters.is_on_public_project) {
-        url = `/api/project/${this.$props.project_string_id}/file/${this.$props.file.id}/annotation/list`;
-        payload = {
-          directory_id:
-          this.$store.state.project.current_directory.directory_id,
-          job_id: this.job_id,
-          attached_to_job: file.attached_to_job,
-        };
-      } else if (this.$store.state.builder_or_trainer.mode == "builder") {
-        if (this.task && this.task.id) {
-          if(this.task.id === '-1' || this.task.id === -1){
-            return
-          }
-          // If a task is present, prefer this route to handle permissions
-          url = "/api/v1/task/" + this.task.id + "/annotation/list";
-          file = this.$props.task.file;
-        } else {
-          url = `/api/project/${this.$props.project_string_id}/file/${this.$props.file.id}/annotation/list`;
-        }
-        payload = {
-          directory_id:
-          this.$store.state.project.current_directory.directory_id,
-          job_id: this.job_id,
-          attached_to_job: file.attached_to_job,
-        };
-      }
-      else if (this.$store.state.builder_or_trainer.mode == "trainer") {
-        if(this.task.id === '-1' || this.task.id === -1){
-          return
-        }
-        url = "/api/v1/task/" + this.task.id + "/annotation/list";
-      }
-      try {
-        const response = await axios.post(url, payload);
-        if (response.data['file_serialized']) {
-          let new_instance_list = this.create_instance_list_with_class_types(
-            response.data['file_serialized']['instance_list']
-          );
-          this.video_parent_file_instance_list = new_instance_list
-        }
-        this.annotations_loading = false;
-        this.trigger_refresh_with_delay();
-      } catch (error) {
-        console.error(error);
-        this.loading = false;
-      }
-
-    },
     get_instance_list_for_image: async function () {
       let url = undefined;
       let file = this.$props.file;
@@ -7829,7 +7779,6 @@ export default Vue.extend({
           }
           this.html_image = new_image;
           this.refresh = Date.now();
-          await this.get_parent_instance_list_for_video();
           await this.get_instances();
           this.canvas_width = file.image.width;
           this.canvas_height = file.image.height;

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -1129,7 +1129,6 @@ export default Vue.extend({
     },
     task: {
       handler(newVal, oldVal) {
-        console.log('WATCHER TASK', newVal, oldVal)
         if (newVal != oldVal) {
           this.on_change_current_task();
         }
@@ -3215,7 +3214,6 @@ export default Vue.extend({
       // If we only want one can just pass that singluar instance as the "focus" one
       // this.instance_list[index].focused = True
       // careful can't use id, since newly created instances won't have an ID!
-      console.log('FOCUSSS', focus)
       this.instance_focused_index = focus.index;
       this.selected_instance_list = [
         this.instance_list[this.instance_focused_index],
@@ -3438,7 +3436,6 @@ export default Vue.extend({
       if (this.$props.file) {
         this.on_change_current_file();
       } else if (this.$props.task) {
-        console.log('CREATED TASK ANN CORE')
         this.on_change_current_task();
       }
 
@@ -3695,7 +3692,6 @@ export default Vue.extend({
       }
       await this.$nextTick();
       this.$refs.toolbar.set_mode(this.current_instance_template.mode)
-      console.log('AAAA', this.current_instance_template, this.current_instance_template.mode === 'guided' && this.draw_mode)
       if(this.current_instance_template.mode === 'guided' && this.draw_mode){
         this.show_snackbar_guided_keypoints_drawing(1);
       }

--- a/frontend/src/components/annotation/annotation_ui_factory.vue
+++ b/frontend/src/components/annotation/annotation_ui_factory.vue
@@ -129,6 +129,7 @@
         ref="file_manager_sheet"
         :project_string_id="computed_project_string_id"
         :task="task"
+        :context="context"
         :view_only="view_only"
         :enabled_edit_schema="enabled_edit_schema"
         :show_explorer_full_screen="show_explorer_full_screen"
@@ -258,6 +259,7 @@ export default Vue.extend({
       loading: false,
       loading_project: true,
       task: null,
+      context: null,
       current_file: null,
       error: null,
       request_save: false,
@@ -314,12 +316,13 @@ export default Vue.extend({
       }
 
     }
-
+    this.context = 'file'
     if (
       !this.$store.getters.is_on_public_project ||
       this.$store.state.user.current.is_super_admin == true
     ) {
       if (this.$props.task_id_prop) {
+        this.context = 'task'
         this.add_visit_history_event("task");
       } else if (this.$props.file_id_prop) {
         this.add_visit_history_event("file");
@@ -536,6 +539,7 @@ export default Vue.extend({
     },
 
     change_file: async function (file, model_runs, color_list) {
+      console.log('CHANGE FILE')
       this.changing_file = true
       this.current_file = file;
       await this.$nextTick();

--- a/frontend/src/components/annotation/annotation_ui_factory.vue
+++ b/frontend/src/components/annotation/annotation_ui_factory.vue
@@ -539,7 +539,6 @@ export default Vue.extend({
     },
 
     change_file: async function (file, model_runs, color_list) {
-      console.log('CHANGE FILE')
       this.changing_file = true
       this.current_file = file;
       await this.$nextTick();
@@ -667,7 +666,6 @@ export default Vue.extend({
             assign_to_user: assign_to_user,
           }
         );
-        console.log(response)
         if (response.data) {
           if (response.data.task && response.data.task.id !== task.id) {
             this.$router.push(`/task/${response.data.task.id}`);

--- a/frontend/src/components/annotation/media_core.vue
+++ b/frontend/src/components/annotation/media_core.vue
@@ -1395,7 +1395,8 @@ import Compound_file_preview from "../source_control/compound_file_preview.vue";
       if(!file){
         return
       }
-      let [url_data, err] = await get_file_signed_url(project_string_id, file.id);
+      let create_thumbnails = this.context === 'task' ? false : true
+      let [url_data, err] = await get_file_signed_url(project_string_id, file.id, create_thumbnails);
       if (err){
         this.error = this.$route_api_errors(err)
       }

--- a/frontend/src/components/annotation/media_core.vue
+++ b/frontend/src/components/annotation/media_core.vue
@@ -938,6 +938,10 @@ import Compound_file_preview from "../source_control/compound_file_preview.vue";
         type: Boolean,
         default: false
        },
+      'context':{
+        type: String,
+        default: null
+      }
 
 
     },
@@ -1318,7 +1322,6 @@ import Compound_file_preview from "../source_control/compound_file_preview.vue";
     },
 
     get_media: async function (fetch_single_file = true, file_id) {
-      console.log('GET MEDIA', fetch_single_file, file_id)
       this.loading = true
       this.error = {}   // reset
       this.media_loading = true;
@@ -1405,6 +1408,10 @@ import Compound_file_preview from "../source_control/compound_file_preview.vue";
       }
     },
     fetch_file_list_signed_urls: async function(file_list){
+
+      if(this.context === 'task'){
+        return
+      }
       for (let file of file_list){
         this.fetch_single_file_signed_url(file, this.$props.project_string_id)
       }

--- a/frontend/src/components/source_control/file_manager_sheet.vue
+++ b/frontend/src/components/source_control/file_manager_sheet.vue
@@ -82,6 +82,7 @@
                               :project_string_id="project_string_id"
                               file_view_mode="annotation"
                               :task="task"
+                              :context="context"
                               :full_screen="full_screen"
                               :view_only_mode="view_only"
                               :file_id_prop="file_id_prop"
@@ -147,6 +148,7 @@
       'show_explorer_full_screen',
       'enabled_edit_schema',
       'initializing',
+      'context',
 
     ],
     components:{

--- a/frontend/src/services/fileServices.ts
+++ b/frontend/src/services/fileServices.ts
@@ -20,10 +20,12 @@ export const get_file_list = async (project_string_id, user_name, metadata) => {
   }
 }
 
-export const get_file_signed_url = async (project_string_id, file_id) => {
+export const get_file_signed_url = async (project_string_id: string, file_id: number, create_thumbnails: boolean = true) => {
   let url = `/api/project/${project_string_id}/file/${file_id}/get-signed-url`
   try {
-    const response = await axios.get(url)
+    const response = await axios.get(url, {
+      params:{ create_thumbnails: create_thumbnails}
+    })
 
     return [response.data, null]
   } catch(e) {

--- a/shared/database/audio/audio_file.py
+++ b/shared/database/audio/audio_file.py
@@ -28,13 +28,14 @@ class AudioFile(Base, SerializerMixin):
     def get_by_id(session, id):
         return session.query(AudioFile).filter(AudioFile.id == id).first()
 
-    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True):
+    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True, create_thumbnails = True):
         if regen_url:
             from shared.url_generation import blob_regenerate_url
             blob_regenerate_url(blob_object = self,
                                 session = session,
                                 connection_id = connection_id,
-                                bucket_name = bucket_name)
+                                bucket_name = bucket_name,
+                                create_thumbnails = create_thumbnails)
 
         data = self.to_dict(rules = ())
 

--- a/shared/database/image.py
+++ b/shared/database/image.py
@@ -78,14 +78,16 @@ class Image(Base):
                                      connection_id = None,
                                      bucket_name = None,
                                      reference_file: 'File' = None,
-                                     regen_url = True):
+                                     regen_url = True,
+                                     create_thumbnails: bool = True):
         if regen_url:
             from shared.url_generation import blob_regenerate_url
             blob_regenerate_url(blob_object = self,
                                 session = session,
                                 connection_id = connection_id,
                                 bucket_name = bucket_name,
-                                reference_file = reference_file)
+                                reference_file = reference_file,
+                                create_thumbnails = create_thumbnails)
         return {
             'original_filename': self.original_filename,
             'width': self.width,

--- a/shared/database/source_control/file.py
+++ b/shared/database/source_control/file.py
@@ -381,12 +381,12 @@ class File(Base, Caching):
         ).all()
         return assets
 
-    def serialize_geospatial_assets(self, session, connection_id = None, bucket_name = None, regen_url = True):
+    def serialize_geospatial_assets(self, session, connection_id = None, bucket_name = None, regen_url = True, create_thumbnails: bool = True):
         assets_list = self.get_geo_assets(session)
         result = []
         for asset in assets_list:
             result.append(asset.serialize(session, connection_id = connection_id, bucket_name = bucket_name,
-                                          regen_url = regen_url))
+                                          regen_url = regen_url, create_thumbnails = create_thumbnails))
         return result
 
     def serialize_with_type(self, session = None, regen_url = True):

--- a/shared/database/text_file.py
+++ b/shared/database/text_file.py
@@ -67,13 +67,14 @@ class TextFile(Base):
         }
         return text
 
-    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True):
+    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True, create_thumbnails = True):
         if regen_url:
             from shared.url_generation import blob_regenerate_url
             blob_regenerate_url(blob_object = self,
                                 session = session,
                                 connection_id = connection_id,
-                                bucket_name = bucket_name)
+                                bucket_name = bucket_name,
+                                create_thumbnails = create_thumbnails)
 
         text = {
             'original_filename': self.original_filename,

--- a/shared/url_generation.py
+++ b/shared/url_generation.py
@@ -277,7 +277,8 @@ def connection_url_regenerate(session: Session,
                               bucket_name: str,
                               new_offset_in_seconds: int,
                               access_token: str = None,
-                              reference_file: File = None) -> [DiffgramBlobObjectType, dict]:
+                              reference_file: File = None,
+                              create_thumbnails: bool = True) -> [DiffgramBlobObjectType, dict]:
     """
         Regenerates signed url from the given connection ID, bucket and blob path.
     :param session:
@@ -317,7 +318,7 @@ def connection_url_regenerate(session: Session,
     blob_object.url_signed = signed_url
 
     # Extra assets (Depending on type)
-    if type(blob_object) == Image:
+    if type(blob_object) == Image and create_thumbnails:
         blob_object, url = generate_thumbnails_for_image(
             session = session,
             log = log,
@@ -345,10 +346,11 @@ def connection_url_regenerate(session: Session,
 
 def blob_regenerate_url(blob_object: DiffgramBlobObjectType,
                         session: Session,
-                        connection_id = None,
-                        bucket_name = None,
-                        access_token = None,
-                        reference_file: File = None) -> [str, dict]:
+                        connection_id: int = None,
+                        bucket_name: str = None,
+                        access_token: str = None,
+                        reference_file: File = None,
+                        create_thumbnails: bool = True) -> [str, dict]:
     """
         Regenerates the signed url of the given blob object.
     :param blob_object:
@@ -386,7 +388,8 @@ def blob_regenerate_url(blob_object: DiffgramBlobObjectType,
             bucket_name = bucket_name,
             new_offset_in_seconds = new_offset_in_seconds,
             reference_file = reference_file,
-            access_token = access_token
+            access_token = access_token,
+            create_thumbnails = create_thumbnails
         )
 
     if regular_log.log_has_error(log):


### PR DESCRIPTION
## Description
* Removes duplicate calls to instance list fetch for images in general.
* Removes calls to get signed url on file list when being on task context.
* Avoid thumbnail generation on first fetch if file is first opened in task context.

### Author Checklist
_All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues._

I have...

* [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ]  added `!` to the type prefix if API or client breaking change
* [ ]  provided a link to the relevant issue in JIRA or Github Link in PR.
* [ ]  included the necessary unit and integration
* [ ]  included comments & docs for new API Endpoints
* [ ]  updated the relevant documentation or specification in readme.io
* [ ]  reviewed "Files changed" and left comments if necessary
* [ ]  confirmed all CI checks have passed

### Reviewers Checklist
_All items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items._

I have...

* [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ]  confirmed `!` in the type prefix if API or client breaking change
* [ ]  confirmed all author checklist items have been addressed
* [ ]  reviewed API design and naming
* [ ]  reviewed documentation is accurate
* [ ]  reviewed tests and test coverage
* [ ]  manually tested (if applicable)