### PR TITLE
Fix: Avoid creating thumbnails Once generated

### DIFF
--- a/frontend/cypress/e2e/diffgram/annotate_files/08_video_annotation_tools.cy.js
+++ b/frontend/cypress/e2e/diffgram/annotate_files/08_video_annotation_tools.cy.js
@@ -15,7 +15,7 @@ describe('Annotate Files Tests', () => {
       cy.gotToProject(testUser.project_string_id);
       cy.createLabels(testLabels)
       cy.uploadAndViewSampleVideo(testUser.project_string_id);
-      cy.wait(3500);
+      cy.wait(6500);
 
     })
 

--- a/frontend/src/components/annotation/media_core.vue
+++ b/frontend/src/components/annotation/media_core.vue
@@ -1396,7 +1396,7 @@ import Compound_file_preview from "../source_control/compound_file_preview.vue";
       if(!file){
         return
       }
-      let create_thumbnails = this.context === 'task' ? false : true
+      let create_thumbnails = this.context === 'task' || file.image.url_signed_blob_path   ? false : true
       let [url_data, err] = await get_file_signed_url(project_string_id, file.id, create_thumbnails);
       if (err){
         this.error = this.$route_api_errors(err)


### PR DESCRIPTION
## Description
Avoids thumbnail creation once generated.

### Author Checklist
_All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues._

I have...

* [ ]  added `!` to the type prefix if Breaking Changes.
* [ ]  considered the impact to the SDK.
* [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ]  provided a link to the relevant issue in JIRA or Github Link in PR.
* [ ]  included the unit and integration tests
* [ ]  included comments & docs for new API Endpoints
* [ ]  updated the relevant documentation or specification in readme.io
* [ ]  reviewed "Files changed" and left comments if necessary
* [ ]  confirmed all CI checks have passed

Breaking Changes including adding required params.

### Reviewers Checklist
_All items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items._

I have...

* [ ]  confirmed the Author checklist was followed
* [ ]  reviewed API design and naming
* [ ]  reviewed documentation is accurate
* [ ]  reviewed tests and test coverage
* [ ]  manually tested (if applicable)