### PR TITLE
fix: creation ref id for prelabeled data

### DIFF
--- a/frontend/src/components/annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/annotation_core.vue
@@ -4291,7 +4291,6 @@ export default Vue.extend({
       }
       // important, we don't change the value if it's locked
       // otherwise it's easy for user to get "off" of the point they want
-
       if (index != null) {
         this.instance_hover_index = parseInt(index);
         this.hovered_figure_id = figure_id;
@@ -6403,7 +6402,6 @@ export default Vue.extend({
 
       this.polygon_click_index = null;
       this.polygon_point_click_index = null;
-
       if (this.draw_mode == false) {
         //console.debug('mouse upp edit', this.instance_hover_index, this.instance_hover_type);
         if (this.instance_list != undefined) {
@@ -8510,7 +8508,6 @@ export default Vue.extend({
       frame_number_param = undefined,
       instance_list_param = undefined
     ) {
-      console.log('KEYFRAME', this.current_frame, this.instance_list)
       this.save_error = {};
       this.save_warning = {};
       if (this.go_to_keyframe_loading) {
@@ -8540,7 +8537,6 @@ export default Vue.extend({
           instance_list = this.instance_buffer_dict[frame_number]
         }
       }
-      console.log('KEYFRAME', this.current_frame, instance_list)
       if (this.get_save_loading(frame_number) == true) {
         // If we have new instances created while saving. We might still need to save them after the first
         // save has been completed.

--- a/frontend/src/components/vue_canvas/coordinators/ImageAnnotationCoordinatorRouter.ts
+++ b/frontend/src/components/vue_canvas/coordinators/ImageAnnotationCoordinatorRouter.ts
@@ -53,6 +53,7 @@ export class ImageAnnotationCoordinatorRouter implements CoordinatorGenerator {
     }
     let result = []
     if(this.instance_hover_index != undefined){
+      console.log('RESULE GET HOVERED', this.instance_hover_index, this.instance_list)
       result.push(this.instance_list[this.instance_hover_index])
     }
     for (let i = 0; i < this.instance_list.length; i++) {
@@ -60,6 +61,7 @@ export class ImageAnnotationCoordinatorRouter implements CoordinatorGenerator {
         result.push(this.instance_list[i])
       }
     }
+    console.log('RESULE GET HOVERED', result)
     // Sort by selected instances first
     result = result.sort((a,b) => b.selected - a.selected)
     return result

--- a/frontend/src/utils/instance_utils.ts
+++ b/frontend/src/utils/instance_utils.ts
@@ -10,7 +10,7 @@ import {ImageLabelSettings} from "../types/image_label_settings";
 import {InstanceImage2D} from "../components/vue_canvas/instances/InstanceImage2D";
 import {ImageCanvasTransform} from "../types/CanvasTransform";
 import {LabelFileMap} from "../types/label";
-
+import {v4 as uuidv4} from 'uuid';
 export const duplicate_instance = function (instance_to_copy, component_ctx: CanvasMouseCtx, with_ids = false) {
   let points = [];
   let nodes = [];
@@ -213,7 +213,9 @@ export const post_init_instance = function (instance: Instance,
   if(!instance.label_file){
     instance.label_file = label_file
   }
-
+  if(instance.creation_ref_id == undefined){
+    instance.creation_ref_id = uuidv4()
+  }
   if (SUPPORTED_CLASS_INSTANCE_TYPES.includes(instance.type)) {
     let inst = instance as InstanceImage2D
     inst.set_label_file_colour_map(colour_map)


### PR DESCRIPTION
## Description
When uploading prelabeled data the hover index was not working due to creation ref ID not being populated from the prelabeled upload. We've added as part of the post init script the creation ref ID population if the instance was stored without a creation ref ID
### Author Checklist
_All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues._

I have...

* [ ]  added `!` to the type prefix if Breaking Changes.
* [ ]  considered the impact to the SDK.
* [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ]  provided a link to the relevant issue in JIRA or Github Link in PR.
* [ ]  included the unit and integration tests
* [ ]  included comments & docs for new API Endpoints
* [ ]  updated the relevant documentation or specification in readme.io
* [ ]  reviewed "Files changed" and left comments if necessary
* [ ]  confirmed all CI checks have passed

Breaking Changes including adding required params.

### Reviewers Checklist
_All items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items._

I have...

* [ ]  confirmed the Author checklist was followed
* [ ]  reviewed API design and naming
* [ ]  reviewed documentation is accurate
* [ ]  reviewed tests and test coverage
* [ ]  manually tested (if applicable)