### PR TITLE
fix: persist last instance type selection across reloads

### DIFF
--- a/frontend/src/components/annotation/annotation_ui_factory.vue
+++ b/frontend/src/components/annotation/annotation_ui_factory.vue
@@ -1086,8 +1086,8 @@ export default Vue.extend({
         },
         change_instance_type: function (instance_type: string): void {
             this.$store.commit("finish_draw");
-            this.$store.commit("set_last_selected_tool", this.instance_type);
             this.annotation_ui_context.instance_type = instance_type
+            this.$store.commit("set_last_selected_tool", instance_type);
         },
         change_current_label_file_template: function (label_file) {
             this.annotation_ui_context.current_label_file = label_file;

--- a/frontend/src/components/annotation/image_and_video_annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/image_and_video_annotation/annotation_core.vue
@@ -1727,7 +1727,7 @@ export default Vue.extend({
         width: width,
         height: height,
         label_file: this.annotation_ui_context.current_label_file,
-        label_file_id: this.annotation_ui_context.current_label_file.id,
+        label_file_id: this.annotation_ui_context.current_label_file ? this.annotation_ui_context.current_label_file.id : null,
         selected: "false",
         number: number,
         machine_made: false,

--- a/frontend/src/components/annotation/image_and_video_annotation/toolbar.vue
+++ b/frontend/src/components/annotation/image_and_video_annotation/toolbar.vue
@@ -1170,7 +1170,13 @@ export default Vue.extend({
     if(this.rotation_degrees == undefined){
       this.rotation_degrees = 0
     }
+
     this.loading_instance_type = false;
+    await this.$nextTick();
+
+    if(this.$store.state && this.$store.state.user && this.$store.state.user.settings && this.$store.state.user.settings.last_selected_annotation_tool){
+      this.set_instance_type(this.$store.state.user.settings.last_selected_annotation_tool)
+    }
   },
 
   computed: {


### PR DESCRIPTION
## Description
fix: persist last instance type selection across reloads

### Author Checklist
_All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues._

I have...

* [ ]  added `!` to the type prefix if Breaking Changes.
* [ ]  considered the impact to the SDK.
* [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ]  provided a link to the relevant issue in JIRA or Github Link in PR.
* [ ]  included the unit and integration tests
* [ ]  included comments & docs for new API Endpoints
* [ ]  updated the relevant documentation or specification in readme.io
* [ ]  reviewed "Files changed" and left comments if necessary
* [ ]  confirmed all CI checks have passed

Breaking Changes including adding required params.

### Reviewers Checklist
_All items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items._

I have...

* [ ]  confirmed the Author checklist was followed
* [ ]  reviewed API design and naming
* [ ]  reviewed documentation is accurate
* [ ]  reviewed tests and test coverage
* [ ]  manually tested (if applicable)