### PR TITLE
Instance Store

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -1094,7 +1094,7 @@ export default Vue.extend({
   },
   watch: {
     instance_list: function(newVal) {
-      this.instance_store.set_instance_list(this.file.id, newVal)
+      this.instance_store.set_instance_list(this.file_id, newVal)
     },
     finish_annotation_show: function (val) {
       if (val) this.annotation_show_on = false;
@@ -1586,6 +1586,10 @@ export default Vue.extend({
     };
   },
   computed: {
+    file_id: function() {
+      if (!this.task) return this.file.id
+      else return this.task.file.id
+    },
     label_file_map: function () {
       let result = {}
       for (let elm of this.label_list) {

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -7498,7 +7498,7 @@ export default Vue.extend({
           this.instance_list = this.instance_buffer_dict[this.current_frame];
         } else {
           // handle if buffer list doesn't load all the way?
-          this.insatnce_list = [];
+          this.instance_list = [];
         }
 
         this.show_annotations = true;

--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -3906,7 +3906,7 @@ export default Vue.extend({
         this.initialize_instance_buffer_dict_frame(this.current_frame);
         // IMPORTANT  This is a POINTER not a new object. This is a critical assumption.
         // See https://docs.google.com/document/d/1KkpccWaCoiVWkiit8W_F5xlH0Ap_9j4hWduZteU4nxE/edit
-        this.instance_list = this.instance_buffer_dict[this.current_frame]
+        this.instance_list = this.instance_buffer_dict[this.current_frame];
       } else {
         this.video_pause = Date.now();
         this.get_instances(true);
@@ -7388,7 +7388,7 @@ export default Vue.extend({
         // IMPORTANT  This is a POINTER not a new object. This is a critical assumption.
         // See https://docs.google.com/document/d/1KkpccWaCoiVWkiit8W_F5xlH0Ap_9j4hWduZteU4nxE/edit
 
-        this.instance_list = this.instance_buffer_dict[this.current_frame]
+        this.instance_list = this.instance_buffer_dict[this.current_frame];
         this.add_override_colors_for_model_runs();
         this.show_annotations = true;
         this.loading = false;
@@ -7495,10 +7495,10 @@ export default Vue.extend({
         if (this.instance_buffer_dict) {
           // We want to do the equals because that creates the reference on the instance list to buffer dict
           this.initialize_instance_buffer_dict_frame(this.current_frame);
-          this.instance_list = this.instance_buffer_dict[this.current_frame]
+          this.instance_list = this.instance_buffer_dict[this.current_frame];
         } else {
           // handle if buffer list doesn't load all the way?
-          this.insatnce_list = []
+          this.insatnce_list = [];
         }
 
         this.show_annotations = true;

--- a/frontend/src/components/annotation/annotation_ui_factory.vue
+++ b/frontend/src/components/annotation/annotation_ui_factory.vue
@@ -22,6 +22,7 @@
         <v_annotation_core
           v-if="!changing_file && !changing_task"
           class="pt-1 pl-1"
+          :instance_store="instance_store"
           :project_string_id="computed_project_string_id"
           :label_schema="current_label_schema"
           :model_run_id_list="model_run_id_list"
@@ -220,6 +221,7 @@ import geo_annotation_core from "../geo_annotation/geo_annotation_core.vue"
 import Vue from "vue";
 
 import TaskPrefetcher from "../../helpers/task/TaskPrefetcher"
+import InstanceStore from "../../helpers/InstanceStore"
 
 
 export default Vue.extend({
@@ -252,6 +254,7 @@ export default Vue.extend({
   },
   data() {
     return {
+      instance_store: null,
       task_prefetcher: null,
       task_image: null,
       task_instances: null,
@@ -319,8 +322,6 @@ export default Vue.extend({
     }
   },
   created() {
-
-
     if (this.$route.query.edit_schema) {
       this.enabled_edit_schema = true;
     }
@@ -350,6 +351,8 @@ export default Vue.extend({
     }
   },
   async mounted() {
+    this.instance_store = new InstanceStore()
+
     if (!this.$props.task_id_prop) {
       await this.get_project();
     } else {

--- a/frontend/src/helpers/InstanceStore.ts
+++ b/frontend/src/helpers/InstanceStore.ts
@@ -1,0 +1,11 @@
+export default class InstanceStore {
+  private _instance_store: any = {};
+
+  get_instance_list(file_id: number) {
+    return this._instance_store[file_id]
+  }
+
+  set_instance_list(file_id: number, instance_list: any[]) {
+    this._instance_store[file_id] = instance_list
+  }
+}


### PR DESCRIPTION
# Instance Store

## Background

With the current architecture, every annotation interface keeps its own state and all the implementation of all the functionality. This was working fine a year ago, when Diffgram had only one annotation interface (Image + Video). Since then, we are growing rapidly, and now we have 5 (Image + Video, 3D, Text, Audio, Geo) different annotation interfaces, and potentially have more in the future, which will lead to more repeated code

Another reason, is a Compound File interface that are WIP right now. The problem here is that we should be able to annotate 2 different files simultaneously, with possibility to have same toolbar and same sidebar (and current architecture isn't ideal for this)

## Implementation

**InstanceStore** class is an management class that will store instances in an object with the key of file id:

```javascript
private _instance_store: any = {};
```

And there are two main methods: **get_instance_list** and **set_instance_list** (which are basically getter and setter). The example usage would be:

```javascript
this.instance_store.set_instance_list(this.file.id, newVal)
```

This will pass current instances to the management class, and they will be accessed on the parent component (**annotation_ui_factory.vue**):

```javascript
 this.instance_store.get_instance_list(this.file.id)
```

## File vs Task context

Since we have 2 different ways how file can be annotated (file and task), Instance Store should be able to work in the both modes. The Diffgram's main direction is move all the task related logic to the **annotation_ui_factory.vue**, and make annotation interfaces "context agnostic", however for now file id has been moved to computed property:
```javascript
    file_id: function() {
      if (!this.task) return this.file.id
      else return this.task.file.id
    },
```