### PR TITLE
New runner

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -107,7 +107,7 @@ jobs:
     - run: echo ${{ secrets.GOOGLE_SERVICE_ACCOUNT_ENCODED }} | base64 --decode --ignore-garbage > /gcp/gcloud-service-key.json
     - name: Check processes
       run: ls -a
-    - run: yarn --cwd frontend/ install --network-timeout 600000
+    - run: yarn --cwd frontend/ install
     #    - run: yarn --cwd frontend/ run cypress install
     - run: yarn --cwd frontend/ build
     # Populate DB

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -8,7 +8,7 @@ on:
       - master
 jobs:
   E2E-Tests:
-    runs-on: k8s-diffgram-runner
+    runs-on: k8s-diffgram-arc-runner-set
 #     Service containers to run with `container-job`
     strategy:
       matrix:

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -107,7 +107,7 @@ jobs:
     - run: echo ${{ secrets.GOOGLE_SERVICE_ACCOUNT_ENCODED }} | base64 --decode --ignore-garbage > /gcp/gcloud-service-key.json
     - name: Check processes
       run: ls -a
-    - run: yarn --cwd frontend/ install
+    - run: yarn --cwd frontend/ install --network-timeout 600000
     #    - run: yarn --cwd frontend/ run cypress install
     - run: yarn --cwd frontend/ build
     # Populate DB


### PR DESCRIPTION
New AWS K8s runner for E2E tests. All relevant changes have been made in the actions-runner-k8s repo on [this PR](https://github.com/diffgram/actions-runners-k8s/pull/1).