### PR TITLE
fix: Add Partial Indexes to nullable parent ID column

### DIFF
--- a/default/tests/shared/query_engine/expressions/test_dataset.py
+++ b/default/tests/shared/query_engine/expressions/test_dataset.py
@@ -46,4 +46,4 @@ class TestDatasetCompareExpression(testing_setup.DiffgramBaseTestCase):
         )
         self.assertEqual(type(expr), DatasetCompareExpression)
         expr.build_expression_subquery(session = self.session)
-        self.assertIsNotNone(expr.subquery)
+        self.assertIsNotNone(expr.expression)

--- a/frontend/src/components/source_control/file_preview.vue
+++ b/frontend/src/components/source_control/file_preview.vue
@@ -53,9 +53,10 @@
       />
     </div>
     <div
+      v-if="file.type === 'video'"
       class="pa-0 ma-0 drawable-wrapper"
       :style="{border: selected ? '4px solid #1565c0' : '4px solid #e0e0e0', height: `${file_preview_height + 8}px`, position: 'relative'}"
-      v-if="file.type === 'video'" ref="file_card">
+      ref="file_card">
       <file_preview_details_card
         v-if="show_preview_details"
         :file="file"
@@ -84,6 +85,32 @@
         @update_instance_list="set_video_instance_list"
       >
       </video_drawable_canvas>
+    </div>
+    <div
+      v-if="file.type === 'text'"
+      class="pa-0 ma-0 drawable-wrapper"
+      :style="{border: selected ? '4px solid #1565c0' : '4px solid #e0e0e0', height: `${file_preview_height + 8}px`, position: 'relative'}"
+      ref="file_card"
+
+    >
+      <file_preview_details_card
+        v-if="show_preview_details"
+        :file="file"
+        :file_preview_height="file_preview_height"
+        :file_preview_width="file_preview_width"
+      ></file_preview_details_card>
+      <div v-if="file.type === 'text'" :style="`width: ${file_preview_width}; position: relative;`">
+        <v-icon :size="file_preview_width" class="ma-0 pa-0">
+          mdi-script-text
+        </v-icon>
+
+      </div>
+      <v-skeleton-loader
+        v-else
+        type="image"
+        :width="128"
+        :height="128"
+      />
     </div>
     <div v-if="file.type === 'compound'"
          class="pa-0 ma-0 drawable-wrapper"

--- a/shared/alembic/env.py
+++ b/shared/alembic/env.py
@@ -43,7 +43,7 @@ def run_migrations_offline():
         url=url,
         target_metadata=target_metadata,
         literal_binds=True,
-        dialect_opts={"paramstyle": "named"},
+        dialect_opts={"paramstyle": "named", "statement_timeout": 1, "idle_in_transaction_session_timeout": 1},
     )
 
     with context.begin_transaction():
@@ -58,9 +58,11 @@ def run_migrations_online():
 
     """
     connectable = engine_from_config(
+
         config.get_section(config.config_ini_section),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        connect_args = {"options": "-c statement_timeout=270000 -c idle_in_transaction_session_timeout=270000"} # 4.5 mins timeout
     )
 
     with connectable.connect() as connection:

--- a/shared/alembic/versions_opencore/alembic_2022_11_25_10_07_4748c936ca87_index_dataset_explorer.py
+++ b/shared/alembic/versions_opencore/alembic_2022_11_25_10_07_4748c936ca87_index_dataset_explorer.py
@@ -17,14 +17,8 @@ depends_on = None
 
 
 def upgrade():
-    op.create_index('index__project_id_parent_id_type', 'file', ['project_id', 'state', 'type', 'parent_id'])
-    op.create_index(
-        'index__parent_files',
-        'file',
-        ['project_id', 'parent_id'],
-        postgresql_where = text("file.parent_id IS NOT Null"))
+    op.create_index('index__project_id_parent_id_type', 'file', ['project_id', 'state', 'parent_id', 'type'])
 
 
 def downgrade():
     op.drop_index('index__project_id_parent_id_type', 'file')
-    op.drop_index('index__parent_files', 'file')

--- a/shared/alembic/versions_opencore/alembic_2022_11_25_10_07_4748c936ca87_index_dataset_explorer.py
+++ b/shared/alembic/versions_opencore/alembic_2022_11_25_10_07_4748c936ca87_index_dataset_explorer.py
@@ -1,0 +1,30 @@
+"""Index dataset explorer
+
+Revision ID: 4748c936ca87
+Revises: 25580ca9875a
+Create Date: 2022-11-25 10:07:58.317453
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = '4748c936ca87'
+down_revision = '25580ca9875a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('index__project_id_parent_id_type', 'file', ['project_id', 'state', 'type', 'parent_id'])
+    op.create_index(
+        'index__parent_files',
+        'file',
+        ['project_id', 'parent_id'],
+        postgresql_where = text("file.parent_id IS NOT Null"))
+
+
+def downgrade():
+    op.drop_index('index__project_id_parent_id_type', 'file')
+    op.drop_index('index__parent_files', 'file')

--- a/shared/query_engine/expressions/expressions.py
+++ b/shared/query_engine/expressions/expressions.py
@@ -6,7 +6,7 @@ from sqlalchemy.sql.expression import BooleanClauseList
 from shared.shared_logger import get_shared_logger
 from shared.database.source_control.file_stats import FileStats
 from sqlalchemy.sql.elements import FunctionFilter
-from sqlalchemy.sql.expression import and_, or_
+from sqlalchemy.sql.expression import and_, or_, BinaryExpression
 from shared.query_engine.sql_alchemy_query_elements.query_elements import QueryElement, CompareOperator, QueryEntity
 from shared.query_engine.sql_alchemy_query_elements.scalar import ScalarQueryElement
 
@@ -27,6 +27,7 @@ class CompareExpression:
     operator: CompareOperator
     query_right: QueryElement
     subquery: Selectable
+    expression: BinaryExpression
     left_raw: Token or object
     compare_op_raw: Token or object
     right_raw: Token or object

--- a/shared/query_engine/sqlalchemy_query_exectutor.py
+++ b/shared/query_engine/sqlalchemy_query_exectutor.py
@@ -32,7 +32,7 @@ class SqlAlchemyQueryExecutor(BaseDiffgramQueryExecutor):
             File.project_id == self.diffgram_query.project.id,
             File.state != 'removed',
             File.parent_id == None,
-            File.type.in_(['video', 'image', 'compound'])
+            File.type.in_(['video', 'image', 'compound', 'text'])
         )
 
 


### PR DESCRIPTION
## Description
The reason dataset explorer queries where now slower was due to the new condition `file.parent_id IS NOT NULL`. It seems that 'normal' indexes tend to ignore nullable columns, so you have to go with either adding an order statement to the index, or a partial index (this PR).

Now the slow query takes about 3-4 seconds to respond

### Author Checklist
_All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues._

I have...

* [ ]  added `!` to the type prefix if Breaking Changes.
* [ ]  considered the impact to the SDK.
* [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ]  provided a link to the relevant issue in JIRA or Github Link in PR.
* [ ]  included the unit and integration tests
* [ ]  included comments & docs for new API Endpoints
* [ ]  updated the relevant documentation or specification in readme.io
* [ ]  reviewed "Files changed" and left comments if necessary
* [ ]  confirmed all CI checks have passed

Breaking Changes including adding required params.

### Reviewers Checklist
_All items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items._

I have...

* [ ]  confirmed the Author checklist was followed
* [ ]  reviewed API design and naming
* [ ]  reviewed documentation is accurate
* [ ]  reviewed tests and test coverage
* [ ]  manually tested (if applicable)