### PR TITLE
Fix report label names

### DIFF
--- a/default/methods/report/report_runner.py
+++ b/default/methods/report/report_runner.py
@@ -1010,7 +1010,7 @@ class Report_Runner():
             return self.format_for_charting(execution_results)
 
 
-    def build_label_names_map_from_second_grouping(
+    def build_label_map_from_ids(
             self,
             second_grouping):
 
@@ -1086,7 +1086,10 @@ class Report_Runner():
             count = sum(values)
 
             if self.report_template.second_group_by == 'label':
-                label_names_map = self.build_label_names_map_from_second_grouping(second_grouping)
+                label_names_map = self.build_label_map_from_ids(second_grouping)
+
+            if self.report_template.group_by == 'label': 
+                label_names_map = self.build_label_map_from_ids(labels)
 
             serialized_list_tuples_by_period = self.serialize_list_tuples_by_period(list_tuples_by_period)
 

--- a/frontend/src/components/report/report.vue
+++ b/frontend/src/components/report/report.vue
@@ -1193,8 +1193,19 @@ export default Vue.extend({
           values = report.values
         }
 
+        let labels = report.labels
+
+        if (report.labels && this.report_template.group_by == 'label') {
+          labels = []
+          for (let label of report.labels)
+            {
+            label = report.schema.labelNamesMap[label]
+            labels.push(label)
+            }
+        }
+
         this.datacollection = {
-          labels: report.labels,
+          labels: labels,
           datasets: [
             {
               // Label means header (not label schema or rest of data labels)


### PR DESCRIPTION
## Description

1) Enables second group by label
2) Enable CSV download for second group by label
3) Fix No result cases to show no results instead of JSON error
4) Fix Schema label name for some cases

![labels by date](https://user-images.githubusercontent.com/18080164/210907697-eff2eece-910a-4481-9301-225bbe9e0536.PNG)
![labels by task](https://user-images.githubusercontent.com/18080164/210907700-3f27fac1-fe87-4074-920d-d7db7920e9dc.PNG)
![example label by user](https://user-images.githubusercontent.com/18080164/210907702-6ceed7fe-a7f9-4ed9-aa8b-2be780cfc31c.PNG)
![image](https://user-images.githubusercontent.com/18080164/210907752-dae6cff1-9458-4810-af1e-7181b9bb96ae.png)
![group by user and label](https://user-images.githubusercontent.com/18080164/210907821-edb19f9e-c04e-4937-99be-b932f5087c3d.PNG)
