### PR TITLE
feat: add read only attribute

### DIFF
--- a/default/docs/swagger_spec.json
+++ b/default/docs/swagger_spec.json
@@ -42,6 +42,45 @@
                     "Discussions"
                 ]
             }
+        },
+        "/api/v1/project/{project_string_id}/file/{file_id}/update-metadata": {
+            "put": {
+                "summary": "Update File Metadata",
+                "description": "Updates the given file ID file metadata.",
+                "responses": {
+                    "200": {
+                        "description": "The updated file.",
+                        "schema": {
+                            "$ref": "#/definitions/File"
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "project_string_id",
+                        "in": "path",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "file_id",
+                        "in": "path",
+                        "type": "number",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "name": "FileUpdateMetadataReqBody",
+                        "description": "The metadata to be updated. Any keys not provided will be ignored.",
+                        "schema": {
+                            "$ref": "#/definitions/FileUpdateMetadataReqBody"
+                        }
+                    }
+                ],
+                "tags": [
+                    "Files"
+                ]
+            }
         }
     },
     "definitions": {
@@ -58,6 +97,72 @@
             "properties": {
                 "content": {
                     "type": "string"
+                }
+            }
+        },
+        "File": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "description": "the image related data.",
+                    "type": "object"
+                },
+                "video": {
+                    "description": "the video related data.",
+                    "type": "object"
+                },
+                "id": {
+                    "description": "the file ID",
+                    "type": "object"
+                },
+                "hash": {
+                    "description": "the file hash.",
+                    "type": "string"
+                },
+                "state": {
+                    "description": "the state of the file.",
+                    "type": "string"
+                },
+                "created_time": {
+                    "description": "The time the file was created.",
+                    "type": "string"
+                },
+                "time_last_updated": {
+                    "description": "The time the file was updated.",
+                    "type": "object"
+                },
+                "original_filename": {
+                    "description": "The name of the file.",
+                    "type": "string"
+                },
+                "bucket_name": {
+                    "description": "Bucket name where file resides (if applicable)",
+                    "type": "string"
+                },
+                "connection_id": {
+                    "description": "Connection ID to access the file (if applicable)",
+                    "type": "number"
+                },
+                "video_id": {
+                    "description": "Video ID to for accessing the video object.",
+                    "type": "number"
+                },
+                "video_parent_file_id": {
+                    "description": "File ID of the parent video file.",
+                    "type": "number"
+                }
+            }
+        },
+        "FileUpdateMetadataReqBody": {
+            "type": "object",
+            "properties": {
+                "rotation_degrees": {
+                    "description": "the rotation degrees for rotating image. Works only on image type files.",
+                    "type": "number"
+                },
+                "ordinal": {
+                    "description": "the ordinal for a child file. Useful for ordering compound files.",
+                    "type": "number"
                 }
             }
         }

--- a/default/main.py
+++ b/default/main.py
@@ -143,8 +143,9 @@ print("Startup in", time.time() - start_time)
 from swagger_setup import setup_swagger
 try:
     setup_swagger(app)
-except:
-    logger.warning('Failed to generate swagger spec')
+except Exception as e:
+    data = traceback.format_exc()
+    logger.warning(f'Failed to generate swagger spec: {data}')
 # Debug
 if __name__ == '__main__':
 

--- a/default/methods/attribute/attribute_template_group_update.py
+++ b/default/methods/attribute/attribute_template_group_update.py
@@ -23,6 +23,11 @@ def api_attribute_template_group_update(project_string_id):
             "default": 0,
             "type": int
         }},
+        {'is_read_only': {
+            "required": False,
+            "default": False,
+            "type": bool
+        }},
         {'name': None},
         {'prompt': None},
         {'kind': str},
@@ -72,7 +77,9 @@ def api_attribute_template_group_update(project_string_id):
             default_id = input['default_id'],
             is_global = input['is_global'],
             global_type = input['global_type'],
-            ordinal = input['ordinal']        )
+            ordinal = input['ordinal'],
+            is_read_only = input['is_read_only'],
+        )
 
         if len(log["error"].keys()) >= 1:
             return jsonify(log = log), 400
@@ -114,7 +121,9 @@ def group_update_core(
     tree_data: dict = None,
     is_global: bool = False,
     global_type: str = 'file',
-    ordinal: int = None):
+    ordinal: int = None,
+    is_read_only: bool = False,
+):
     if mode == "ARCHIVE":
 
         group.archived = True
@@ -194,6 +203,7 @@ def group_update_core(
             group.ordinal = ordinal
         group.name = name
         group.min_value = min_value
+        group.is_read_only = is_read_only
         group.max_value = max_value
         group.prompt = prompt
         group.member_updated = member

--- a/default/methods/source_control/file/file_update_metadata.py
+++ b/default/methods/source_control/file/file_update_metadata.py
@@ -16,7 +16,7 @@ from flasgger import swag_from
 @Project_permissions.user_has_project(
     Roles = ["admin", "Editor"],
     apis_user_list = ['api_enabled_builder', 'security_email_verified'])
-@swag_from('../../docs/file_update_metadata.yml')
+@swag_from('../../../docs/file_update_metadata.yml')
 def api_file_update_metadata(project_string_id: str, file_id: int):
     """
         Updates a file ID metadata.

--- a/frontend/src/components/attribute/attribute_group.vue
+++ b/frontend/src/components/attribute/attribute_group.vue
@@ -802,6 +802,7 @@
         }
       },
       methods: {
+
         add_hotkey_listeners: function(){
           window.addEventListener('keyup', this.attribute_keyup_handler);
           window.addEventListener('keydown', this.attribute_keydown_handler);

--- a/frontend/src/components/attribute/attribute_group_wizard.vue
+++ b/frontend/src/components/attribute/attribute_group_wizard.vue
@@ -34,14 +34,22 @@
             Scope
           </v-stepper-step>
 
+          <v-stepper-step
+            editable
+            :complete="step > 4"
+            step="4"
+          >
+            Editable
+          </v-stepper-step>
+
 
 
           <v-divider></v-divider>
 
           <v-stepper-step
             editable
-            :complete="step > 4"
-            step="4">
+            :complete="step > 5"
+            step="5">
            Visible When
           </v-stepper-step>
 
@@ -49,8 +57,8 @@
 
           <v-stepper-step
             editable
-            :complete="step > 5"
-            step="5"
+            :complete="step > 6"
+            step="6"
           >
             {{ group.kind !== "tree" ? "Options" : "Tree" }}
           </v-stepper-step>
@@ -59,8 +67,8 @@
           <v-stepper-step
             v-if="group.kind !== 'tree'"
             editable
-            :complete="step > 6"
-            step="6">
+            :complete="step > 7"
+            step="7">
             Defaults
           </v-stepper-step>
 
@@ -71,12 +79,12 @@
           color="secondary"
           striped
           :value="global_progress"
-          :height="group.kind !== 'tree' ? 7 : 6"
+          :height="group.kind !== 'tree' ? 8 : 7"
         >
         </v-progress-linear>
 
 
-        <v-stepper-items style="height: 100%" class="pt-4">
+        <v-stepper-items style="height: 100%; min-height: 300px; border-bottom: 1px solid #e0e0e0" class="pt-4">
 
           <v-stepper-content step="1" style="height: 100%" data-cy="attribute_wizard_step_1">
 
@@ -209,8 +217,40 @@
 
           </v-stepper-content>
 
-
           <v-stepper-content step="4" style="height: 100%" data-cy="attribute_wizard_step_4">
+
+            <h2> 4. Read Only or Editable? </h2>
+
+            <br>
+            <p>
+              The Default is editable. You can use read only attributes to upload additional metadata to files, this metadata
+              will not be changed by annotators. I can only be set at upload time, via the API/SDK.
+            </p>
+
+            <br>
+
+            <v-layout class="justify-center align-center">
+              <v-checkbox
+                clearable
+                v-model="group.is_read_only"
+                label="Read only?"
+                @change="$emit('change')"
+              >
+              </v-checkbox>
+
+            </v-layout>
+
+            <wizard_navigation
+              @next="go_to_step(5)"
+              @back="go_back_a_step()"
+              :disabled_next="!group.prompt"
+              :skip_visible="false"
+            >
+            </wizard_navigation>
+
+          </v-stepper-content>
+
+          <v-stepper-content step="5" style="height: 100%" data-cy="attribute_wizard_step_5">
 
             <h2 class="pb-2" > 4. When Do You Want to Show This? </h2>
 
@@ -237,7 +277,7 @@
             </label_select_only>
 
             <wizard_navigation
-              @next="go_to_step(5)"
+              @next="go_to_step(6)"
               @back="go_back_a_step()"
               :disabled_next="!group.kind"
               :skip_visible="false"
@@ -246,7 +286,7 @@
 
           </v-stepper-content>
 
-          <v-stepper-content step="5" style="height: 100%" data-cy="attribute_wizard_step_5">
+          <v-stepper-content step="6" style="height: 100%" data-cy="attribute_wizard_step_6">
 
           <v-layout v-if="group.kind !== 'tree'" column>
 
@@ -396,7 +436,7 @@
 
 
             <wizard_navigation
-              @next="go_to_step(6)"
+              @next="go_to_step(7)"
               @back="go_back_a_step()"
               :disabled_next="!group.kind"
               :skip_visible="false"
@@ -405,7 +445,7 @@
 
           </v-stepper-content>
 
-          <v-stepper-content v-if="group.kind !== 'tree'" step="6" style="height: 100%" data-cy="attribute_wizard_step_6">
+          <v-stepper-content v-if="group.kind !== 'tree'" step="7" style="height: 100%" data-cy="attribute_wizard_step_7">
 
             <!-- Edit Default  default_id default_value -->
             <v-layout column>
@@ -513,15 +553,15 @@
 
 
             <wizard_navigation
-              @next="go_to_step(7)"
-              @skip="go_to_step(6)"
+              @next="go_to_step(8)"
+              @skip="go_to_step(7)"
               @back="go_back_a_step()"
                                >
             </wizard_navigation>
 
           </v-stepper-content>
 
-          <v-stepper-content :step="group.kind !== 'tree' ? 7 : 6" data-cy="attribute_wizard_step_7">
+          <v-stepper-content :step="group.kind !== 'tree' ? 8 : 7" data-cy="attribute_wizard_step_8">
 
             <h2> Complete! Great work. </h2>
 

--- a/frontend/src/components/attribute/attribute_select.vue
+++ b/frontend/src/components/attribute/attribute_select.vue
@@ -7,7 +7,7 @@
         return_object
         :multiple="true"
         :label="label"
-        :item_list="attribute_list"
+        :item_list="attribute_list_computed"
       />
       <div v-if="selected_attributes.length > 0">
           <attribute_group_list
@@ -30,7 +30,7 @@ import attribute_group_list from "./attribute_group_list.vue";
 
 export default Vue.extend( {
     name: 'attribute_select',
-    components: { 
+    components: {
       diffgram_select,
       attribute_group_list
     },
@@ -57,6 +57,14 @@ export default Vue.extend( {
         selected_attributes: [],
       }
     },
+    computed: {
+      attribute_list_computed: function(){
+        return this.attribute_list.map(elm => {
+          elm.prompt = !elm.prompt ? 'Untitled Attribute Group': elm.prompt
+          return elm
+        })
+      }
+    }
   }
-) 
+)
 </script>

--- a/frontend/src/services/attributesService.ts
+++ b/frontend/src/services/attributesService.ts
@@ -72,6 +72,7 @@ export const attribute_group_update = async (project_string_id, mode, group: Att
         kind: group.kind,
         default_id: group.default_id,
         default_value: group.default_value,
+        is_read_only: group.is_read_only,
         min_value: group.min_value,
         max_value: group.max_value,
         ordinal: group.ordinal,

--- a/frontend/src/types/attributes/AttributeTemplateGroup.ts
+++ b/frontend/src/types/attributes/AttributeTemplateGroup.ts
@@ -10,6 +10,8 @@ export type AttributeTemplateGroup = {
   ordinal: number
   is_global: boolean
   is_root: boolean
+
+  is_read_only: boolean
   kind: string
   max_value: number
   min_value: number

--- a/shared/alembic/versions_opencore/alembic_2023_02_23_08_38_7c18149a20c8_add_read_only_flag_to_attributes.py
+++ b/shared/alembic/versions_opencore/alembic_2023_02_23_08_38_7c18149a20c8_add_read_only_flag_to_attributes.py
@@ -1,0 +1,23 @@
+"""Add read only flag to attributes
+
+Revision ID: 7c18149a20c8
+Revises: 2b273b1ff1b3
+Create Date: 2023-02-23 08:38:53.709659
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '7c18149a20c8'
+down_revision = '2b273b1ff1b3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('attribute_template_group', sa.Column('is_read_only', sa.Boolean, default = False))
+
+
+def downgrade():
+    op.drop_column('attribute_template_group', 'is_read_only')

--- a/shared/database/attribute/attribute_template_group.py
+++ b/shared/database/attribute/attribute_template_group.py
@@ -58,11 +58,11 @@ class Attribute_Template_Group(Base):
 
     is_global = Column(Boolean, default = False)
 
-    is_read_only = Column(Boolean, default = False)
+    # is_read_only = Column(Boolean, default = False)
     # Allowed Values: [compound_file, file]
     global_type = Column(String(), default = 'file')  # Expansion direction eg for frame, series, etc.
 
-    ordinal = Column(Integer, default = 0)
+    # ordinal = Column(Integer, default = 0)
     @staticmethod
     def new(session,
             project,
@@ -96,9 +96,9 @@ class Attribute_Template_Group(Base):
             'is_root': self.is_root,
             'name': self.name,
             'kind': self.kind,
-            'is_read_only': self.is_read_only,
+            # 'is_read_only': self.is_read_only,
             'prompt': self.prompt,
-            'ordinal': self.ordinal,
+            # 'ordinal': self.ordinal,
             'show_prompt': self.show_prompt,
             # wrapping in str() seems to be needed to avoid some strange
             # embedded serialization issues (not with calling it directly, but things
@@ -122,8 +122,8 @@ class Attribute_Template_Group(Base):
             'is_root': self.is_root,
             'name': self.name,
             'kind': self.kind,
-            'is_read_only': self.is_read_only,
-            'ordinal': self.ordinal,
+            # 'is_read_only': self.is_read_only,
+            # 'ordinal': self.ordinal,
             'prompt': self.prompt,
             'show_prompt': self.show_prompt,
             'default_value': self.default_value,

--- a/shared/database/attribute/attribute_template_group.py
+++ b/shared/database/attribute/attribute_template_group.py
@@ -57,6 +57,8 @@ class Attribute_Template_Group(Base):
                                         foreign_keys = [default_external_map_id])
 
     is_global = Column(Boolean, default = False)
+
+    is_read_only = Column(Boolean, default = False)
     # Allowed Values: [compound_file, file]
     global_type = Column(String(), default = 'file')  # Expansion direction eg for frame, series, etc.
 
@@ -94,6 +96,7 @@ class Attribute_Template_Group(Base):
             'is_root': self.is_root,
             'name': self.name,
             'kind': self.kind,
+            'is_read_only': self.is_read_only,
             'prompt': self.prompt,
             'ordinal': self.ordinal,
             'show_prompt': self.show_prompt,
@@ -119,6 +122,7 @@ class Attribute_Template_Group(Base):
             'is_root': self.is_root,
             'name': self.name,
             'kind': self.kind,
+            'is_read_only': self.is_read_only,
             'ordinal': self.ordinal,
             'prompt': self.prompt,
             'show_prompt': self.show_prompt,
@@ -232,7 +236,8 @@ class Attribute_Template_Group(Base):
              is_root = None,
              schema_id = None,
              group_id_list = None,
-             is_global = None
+             is_global = None,
+             is_read_only = None
              ):
         """
 
@@ -249,6 +254,8 @@ class Attribute_Template_Group(Base):
         if group_id:
             query = query.filter(Attribute_Template_Group.id == group_id)
 
+        if is_read_only is not None:
+            query = query.filter(Attribute_Template_Group.is_read_only == is_read_only)
         if is_global:
             query = query.filter(Attribute_Template_Group.is_global == is_global)
 


### PR DESCRIPTION
## Description
Adds read only attribute flag to allow uploading attribute values that users don't want to get annotated. Useful for metadata on files.
### Author Checklist
_All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues._

I have...

* [ ]  added `!` to the type prefix if Breaking Changes.
* [ ]  considered the impact to the SDK.
* [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ]  provided a link to the relevant issue in JIRA or Github Link in PR.
* [ ]  included the unit and integration tests
* [ ]  included comments & docs for new API Endpoints
* [ ]  updated the relevant documentation or specification in readme.io
* [ ]  reviewed "Files changed" and left comments if necessary
* [ ]  confirmed all CI checks have passed

Breaking Changes including adding required params.

### Reviewers Checklist
_All items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items._

I have...

* [ ]  confirmed the Author checklist was followed
* [ ]  reviewed API design and naming
* [ ]  reviewed documentation is accurate
* [ ]  reviewed tests and test coverage
* [ ]  manually tested (if applicable)