### PR TITLE
AI-35: feat: open first global attribute panel by default

### DIFF
--- a/frontend/src/components/attribute/attribute_group_list.vue
+++ b/frontend/src/components/attribute/attribute_group_list.vue
@@ -215,6 +215,9 @@ import attribute_group_new from './attribute_group_new.vue'
       attribute_group_list_prop() {
         this.attribute_group_list = this.attribute_group_list_prop
         this.attribute_group_list_computed
+        if(this.attribute_group_list.length > 0 && this.openedPanel == undefined){
+          this.openedPanel = 0
+        }
       },
       current_instance(){
         this.fetch_current_instance_missing_attributes("from_project")
@@ -253,7 +256,9 @@ import attribute_group_new from './attribute_group_new.vue'
       if (this.$route.query.attribute_group) {
         this.open_panel_by_id(this.$route.query.attribute_group)
       }
-
+      if(this.attribute_group_list.length > 0 && this.openedPanel == undefined){
+        this.openedPanel = 0
+      }
     },
     destroyed() {
       this.refresh_watcher() // destroy

--- a/frontend/src/components/attribute/global_attributes_list.vue
+++ b/frontend/src/components/attribute/global_attributes_list.vue
@@ -83,15 +83,19 @@ import attribute_group_list from './attribute_group_list.vue';
         loading: false,
         error: {},
         success: false,
-        open: true
+        open: undefined
       }
     },
 
     watch: {
 
     },
-
-    created() {
+    mounted() {
+     if(this.global_attribute_groups_list.length > 0 ){
+       this.open = 0
+     }
+    },
+  created() {
 
 
     },


### PR DESCRIPTION
## Description
Leaves the first global attribute opened by default when opening a file that has at least 1 global attributes on its schema.

### Author Checklist
_All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues._

I have...

* [x]  added `!` to the type prefix if Breaking Changes.
* [x]  considered the impact to the SDK.
* [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x]  provided a link to the relevant issue in JIRA or Github Link in PR.
* [x]  included the unit and integration tests
* [x]  included comments & docs for new API Endpoints
* [x]  updated the relevant documentation or specification in readme.io
* [x]  reviewed "Files changed" and left comments if necessary
* [ ]  confirmed all CI checks have passed

Breaking Changes including adding required params.

### Reviewers Checklist
_All items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items._

I have...

* [x]  confirmed the Author checklist was followed
* [ ]  reviewed API design and naming
* [ ]  reviewed documentation is accurate
* [ ]  reviewed tests and test coverage
* [ ]  manually tested (if applicable)