### PR TITLE
Improve custom url error handling

### DIFF
--- a/default/methods/source_control/file/file_get_signed_url.py
+++ b/default/methods/source_control/file/file_get_signed_url.py
@@ -21,8 +21,7 @@ def api_file_get_signed_url(project_string_id, file_id):
        """
     # For now, no filters needed. But might add in the future.
     log = regular_log.default()
-    create_thumbnails = request.args['create_thumbnails']
-    create_thumbnails = False if create_thumbnails == 'false' else False
+
     with sessionMaker.session_scope() as session:
         project = Project.get_by_string_id(session, project_string_id)
         member = get_member(session)
@@ -31,8 +30,7 @@ def api_file_get_signed_url(project_string_id, file_id):
             log = log,
             project = project,
             member = member,
-            file_id = file_id,
-            create_thumbnails = create_thumbnails,
+            file_id = file_id
         )
         if len(log["error"].keys()) >= 1:
             return jsonify(log = log), 400
@@ -44,8 +42,7 @@ def get_file_signed_url_core(session: Session,
                              project: Project,
                              file_id: int,
                              member: Member,
-                             log: dict = regular_log.default(),
-                             create_thumbnails: bool = True):
+                             log: dict = regular_log.default()):
     """
         List comments of the discussion. At this point we assume data has been validated so no extra checks are
         done to the input data.
@@ -71,8 +68,8 @@ def get_file_signed_url_core(session: Session,
                                                                            connection_id = file.connection_id,
                                                                            bucket_name = file.bucket_name,
                                                                            reference_file = file,
-                                                                           regen_url = True,
-                                                                           create_thumbnails = True)
+                                                                           regen_url = True
+                                                                           )
     elif file.type == "video":
         if file.video:
             file_data[file.type] = file.video.serialize_list_view(session = session,
@@ -84,24 +81,24 @@ def get_file_signed_url_core(session: Session,
             file_data[file.type] = file.text_file.serialize(session = session,
                                                             connection_id = file.connection_id,
                                                             bucket_name = file.bucket_name,
-                                                            regen_url = True,
-                                                            create_thumbnails = True)
+                                                            regen_url = True
+                                                            )
 
     elif file.type == "geospatial":
         file_data[file.type] = {
             'layers': file.serialize_geospatial_assets(session = session,
                                                        connection_id = file.connection_id,
                                                        bucket_name = file.bucket_name,
-                                                       regen_url = True,
-                                                       create_thumbnails = True)
+                                                       regen_url = True
+                                                       )
         }
     if file.type == "audio":
         if file.audio_file:
             file_data[file.type] = file.audio_file.serialize(session = session,
                                                              connection_id = file.connection_id,
                                                              bucket_name = file.bucket_name,
-                                                             regen_url = True,
-                                                             create_thumbnails = True)
+                                                             regen_url = True
+                                                             )
 
     elif file.type == "sensor_fusion":
         point_cloud_file = file.get_child_point_cloud_file(session = session)
@@ -109,7 +106,7 @@ def get_file_signed_url_core(session: Session,
             file_data['point_cloud'] = point_cloud_file.point_cloud.serialize(session = session,
                                                                               connection_id = file.connection_id,
                                                                               bucket_name = file.bucket_name,
-                                                                              regen_url = True,
-                                                                              create_thumbnails = True)
+                                                                              regen_url = True
+                                                                              )
     
     return file_data, log

--- a/frontend/src/components/annotation/annotation_area_factory.vue
+++ b/frontend/src/components/annotation/annotation_area_factory.vue
@@ -4,11 +4,6 @@
     <div v-if="!interface_type || !interface_type && !initializing">
       No Interface Type Defined.
     </div>
-    <div v-else-if="interface_type === 'compound' && annotation_ui_context.working_file_list.length === 0 && !initializing" >
-      <empty_file_editor_placeholder
-        :message="'Try adding child files to this compound file.'"
-        :title="'This compound file has no child files.'" />
-    </div>
     <div v-else-if="!credentials_granted && !initializing">
       <empty_file_editor_placeholder
         icon="mdi-account-cancel"

--- a/frontend/src/components/annotation/annotation_area_factory.vue
+++ b/frontend/src/components/annotation/annotation_area_factory.vue
@@ -2,10 +2,7 @@
   <div>
     <v_error_multiple :error="error" />
     <div v-if="!interface_type || !interface_type && !initializing">
-      <empty_file_editor_placeholder
-        :message="`File ID: ${annotation_ui_context.working_file ? annotation_ui_context.working_file.id : 'N/A'}. File Type: ${annotation_ui_context.working_file ? annotation_ui_context.working_file.type : 'N/A'}`"
-        :title="'No File Loaded'"
-      />
+      No Interface Type Defined.
     </div>
     <div v-else-if="interface_type === 'compound' && annotation_ui_context.working_file_list.length === 0 && !initializing" >
       <empty_file_editor_placeholder

--- a/frontend/src/components/annotation/image_and_video_annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/image_and_video_annotation/annotation_core.vue
@@ -7,21 +7,21 @@
       <v-alert v-if="task_error.task_request" type="info">
         {{ task_error.task_request }}
       </v-alert>
+
+      <div v-if="working_file && working_file.image && working_file.image.error">
+        <v_error_multiple :error="working_file.image.error"></v_error_multiple>
+      </div>
       <v_error_multiple :error="save_error"></v_error_multiple>
       <v_error_multiple :error="image_annotation_ctx.save_multiple_frames_error"></v_error_multiple>
-      <v_error_multiple
-        :error="image_annotation_ctx.save_warning"
-        type="warning"
-        data-cy="save_warning"
-      >
+      <v_error_multiple :error="image_annotation_ctx.save_warning"
+                        type="warning"
+                        data-cy="save_warning">
       </v_error_multiple>
       <div fluid v-if="display_refresh_cache_button">
-        <v-btn
-          small
-          color="warning"
-          @click="regenerate_file_cache"
-          :loading="regenerate_file_cache_loading"
-        >
+        <v-btn small
+               color="warning"
+               @click="regenerate_file_cache"
+               :loading="regenerate_file_cache_loading">
           <v-icon>mdi-refresh</v-icon>
           Refresh File Data
         </v-btn>

--- a/frontend/src/components/annotation/image_and_video_annotation/annotation_core.vue
+++ b/frontend/src/components/annotation/image_and_video_annotation/annotation_core.vue
@@ -9,7 +9,9 @@
       </v-alert>
 
       <div v-if="working_file && working_file.image && working_file.image.error">
-        <v_error_multiple :error="working_file.image.error"></v_error_multiple>
+        <v-alert type="info">
+          {{ working_file.image.error}}
+        </v-alert>
       </div>
       <v_error_multiple :error="save_error"></v_error_multiple>
       <v_error_multiple :error="image_annotation_ctx.save_multiple_frames_error"></v_error_multiple>

--- a/frontend/src/components/annotation/image_and_video_annotation/media_core.vue
+++ b/frontend/src/components/annotation/image_and_video_annotation/media_core.vue
@@ -1390,8 +1390,7 @@ export default Vue.extend({
         if (!file) {
           return
         }
-        let create_thumbnails = (this.context === 'task' || (file && file.image && file.image.url_signed_blob_path)) ? false : true
-        let [url_data, err] = await get_file_signed_url(project_string_id, file.id, create_thumbnails);
+        let [url_data, err] = await get_file_signed_url(project_string_id, file.id);
         if (err) {
           this.error = this.$route_api_errors(err)
         }

--- a/frontend/src/services/fileServices.ts
+++ b/frontend/src/services/fileServices.ts
@@ -39,12 +39,10 @@ export const get_file_list = async (project_string_id, user_name, metadata) => {
   }
 }
 
-export const get_file_signed_url = async (project_string_id: string, file_id: number, create_thumbnails: boolean = true) => {
+export const get_file_signed_url = async (project_string_id: string, file_id: number) => {
   let url = `/api/project/${project_string_id}/file/${file_id}/get-signed-url`
   try {
-    const response = await axios.get(url, {
-      params:{ create_thumbnails: create_thumbnails}
-    })
+    const response = await axios.get(url)
 
     return [response.data, null]
   } catch(e) {

--- a/shared/alembic/versions_opencore/alembic_2023_08_14_14_34_e93e2edbb6b7_add_image_error.py
+++ b/shared/alembic/versions_opencore/alembic_2023_08_14_14_34_e93e2edbb6b7_add_image_error.py
@@ -1,0 +1,25 @@
+"""add image error
+
+Revision ID: e93e2edbb6b7
+Revises: 2ef6ace7da75
+Create Date: 2023-08-14 14:34:06.884101
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e93e2edbb6b7'
+down_revision = '2ef6ace7da75'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('image', sa.Column('error', sa.String))
+
+
+def downgrade():
+    op.drop_column('image', 'error')
+

--- a/shared/connection/azure_connector.py
+++ b/shared/connection/azure_connector.py
@@ -308,7 +308,7 @@ class AzureConnector(Connector):
             blob_name,
             sas
         )
-        return {'result': sas_url}
+        return {'signed_url': sas_url}
 
     @with_connection
     @with_azure_exception_handler

--- a/shared/connection/s3_connector.py
+++ b/shared/connection/s3_connector.py
@@ -251,9 +251,11 @@ class S3Connector(Connector):
             'Content-Type': content_type
         }
 
-        logger.info(f'Custom Signer Headers: {headers}')
+        logger.debug(f'Custom Signer Headers: {headers}')
         blob_name_encoded = urllib.parse.quote(blob_name, safe = '')
         url_path = f'{self.url_signer_service}/{bucket_name}'
+        
+        error = None
 
         try:
             params = {'key': blob_name, "method": "get"}
@@ -261,19 +263,29 @@ class S3Connector(Connector):
             if result.status_code == 200:
 
                 data = result.json()
-                url_result = data['url']
+                signed_url = data['url']
                 logger.debug(f'GET Presign URL response {result.text}')
-                return url_result
+                return {
+                    "signed_url" : signed_url, 
+                    "error": error
+                }
             else:
                 logger.error(f'Error generating signed url with: {url_path}')
                 logger.error(f'Error payload: {result.text}')
                 logger.error(f'Request payload: {params}')
-                return None
+                result = {
+                    "signed_url": None,
+                    "error": result.text
+                }
+                return result
         except Exception as e:
-            err = traceback.format_exc()
+            error = traceback.format_exc()
             logger.error(f'Error generating signed url with: {url_path}')
-            logger.error(f'Error payload: {err}')
-            return None
+            logger.error(f'Error payload: {error}')
+            return {
+                    "signed_url": None,
+                    "error": error
+                }
 
     def __image_upload_url(self, bucket_name: str, blob_name: str, expiration_offset: int, log: dict) -> dict:
         """
@@ -372,9 +384,10 @@ class S3Connector(Connector):
         bucket_name = opts['bucket_name']
 
         if self.url_signer_service:
-            signed_url = self.__custom_presign_url(bucket_name = bucket_name,
-                                                   blob_name = blob_name)
-            return {'result': signed_url}
+            result = self.__custom_presign_url(
+                bucket_name = bucket_name,
+                blob_name = blob_name)
+            return result
 
         signed_url = self.connection_client.generate_presigned_url('get_object',
                                                                    Params = {

--- a/shared/connection/s3_connector.py
+++ b/shared/connection/s3_connector.py
@@ -256,14 +256,17 @@ class S3Connector(Connector):
         url_path = f'{self.url_signer_service}/{bucket_name}'
         
         error = None
+        signed_url = None
 
         try:
             params = {'key': blob_name, "method": "get"}
             result = requests.get(url = url_path, headers = headers, params = params)
             if result.status_code == 200:
-
-                data = result.json()
-                signed_url = data['url']
+                try:
+                    data = result.json()
+                    signed_url = data['url']
+                except:
+                    error = result.text
                 logger.debug(f'GET Presign URL response {result.text}')
                 return {
                     "signed_url" : signed_url, 

--- a/shared/connection/s3_connector.py
+++ b/shared/connection/s3_connector.py
@@ -387,10 +387,9 @@ class S3Connector(Connector):
         bucket_name = opts['bucket_name']
 
         if self.url_signer_service:
-            result = self.__custom_presign_url(
+            return self.__custom_presign_url(
                 bucket_name = bucket_name,
                 blob_name = blob_name)
-            return result
 
         signed_url = self.connection_client.generate_presigned_url('get_object',
                                                                    Params = {

--- a/shared/connection/s3_connector.py
+++ b/shared/connection/s3_connector.py
@@ -394,7 +394,7 @@ class S3Connector(Connector):
                                                                        'Bucket': bucket_name,
                                                                        'Key': blob_name},
                                                                    ExpiresIn = int(expiration_offset))
-        return {'result': signed_url}
+        return {'signed_url': signed_url}
 
     @with_connection
     @with_s3_exception_handler

--- a/shared/data_tools_core_azure.py
+++ b/shared/data_tools_core_azure.py
@@ -237,11 +237,11 @@ class DataToolsAzure:
             }
         }
         response = azure_connection.fetch_data(params)
-        if response is None or response.get('result') is None:
+        if response is None or response.get('signed_url') is None:
             msg = f'Error from Datatools Azure: {params}. Response: {response}'
             logger.error(msg)
             return None
-        url = response.get('result')
+        url = response.get('signed_url')
         return url
 
     def get_string_from_blob(self, blob_name: str):

--- a/shared/database/audio/audio_file.py
+++ b/shared/database/audio/audio_file.py
@@ -28,14 +28,13 @@ class AudioFile(Base, SerializerMixin):
     def get_by_id(session, id):
         return session.query(AudioFile).filter(AudioFile.id == id).first()
 
-    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True, create_thumbnails = True):
+    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True):
         if regen_url:
             from shared.url_generation import blob_regenerate_url
             blob_regenerate_url(blob_object = self,
                                 session = session,
                                 connection_id = connection_id,
-                                bucket_name = bucket_name,
-                                create_thumbnails = create_thumbnails)
+                                bucket_name = bucket_name)
 
         data = self.to_dict(rules = ())
 

--- a/shared/database/geospatial/geo_asset.py
+++ b/shared/database/geospatial/geo_asset.py
@@ -60,14 +60,13 @@ class GeoAsset(Base):
 
         return point_cloud
 
-    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True, create_thumbnails = True):
+    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True):
         if regen_url:
             from shared.url_generation import blob_regenerate_url
             blob_regenerate_url(blob_object = self,
                                 session = session,
                                 connection_id = connection_id,
-                                bucket_name = bucket_name,
-                                create_thumbnails = create_thumbnails)
+                                bucket_name = bucket_name)
         data = {
             'id': self.id,
             'original_filename': self.original_filename,

--- a/shared/database/image.py
+++ b/shared/database/image.py
@@ -83,16 +83,14 @@ class Image(Base):
                                      connection_id = None,
                                      bucket_name = None,
                                      reference_file: 'File' = None,
-                                     regen_url = True,
-                                     create_thumbnails: bool = True):
+                                     regen_url = True):
         if regen_url:
             from shared.url_generation import blob_regenerate_url
             blob_regenerate_url(blob_object = self,
                                 session = session,
                                 connection_id = connection_id,
                                 bucket_name = bucket_name,
-                                reference_file = reference_file,
-                                create_thumbnails = create_thumbnails)
+                                reference_file = reference_file)
         return {
             'original_filename': self.original_filename,
             'width': self.width,

--- a/shared/database/image.py
+++ b/shared/database/image.py
@@ -31,6 +31,8 @@ class Image(Base):
     url_signed = Column(String())
     url_signed_blob_path = Column(String())
 
+    error = Column(String())
+
     # key assumption is that
     # rebuild_secure_urls_image() handles BOTH regular images
     # and thumbnail images...
@@ -99,6 +101,7 @@ class Image(Base):
             'soft_delete': self.soft_delete,
             'url_signed': self.url_signed,
             'url_signed_thumb': self.url_signed_thumb,
+            'error': self.error,
             'url_signed_blob_path': self.url_signed_blob_path,
             'annotation_status': self.annotation_status,
             'id': self.id

--- a/shared/database/point_cloud/point_cloud.py
+++ b/shared/database/point_cloud/point_cloud.py
@@ -49,14 +49,13 @@ class PointCloud(Base):
 
         return point_cloud
 
-    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True, create_thumbnails = True):
+    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True):
         if regen_url:
             from shared.url_generation import blob_regenerate_url
             blob_regenerate_url(blob_object = self,
                                 session = session,
                                 connection_id = connection_id,
-                                bucket_name = bucket_name,
-                                create_thumbnails = create_thumbnails)
+                                bucket_name = bucket_name)
 
         point_cloud = {
             'id': self.id,

--- a/shared/database/source_control/file.py
+++ b/shared/database/source_control/file.py
@@ -380,12 +380,12 @@ class File(Base, Caching):
         ).all()
         return assets
 
-    def serialize_geospatial_assets(self, session, connection_id = None, bucket_name = None, regen_url = True, create_thumbnails: bool = True):
+    def serialize_geospatial_assets(self, session, connection_id = None, bucket_name = None, regen_url = True):
         assets_list = self.get_geo_assets(session)
         result = []
         for asset in assets_list:
             result.append(asset.serialize(session, connection_id = connection_id, bucket_name = bucket_name,
-                                          regen_url = regen_url, create_thumbnails = create_thumbnails))
+                                          regen_url = regen_url))
         return result
 
     def serialize_with_type(self, session = None, regen_url = True):

--- a/shared/database/text_file.py
+++ b/shared/database/text_file.py
@@ -67,14 +67,13 @@ class TextFile(Base):
         }
         return text
 
-    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True, create_thumbnails = True):
+    def serialize(self, session, connection_id = None, bucket_name = None, regen_url = True):
         if regen_url:
             from shared.url_generation import blob_regenerate_url
             blob_regenerate_url(blob_object = self,
                                 session = session,
                                 connection_id = connection_id,
-                                bucket_name = bucket_name,
-                                create_thumbnails = create_thumbnails)
+                                bucket_name = bucket_name)
 
         text = {
             'original_filename': self.original_filename,

--- a/shared/url_generation.py
+++ b/shared/url_generation.py
@@ -209,54 +209,6 @@ def get_custom_url_supported_connector(session: Session, log: dict, connection_i
     return client, log
 
 
-def generate_thumbnails_for_image(
-    session: Session,
-    blob_object: DiffgramBlobObjectType,
-    log: dict,
-    params: dict,
-    connection_id: int,
-    bucket_name: str,
-    new_offset_in_seconds: int,
-    member: Member,
-    client: any,
-    access_token: str = None,
-    reference_file: File = None
-):
-    if type(blob_object) != Image:
-        return blob_object, log
-
-    if type(blob_object) == Image and blob_object.url_signed_thumb_blob_path is None:
-        # Try uploading thumbnails and then generating URL for them
-        blob_object, log = upload_thumbnail_for_connection_image(
-            session = session,
-            blob_object = blob_object,
-            connection_id = connection_id,
-            bucket_name = bucket_name,
-            new_offset_in_seconds = new_offset_in_seconds,
-            member = member,
-            access_token = access_token,
-            reference_file = reference_file
-        )
-        if regular_log.log_has_error(log):
-            logger.error(log)
-            # We reset the log to avoid resetting URL (we still want to get full file url if thumbnail fails)
-            log = regular_log.default()
-            session.add(blob_object)
-            return blob_object, log
-    params['path'] = blob_object.url_signed_thumb_blob_path
-    params['action_type'] = 'get_pre_signed_url'
-    result, log = get_url_from_connector(connector = client, params = params, log = log)
-    if regular_log.log_has_error(log):
-        # We reset the log to avoid resetting URL (we still want to get full file url if thumbnail fails)
-        log = regular_log.default()
-        session.add(blob_object)
-        return blob_object, log
-
-
-    blob_object.url_signed_thumb = result.get('signed_url')
-    blob_object.error = result.get('error')
-    return blob_object, log
-
 
 def generate_text_token_url(
     session: Session,

--- a/shared/url_generation.py
+++ b/shared/url_generation.py
@@ -276,8 +276,7 @@ def blob_regenerate_url(blob_object: DiffgramBlobObjectType,
                         connection_id: int = None,
                         bucket_name: str = None,
                         access_token: str = None,
-                        reference_file: File = None,
-                        create_thumbnails: bool = True) -> list[object, dict]:
+                        reference_file: File = None) -> list[object, dict]:
 
     if not blob_object.url_signed_blob_path:
         return
@@ -308,8 +307,7 @@ def blob_regenerate_url(blob_object: DiffgramBlobObjectType,
             bucket_name = bucket_name,
             new_offset_in_seconds = new_offset_in_seconds,
             reference_file = reference_file,
-            access_token = access_token,
-            create_thumbnails = create_thumbnails
+            access_token = access_token
         )
 
     if regular_log.log_has_error(log):

--- a/shared/url_generation.py
+++ b/shared/url_generation.py
@@ -253,8 +253,12 @@ def connection_url_regenerate(session: Session,
     
     blob_object.url_signed = result.get('signed_url')
     blob_object.url_signed_thumb = result.get('signed_url')
-    blob_object.error = str(result.get('error'))
-
+    error = result.get('error')
+    if error:
+        try:
+            blob_object.error = result.get('error')
+        except:
+            blob_object.error = str(result.get('error'))
     # Extra assets (Depending on type)
 
     if type(blob_object) == TextFile and blob_object.tokens_url_signed_blob_path:


### PR DESCRIPTION
This pull request improves the UI surface of Custom signed URL errors.

For example in screenshot, purposefully created a "bad" result, and it is showing that result to user. 

This is in context that each user may have permission issues, or the 3rd party signed service may operate in unexpected ways, and we need to distinguish between when that service throws a message vs some other processing errors

![image](https://github.com/diffgram/diffgram/assets/18080164/da9bdd11-bcdc-44ef-84cf-23862b33ffc5)

## Other

Also removes `create_thumbnails` concept.
-> We don't want to store artifacts unless we have to.
-> Given the desire to always render the full canvas if possible, getting a preview in this context doesn't make sense
e.g. it's less of an optimization and more of a blocker to then showing user full exp.
-> In general if we want to do preview objects in the future we need a fresh plan that considers the changed contexts