### PR TITLE
fix: Install.py user correct URL when S3 is selected for connection tests.

### DIFF
--- a/install.py
+++ b/install.py
@@ -250,7 +250,8 @@ class DiffgramInstallTool:
         return True
 
     def validate_s3_connection(self):
-        if not self.use_docker_minio:
+        print('AAAA', self.use_docker_minio)
+        if not self.use_docker_minio or self.static_storage_provider == 'aws':
             endpoint_url = self.s3_endpoint_url
         else:
             endpoint_url = 'http://localhost:9000'


### PR DESCRIPTION
## Description
fix: Install.py user correct URL when S3 is selected for connection tests.

### Author Checklist
_All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues._

I have...

* [x]  added `!` to the type prefix if Breaking Changes.
* [x]  considered the impact to the SDK.
* [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x]  provided a link to the relevant issue in JIRA or Github Link in PR.
* [x]  included the unit and integration tests
* [x]  included comments & docs for new API Endpoints
* [x]  updated the relevant documentation or specification in readme.io
* [x]  reviewed "Files changed" and left comments if necessary
* [ ]  confirmed all CI checks have passed

Breaking Changes including adding required params.

### Reviewers Checklist
_All items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items._

I have...

* [ ]  confirmed the Author checklist was followed
* [ ]  reviewed API design and naming
* [ ]  reviewed documentation is accurate
* [ ]  reviewed tests and test coverage
* [ ]  manually tested (if applicable)