### PR TITLE
Fix jobset output dir

### DIFF
--- a/default/methods/task/task_template/job_launch.py
+++ b/default/methods/task/task_template/job_launch.py
@@ -49,15 +49,6 @@ def check_integrations_support(session, task_template, log):
     connection = task_template.interface_connection
     files_count = task_template.get_attached_files(session=session, return_kind='count')
 
-    if connection.integration_name == 'labelbox':
-        if task_template.instance_type not in ['box', 'polygon', 'line']:
-            log['error'][
-                'labelbox_interface'] = 'Cannot use instance type {} for Labelbox UI please choose one of'.format(
-                task_template.instance_type,
-                '"box", "polygon" or "line".')
-            if files_count == 0:
-                log['error']['file_count'] = 'Datasets must contains at least 1 file to launch.'
-
     if connection.integration_name == 'scale_ai':
         if task_template.instance_type not in ['box', 'polygon']:
             log['error'][

--- a/default/methods/task/task_template/job_new_or_update.py
+++ b/default/methods/task/task_template/job_new_or_update.py
@@ -348,7 +348,7 @@ def job_output_dir_update(project_string_id):
         }
         },
         {"output_dir": {
-            'kind': str,
+            'kind': int,
             'default': None,
             'required': False
         }},

--- a/default/methods/task/task_template/job_new_or_update.py
+++ b/default/methods/task/task_template/job_new_or_update.py
@@ -339,8 +339,6 @@ def job_update_api(project_string_id):
     apis_user_list=["api_enabled_builder"])
 def job_output_dir_update(project_string_id):
     """
-    Do we want a different spec list here...
-
     """
     output_job_spec = [
         {"job_id": {
@@ -384,13 +382,20 @@ def job_output_dir_update(project_string_id):
 
         if regular_log.log_has_error(log):
             return jsonify(log=log), 400
+
         log['success'] = True
         out = jsonify(job=job.serialize_new(),
                       log=log)
+
         return out, 200
 
 
 def update_output_dir_actions(session, job, project, input_data, log):
+
+    if input_data['output_dir_action'] not in ['copy', 'move', 'nothing']:
+        log['error']['output_dir'] = 'output_dir  must be "copy", "move" or "nothing".'
+        return None, log
+
     if input_data['output_dir_action'] == 'nothing':
         job.output_dir_action = input_data['output_dir_action']
         job.completion_directory_id = None
@@ -403,9 +408,6 @@ def update_output_dir_actions(session, job, project, input_data, log):
         log['error']['output_dir'] = "No directory found"
         return None, log
 
-    if input_data['output_dir_action'] not in ['copy', 'move', 'nothing']:
-        log['error']['output_dir'] = 'output_dir  must be "copy", "move" or "nothing".'
-        return None, log
     job_observable = task_file_observers.JobObservable(session=session, log=log, job=job)
     job.output_dir_action = input_data['output_dir_action']
     directory_observer = task_file_observers.DirectoryJobObserver(session=session,

--- a/default/tests/methods/task/task_template/test_job_new_or_update.py
+++ b/default/tests/methods/task/task_template/test_job_new_or_update.py
@@ -449,7 +449,7 @@ class TestJobNewUpdate(testing_setup.DiffgramBaseTestCase):
             endpoint,
             data=json.dumps(request_data),
             headers={
-                'directory_id': str(job.project.directory_default_id),
+                'directory_id': job.project.directory_default_id,
                 'Authorization': f"Basic {credentials}"
             }
         )

--- a/frontend/src/components/task/job/job_edit_pipeline.vue
+++ b/frontend/src/components/task/job/job_edit_pipeline.vue
@@ -108,7 +108,7 @@ export default {
         const response = await axios.post(
           `/api/v1/project/${this.project_string_id}/job/set-output-dir`,
           {
-            output_dir: this.output_dir.directory ? this.output_dir.directory.directory_id.toString() : undefined,
+            output_dir: this.output_dir.directory ? this.output_dir.directory.directory_id : undefined,
             output_dir_action: this.output_dir.action,
             job_id: parseInt(this.job.id),
           })

--- a/frontend/src/components/task/job/job_new.vue
+++ b/frontend/src/components/task/job/job_new.vue
@@ -533,7 +533,7 @@
               '/api/v1/project/' + this.project_string_id
               + '/job/set-output-dir',
               {
-                output_dir: this.output_dir.directory ? this.output_dir.directory.directory_id.toString() : undefined,
+                output_dir: this.output_dir.directory ? this.output_dir.directory.directory_id : undefined,
                 output_dir_action: this.output_dir.action,
                 job_id: parseInt(this.job.id),
               })

--- a/frontend/src/components/task/job/task_template_wizard_creation/step_attach_directories_task_template.vue
+++ b/frontend/src/components/task/job/task_template_wizard_creation/step_attach_directories_task_template.vue
@@ -125,7 +125,7 @@
             const response = await axios.post(
               `/api/v1/project/${this.project_string_id}/job/set-output-dir`,
               {
-                output_dir: this.output_dir.directory ? this.output_dir.directory.directory_id.toString() : undefined,
+                output_dir: this.output_dir.directory ? this.output_dir.directory.directory_id : undefined,
                 output_dir_action: this.output_dir.action,
                 job_id: parseInt(this.job.id),
               })

--- a/shared/query_engine/expressions/dataset.py
+++ b/shared/query_engine/expressions/dataset.py
@@ -24,7 +24,5 @@ class DatasetCompareExpression(CompareExpression):
         #     .filter(sql_compare_operator(sql_column, raw_scalar_value),
         #             File.project_id == self.project_id,
         #             File.state != 'removed').subquery(name = "ds_compare")
-        self.expression = and_(sql_compare_operator(sql_column, raw_scalar_value),
-                             File.project_id == self.project_id,
-                             File.state != 'removed')
+        self.expression = sql_compare_operator(sql_column, raw_scalar_value)
         return self.expression

--- a/shared/query_engine/expressions/file.py
+++ b/shared/query_engine/expressions/file.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql import Selectable
 from shared.settings.env_adapter import EnvAdapter
 from datetime import datetime, time
+from shared.shared_logger import get_shared_logger
+logger = get_shared_logger()
 
 class FileCompareExpression(CompareExpression):
 
@@ -27,17 +29,15 @@ class FileCompareExpression(CompareExpression):
             parsed_date = parsed_date.replace(hour = end_of_day.hour, minute = end_of_day.minute,
                                               second = end_of_day.second)
 
-            new_filter_subquery = session.query(AliasFile.id).filter(
-                sql_compare_operator(sql_column, parsed_date)).subquery()
+            self.expression = sql_compare_operator(sql_column, parsed_date)
         elif File.ann_is_complete == query_op.column:
             env_adapter = EnvAdapter()
             parsed_boolean = raw_scalar_value.replace("'", "")
             parsed_boolean = parsed_boolean.replace('"', "")
             parsed_boolean = env_adapter.bool(parsed_boolean)
-            new_filter_subquery = session.query(AliasFile.id).filter(
-                sql_compare_operator(sql_column, parsed_boolean)).subquery()
+            self.expression = sql_compare_operator(sql_column, parsed_boolean)
         else:
-            new_filter_subquery = session.query(AliasFile.id).filter(sql_compare_operator(sql_column, raw_scalar_value)).subquery()
+            self.expression = sql_compare_operator(sql_column, raw_scalar_value)
 
-        self.subquery = new_filter_subquery
-        return self.subquery
+
+        return 

--- a/shared/query_engine/expressions/file.py
+++ b/shared/query_engine/expressions/file.py
@@ -25,9 +25,9 @@ class FileCompareExpression(CompareExpression):
             parsed_date = parsed_date.replace("'", "")
             parsed_date = parsed_date.replace('"', "")
             parsed_date = datetime.strptime(parsed_date, format_string)
-            end_of_day = time(23, 59, 59)
-            parsed_date = parsed_date.replace(hour = end_of_day.hour, minute = end_of_day.minute,
-                                              second = end_of_day.second)
+            start_of_day = time(0, 0, 0)
+            parsed_date = parsed_date.replace(hour = start_of_day.hour, minute = start_of_day.minute,
+                                              second = start_of_day.second)
 
             self.expression = sql_compare_operator(sql_column, parsed_date)
         elif File.ann_is_complete == query_op.column:


### PR DESCRIPTION
Main item is [Fix query expression assumptions for file](https://github.com/diffgram/diffgram/commit/7035f0abc4dac7bfb5e19ee52ada5372fee5cc17)
Also:
[fix str int](https://github.com/diffgram/diffgram/commit/454f5cf3999a7c57d889ecaf94fda0ea65ed142a)
[Remove duplicate condition](https://github.com/diffgram/diffgram/commit/d73ff57ed36ec0ca26e73f11d961164ba6a39ad8)

### Fix query expression assumptions for file

#### Context: 
File query reserved items like `created_time` were appearing to work, but returning erroneous results. e.g. created time set to `file.created_time >= "2023-06-22"` and still returning results `created_time: "2023-06-15T01:02:50.313507"`

![fail](https://github.com/diffgram/diffgram/assets/18080164/c9bff922-ad01-4764-bdc7-09b5448e69aa)

Same query on fix:
![image](https://github.com/diffgram/diffgram/assets/18080164/1a35981a-e133-4a93-bf01-5f351337e43e)

#### SQL Creation
It was creating this statement which (appears to be) invalid:
```
AND file.id IN (SELECT anon_1.id
FROM (SELECT file_1.id AS id
FROM file AS file_1, file
WHERE file.ann_is_complete = true) AS anon_1)
```

My guess is something to do with the base query being the same table and/or that query missing the file table
It also throws "SELECT statement has a cartesian product".
That error may be fixed with a join, but subqueries -> join back to same table doesn't' make sense.

as a comparison, this query works as expected
```
AND file.id IN (SELECT anon_1.file_id
FROM (SELECT file_stats.file_id AS file_id
FROM file_stats
WHERE file_stats.label_file_id = %(label_file_id_1)s AND file_stats.count_instances >= %(count_instances_1)s) AS anon_1)
```
#### Solution

This fixes leans on the option to have `self.expression` filled, e.g. ` self.expression= sql_compare_operator(sql_column, parsed_boolean)` as an option instead of sub query. 
e.g. in https://github.com/diffgram/diffgram/blob/887cea8fbb283d8afc2f7eb0542909c47c107c99/shared/query_engine/sqlalchemy_query_exectutor.py#L133

`def factor()    `
```             elif hasattr(compare_expr, 'expression'):
                    filter_value = compare_expr.expression
```
So it just changes for each area:
![image](https://github.com/diffgram/diffgram/assets/18080164/4e50eb1b-3a2a-4cfa-ab88-f492b8b6fe81)

Since file is treated as the "base" query by changing it to an expression it adds it nicely to the main statement:

```WHERE file.project_id = %(project_id_1)s .... AND file.ann_is_complete = true AND file.created_time <= %(created_time_1)s OR file.created_time >= %(created_time_2)s```

#### More

Also changed the end of day to start of day to [align with <= and >= assumptions](https://github.com/diffgram/diffgram/pull/1428/commits/887cea8fbb283d8afc2f7eb0542909c47c107c99)

Tested manually on a few items and it is working correctly as far as I can tell. Clearly opportunity for some more tests / correctness tests in addition to general syntax and flow.

