### PR TITLE
Attribute Ordering Improvements

### DIFF
--- a/default/methods/attribute/attribute.py
+++ b/default/methods/attribute/attribute.py
@@ -33,8 +33,6 @@ def api_attribute_update_or_new(project_string_id):
 
         user = User.get(session = session)
         project = Project.get(session, project_string_id)
-
-        # Caution, declaring as user.member for now.
         member = get_member(session = session)
 
         attribute_session = Attribute_Session(
@@ -47,13 +45,12 @@ def api_attribute_update_or_new(project_string_id):
             parent_id = input['attribute'].get('parent_id') if input['attribute'] else None,
         )
 
-        # For init errors
         if len(attribute_session.log["error"].keys()) >= 1:
             return jsonify(log = log), 400
 
         if attribute_session.mode in ["UPDATE", "ARCHIVE"]:
 
-            attribute_session.update_or_archive_mode_init()
+            attribute_session.update_or_archive_mode_init(log)
 
             if len(attribute_session.log["error"].keys()) >= 1:
                 return jsonify(log = log), 400
@@ -122,7 +119,7 @@ class Attribute_Session():
         # FUNCTIONS
         self.verify_and_set_group_id()
 
-    def update_or_archive_mode_init(self):
+    def update_or_archive_mode_init(self, log):
 
         self.attribute_template = Attribute_Template.get_by_id(
             session = self.session,

--- a/default/methods/attribute/attribute_template_group_update.py
+++ b/default/methods/attribute/attribute_template_group_update.py
@@ -13,7 +13,6 @@ from shared.database.attribute.attribute_template_group_to_file import Attribute
 def api_attribute_template_group_update(project_string_id):
     """
 
-
     """
 
     spec_list = [
@@ -30,7 +29,11 @@ def api_attribute_template_group_update(project_string_id):
         }},
         {'name': None},
         {'prompt': None},
-        {'kind': str},
+        {'kind': {
+            "required": False,
+            "type": str
+            }
+        },
         {'label_file_list': None},
         {'default_value': None},
         {'default_id': None},

--- a/default/methods/source_control/file/file_browser.py
+++ b/default/methods/source_control/file/file_browser.py
@@ -687,7 +687,7 @@ class File_Browser():
                 resp = jsonify(log=self.log)
                 resp.status = 401
                 raise Unauthorized(response = resp)
-            print('with_children_files', self.metadata.get('with_children_files'))
+
             query, count = WorkingDirFileLink.file_list(
                 session = self.session,
                 working_dir_id = self.directory.id,

--- a/frontend/src/components/annotation/annotation_area_factory.vue
+++ b/frontend/src/components/annotation/annotation_area_factory.vue
@@ -4,7 +4,7 @@
     <div v-if="!interface_type || !interface_type && !initializing">
       <empty_file_editor_placeholder
         :message="`File ID: ${annotation_ui_context.working_file ? annotation_ui_context.working_file.id : 'N/A'}. File Type: ${annotation_ui_context.working_file ? annotation_ui_context.working_file.type : 'N/A'}`"
-        :title="'Invalid File loaded'"
+        :title="'No File Loaded'"
       />
     </div>
     <div v-else-if="interface_type === 'compound' && annotation_ui_context.working_file_list.length === 0 && !initializing" >

--- a/frontend/src/components/annotation/annotation_ui_factory.vue
+++ b/frontend/src/components/annotation/annotation_ui_factory.vue
@@ -110,7 +110,7 @@
             <div v-if="!interface_type && !initializing && !loading">
                 <empty_file_editor_placeholder
                       :message="`File ID: ${annotation_ui_context.working_file ? annotation_ui_context.working_file.id : 'N/A'}. File Type: ${annotation_ui_context.working_file ? annotation_ui_context.working_file.type : 'N/A'}`"
-                      :title="'Invalid File loaded'"
+                      :title="'No File Loaded'"
                 />
             </div>
             <div

--- a/frontend/src/components/attribute/attribute.vue
+++ b/frontend/src/components/attribute/attribute.vue
@@ -6,9 +6,6 @@
 
         <v-layout row>
 
-          <!-- do we just send the "attribute" to front
-              end and not worry about template part -->
-
         <h3 class="font-weight-medium ml-6 mt-2 text--primary flex-grow-1">{{ attribute.name }}</h3>
 
         <v_error_multiple :error="error">
@@ -33,6 +30,7 @@
               :attribute_prop = "attribute"
               :group_id = "attribute.group_id"
               :mode = " 'UPDATE' "
+              @attribute_updated="$emit('attribute_updated', $event)"
                   >
             </attribute_new_or_update>
 
@@ -40,12 +38,6 @@
           </template>
 
         </button_with_menu>
-
-          <!-- Prior we had a more dots icon
-              but it just seems like not needed
-          and if we do want to bring it back should be a seperate
-          button_with_menu  component
-          -->
 
         <standard_button
             tooltip_message="Archive"
@@ -70,8 +62,6 @@
 
 <script lang="ts">
 
-
-import axios from '../../services/customInstance';
 import attribute_new_or_update from './attribute_new_or_update.vue';
 import { attribute_update_or_new } from "../../services/attributesService.ts"
 
@@ -100,9 +90,6 @@ export default Vue.extend( {
         loading: false,
         error: {},
         success: false,
-
-        name: null,
-
         show_menu: true,
 
         show_edit: false
@@ -111,12 +98,6 @@ export default Vue.extend( {
       }
     },
     watch: {
-
-      // we refresh list, so if we don't close it on current vuetify version
-      // it ends up being in wrong spot. can remove or change if that thing gets fixed
-      attribute() {
-        this.show_edit = false
-      }
 
     },
     methods: {

--- a/frontend/src/components/attribute/attribute_group_wizard.vue
+++ b/frontend/src/components/attribute/attribute_group_wizard.vue
@@ -320,6 +320,7 @@
                     :project_string_id="project_string_id"
                     :group_id="group.id"
                     :menu_open="props.menu_open"
+                    @attribute_updated="attribute_updated($event)"
                   >
 
                   </attribute_new_or_update>
@@ -345,6 +346,7 @@
                     :project_string_id="project_string_id"
                     :attribute="item"
                     :key="item.id"
+                    @attribute_updated="attribute_updated($event)"
                   >
                   </attribute>
 
@@ -682,6 +684,17 @@ export default Vue.extend( {
     }
   },
   methods: {
+
+    attribute_updated: function (attribute_template){
+      const attribute_template_existing = this.group.attribute_template_list.find(a => a.id === attribute_template.id)
+      if (attribute_template_existing) {
+        let index = this.group.attribute_template_list.indexOf(attribute_template_existing)
+        this.group.attribute_template_list[index].name = attribute_template.name
+      } else {
+        this.group.attribute_template_list.push(attribute_template)
+      }
+    },
+
     set_global_attribute: function(){
       if(this.group.is_global){
         if(this.group.global_type === 'compound_file'){
@@ -696,6 +709,9 @@ export default Vue.extend( {
       }
     },
     build_tree_data: function(){
+
+      if (this.group.kind != 'tree') { return }
+
       this.group.attribute_template_list.map(attr => {
         const new_node = new TreeNode(attr.group_id, attr.name)
         new_node.initialize_existing_node(attr.id, attr.parent_id)

--- a/frontend/src/components/attribute/attribute_new_or_update.vue
+++ b/frontend/src/components/attribute/attribute_new_or_update.vue
@@ -165,12 +165,14 @@ import { attribute_update_or_new } from "../../services/attributesService.ts"
         this.error = {}
         this.success = false
 
-        const { status, error } = await attribute_update_or_new(mode, this.project_string_id, this.attribute)
+        const { status, data, error } = await attribute_update_or_new(mode, this.project_string_id, this.attribute)
         this.error = error
 
         if (status === 200) {
-          this.$store.commit('attribute_refresh_group_list')
           this.success = true
+          this.attribute.id = data.attribute_template.id
+          this.attribute.name = data.attribute_template.name
+          this.$emit('attribute_updated', this.attribute)
         }
 
         this.loading = false

--- a/frontend/src/components/attribute/attribute_new_or_update.vue
+++ b/frontend/src/components/attribute/attribute_new_or_update.vue
@@ -17,14 +17,6 @@
                         v-model="name">
           </v-text-field>
 
-            <!-- Future, could have option to select
-              another GROUP here -->
-
-          <!-- TODO if enter value, numeric or string -->
-
-          <!-- TODO if enter open children, then open children -->
-
-
 
           <!-- Hide on overlay since already created -->
 
@@ -164,14 +156,6 @@ import { attribute_update_or_new } from "../../services/attributesService.ts"
         this.count.label_file_id = label_file.id
 
         this.overlay.label_file_id = label_file.id
-
-      },
-
-      recieve_brain: function (brain) {
-
-        // TODO maybe just to "brain" not "brain_run"
-
-        this.brain_run.id = brain.id
 
       },
 

--- a/shared/database/attribute/attribute_template_group.py
+++ b/shared/database/attribute/attribute_template_group.py
@@ -62,7 +62,7 @@ class Attribute_Template_Group(Base):
     # Allowed Values: [compound_file, file]
     global_type = Column(String(), default = 'file')  # Expansion direction eg for frame, series, etc.
 
-    ordinal = Column(Integer, default = 0)
+    ordinal = Column(Integer, default = 99999)
     @staticmethod
     def new(session,
             project,

--- a/shared/utils/source_control/file/file_transfer_core.py
+++ b/shared/utils/source_control/file/file_transfer_core.py
@@ -148,7 +148,6 @@ def file_transfer_core(
 
     """
     new_file = None
-    print('NEW COPY ', file.id, defer_copy)
     if transfer_action == "copy":
         new_file = File.copy_file_from_existing(
             session = session,
@@ -164,7 +163,6 @@ def file_transfer_core(
             batch_id = batch_id,
             new_parent_id = new_parent_id
         )
-        print('COPIED FILE IS', new_file)
         session.flush()
         if defer_copy:
             return log

--- a/walrus/main.py
+++ b/walrus/main.py
@@ -111,6 +111,9 @@ sync_actions_thread = SyncActionsHandlerThread(thread_sleep_time_min = settings.
                                                run_once = False)
 
 print("Startup in", time.time() - start_time)
+
+logger.info(f"DIFFGRAM_VERSION_TAG: {settings.DIFFGRAM_VERSION_TAG}")
+
 if __name__ == '__main__':
 
     settings.NAME_EQUALS_MAIN = True  # can adjust this for local deferral testing if needed?

--- a/walrus/methods/data_mocking/generate_data.py
+++ b/walrus/methods/data_mocking/generate_data.py
@@ -312,7 +312,7 @@ class DiffgramDataMocker:
                     User.is_super_admin == True
                 ).first()
                 member = admin.member
-            label_name = f"Diffgram Sample Label {i + 1}"
+            label_name = f"Example_Label_{i + 1}"
             label = self.session.query(Label).filter(
                 Label.name == label_name).first()
             if label:

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -132,7 +132,7 @@ def start_queue_check_loop(VIDEO_QUEUE, FRAME_QUEUE):
 
         check_and_wait_for_memory(memory_limit_float = 85.0)
 
-        logger.info("[Media Queue Heartbeat]")
+        logger.info(f"[Media Queue Heartbeat] V: {settings.DIFFGRAM_VERSION_TAG}")
         try:
             add_deferred_items_time = check_if_add_items_to_queue(add_deferred_items_time, VIDEO_QUEUE, FRAME_QUEUE)
         except Exception as exception:

--- a/walrus/methods/input/process_media.py
+++ b/walrus/methods/input/process_media.py
@@ -149,6 +149,7 @@ def check_if_add_items_to_queue(add_deferred_items_time, VIDEO_QUEUE, FRAME_QUEU
 
     if FRAME_QUEUE.qsize() >= 30:
         logger.info(f"FRAME QUEUE LIMIT {str(FRAME_QUEUE.qsize())}")
+        logger.info(f"Processing May Be Stuck.")
         return add_deferred_items_time
 
     with sessionMaker.session_scope_threaded() as session:
@@ -398,15 +399,9 @@ class Process_Media():
 
         check_and_wait_for_memory(memory_limit_float = 85.0)
 
-        ### Warm up
         self.get_input_with_retry()
 
-        # We update this here because
-        # it may be set to retry, but not start processing for a while
-        # So we only want to set this time when we start processing it
         self.input.time_last_attempted = start_time
-
-        # Jan 20, 2020, TODO can we safely remove self.project
 
         self.project = self.input.project
 

--- a/walrus/methods/input/upload.py
+++ b/walrus/methods/input/upload.py
@@ -495,7 +495,6 @@ def input_from_local(session,
     input.original_filename = os.path.split(original_filename)[1]
     input.parent_file_id = parent_file_id
     input.ordinal = ordinal
-    print('parent_file_id', parent_file_id)
 
     input.temp_dir = tempfile.mkdtemp()
     input.temp_dir_path_and_filename = input.temp_dir + \
@@ -538,8 +537,6 @@ def input_from_local(session,
             input = input)
 
         result = process_media.main_entry()
-
-        # Always return input along with file?
 
         if result == True:
             return True, log, input


### PR DESCRIPTION
## Description
Fixes a variety of issues while ordering attributes.

1) New attributes do not destroy existing order (ordinal defaults to 9999)
2) Attribute option updates (e.g. for Radial) no longer call for a global refresh
improving performance (e.g. local update instead of 100 Attribute groups x 100 options refresh
3) Improved loading and queuing to harden cases of multiple edits while loading confusing ordering
4) Fixes common case for 400 error by making `kind` optional in re-ordering update case
5) Other small cleaning, updating, and logging items

This was mainly in the UI context but also applies to API/SDK for some items e.g. 1) and 4) 

General design notes for future
* Archive still calls for a global refresh
* In general the existing code leans too much on Vue and should be more generic JS/TS with just the final update call to Vue, but for now kept within paradigm to minimize changes.
