### PR TITLE
fvirga/new annotation unit tests

### DIFF
--- a/default/tests/shared/test_annotation.py
+++ b/default/tests/shared/test_annotation.py
@@ -125,6 +125,451 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
 
         self.assertEqual(ann_update.instance_list_kept_serialized[0]['sequence_id'], sequence.id)
 
+    def test_detect_and_remove_collisions(self):
+        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
+        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'video'}, self.session)
+        frame = data_mocking.create_file(
+            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
+            self.session)
+        instance1 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        instance2 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        instance3 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        instance1.hash_instance()
+        instance2.hash_instance()
+        instance3.hash_instance()
+        video_data = {
+            'video_mode': True,
+            'video_file_id': file1.id,
+            'current_frame': frame.frame_number
+        }
+        inst_list = [instance1, instance2, instance3]
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            video_data = video_data,
+            instance_list_new = [],
+            file = file1,
+            do_init_existing_instances = True
+        )
+        result = ann_update.detect_and_remove_collisions(inst_list)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], instance3)
+
+    def test_update_cache_single_instance_in_list_context(self):
+        """
+            Test that the instance gets serialized correctly and that if the instance has no ID
+            the function does not serializer anything.
+        :return:
+        """
+        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'video'}, self.session)
+        frame = data_mocking.create_file(
+            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
+            self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
+        # 2 Exactly equal instances
+        instance1 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        instance2 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'soft_delete': True,
+             'label_file_id': label_file.id},
+            self.session
+        )
+        self.project.label_dict['label_file_id_list'] = [label_file.id]
+        inst = {
+            'creation_ref_id': str(uuid.uuid4()),
+            'x_min': 1,
+            'y_min': 1,
+            'x_max': 18,
+            'y_max': 18,
+            'soft_delete': False,
+            'label_file_id': label_file.id,
+            'type': 'box'
+        }
+        instance_data = [
+            inst.copy(),
+            inst.copy()
+        ]
+        video_data = {
+            'video_mode': True,
+            'video_file_id': file1.id,
+            'current_frame': frame.frame_number
+        }
+
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            video_data = video_data,
+            instance_list_new = instance_data,
+            file = file1,
+            do_init_existing_instances = True
+        )
+
+        with patch.object(instance1, 'serialize_with_label') as mock_1:
+            ann_update.instance = instance1
+            ann_update.update_cache_single_instance_in_list_context()
+            mock_1.assert_called_once()
+
+        with patch.object(instance2, 'serialize_with_label') as mock_1:
+            instance2.id = None
+            ann_update.instance = instance2
+            ann_update.update_cache_single_instance_in_list_context()
+            self.assertEqual(mock_1.call_count, 0)
+
+    def test_append_new_instance_list_hash(self):
+        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'video'}, self.session)
+        frame = data_mocking.create_file(
+            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
+            self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
+        # 2 Exactly equal instances
+        instance1 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        instance2 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'soft_delete': True,
+             'label_file_id': label_file.id},
+            self.session
+        )
+        self.project.label_dict['label_file_id_list'] = [label_file.id]
+        inst = {
+            'creation_ref_id': str(uuid.uuid4()),
+            'x_min': 1,
+            'y_min': 1,
+            'x_max': 18,
+            'y_max': 18,
+            'soft_delete': False,
+            'label_file_id': label_file.id,
+            'type': 'box'
+        }
+        instance_data = [
+            inst.copy(),
+            inst.copy()
+        ]
+        video_data = {
+            'video_mode': True,
+            'video_file_id': file1.id,
+            'current_frame': frame.frame_number
+        }
+
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            video_data = video_data,
+            instance_list_new = instance_data,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        result = ann_update.append_new_instance_list_hash(instance = instance1)
+        result2 = ann_update.append_new_instance_list_hash(instance = instance2)
+
+        self.assertTrue(result)
+        self.assertFalse(result2)
+
+    def test_order_new_instances_by_date(self):
+        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'video'}, self.session)
+        frame = data_mocking.create_file(
+            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
+            self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
+        inst1 = {
+            'creation_ref_id': str(uuid.uuid4()),
+            'x_min': 1,
+            'y_min': 1,
+            'x_max': 18,
+            'y_max': 18,
+            'client_created_time': datetime.datetime(2020, 1, 1),
+            'soft_delete': False,
+            'label_file_id': label_file.id,
+            'type': 'box'
+        }
+        inst2 = {
+            'creation_ref_id': str(uuid.uuid4()),
+            'x_min': 1,
+            'y_min': 1,
+            'x_max': 18,
+            'y_max': 18,
+            'client_created_time': datetime.datetime(2020, 1, 2),
+            'soft_delete': False,
+            'label_file_id': label_file.id,
+            'type': 'box'
+        }
+        inst3 = {
+            'creation_ref_id': str(uuid.uuid4()),
+            'x_min': 1,
+            'y_min': 1,
+            'x_max': 18,
+            'y_max': 18,
+            'client_created_time': datetime.datetime(2020, 1, 3),
+            'soft_delete': False,
+            'label_file_id': label_file.id,
+            'type': 'box'
+        }
+        inst4 = {
+            'creation_ref_id': str(uuid.uuid4()),
+            'x_min': 1,
+            'y_min': 1,
+            'x_max': 18,
+            'y_max': 18,
+            'client_created_time': None,
+            'soft_delete': False,
+            'label_file_id': label_file.id,
+            'type': 'box'
+        }
+        inst_list = [inst1, inst2, inst3, inst4]
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            video_data = None,
+            instance_list_new = inst_list,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        ann_update.instance_list_new = inst_list
+        ann_update.order_new_instances_by_date()
+
+        self.assertEqual(ann_update.instance_list_new[0], inst3)
+        self.assertEqual(ann_update.instance_list_new[1], inst2)
+        self.assertEqual(ann_update.instance_list_new[2], inst1)
+        self.assertEqual(ann_update.instance_list_new[3], inst4)
+
+    def test__check_all_instances_available_in_new_instance_list(self):
+        file1 = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id}, self.session)
+        instance1 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        instance2 = data_mocking.create_instance(
+            {'x_min': 2, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
+            self.session
+        )
+
+        instance3 = data_mocking.create_instance(
+            {'x_min': 3, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
+            self.session
+        )
+        instance1.hash_instance()
+        instance2.hash_instance()
+        instance3.hash_instance()
+        old_payload = [instance1, instance2, instance3]
+        new_list_payload = [x.serialize_with_label() for x in old_payload]
+        new_list_payload_wrong = [instance1.serialize_with_label()]
+
+        # Test Case where we don't want to run verification
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = new_list_payload,
+            file = file1,
+            do_init_existing_instances = False
+        )
+        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
+
+        self.assertTrue(result)
+
+        # Now test case with validations
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = new_list_payload,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
+
+        self.assertTrue(result)
+
+        # Now test case with validations and a wrong payload
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = new_list_payload_wrong,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
+
+        self.assertTrue(result)
+        self.assertTrue(len(ann_update.log['warning'].keys()) > 0)
+        self.assertTrue('new_instance_list_missing_ids' in ann_update.log['warning'])
+        self.assertTrue('information' in ann_update.log['warning'])
+        self.assertTrue('missing_ids' in ann_update.log['warning'])
+        self.assertTrue(instance2.id in ann_update.log['warning']['missing_ids'])
+        self.assertTrue(instance3.id in ann_update.log['warning']['missing_ids'])
+
+        # Now test case with validations and a wrong payload and some existing deleted instances
+        instance4 = data_mocking.create_instance(
+            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'soft_delete': True,
+             'label_file_id': label_file.id},
+            self.session
+        )
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = new_list_payload_wrong,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
+
+        self.assertTrue(result)
+        self.assertTrue(len(ann_update.log['warning'].keys()) > 0)
+        self.assertTrue('new_instance_list_missing_ids' in ann_update.log['warning'])
+        self.assertTrue('information' in ann_update.log['warning'])
+        self.assertTrue('missing_ids' in ann_update.log['warning'])
+        self.assertTrue(instance2.id in ann_update.log['warning']['missing_ids'])
+        self.assertTrue(instance3.id in ann_update.log['warning']['missing_ids'])
+        self.assertTrue(instance4.id not in ann_update.log['warning']['missing_ids'])
+
+    def test_check_relations_id_existence(self):
+        """
+            Check calls to check_relations_id_existence
+        :return:
+        """
+        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'image'}, self.session)
+        frame = data_mocking.create_file(
+            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
+            self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
+        # 2 Exactly equal instances
+        self.project.label_dict['label_file_id_list'] = [label_file.id]
+        instance1 = data_mocking.create_instance(
+            {'x_min': 1,
+             'x_max': 10,
+             'y_min': 1,
+             'y_max': 10,
+             'file_id': file1.id,
+             'label_file_id': label_file.id,
+             'type': 'relation'
+             },
+            self.session
+        )
+        instance2 = data_mocking.create_instance(
+            {'x_min': 2,
+             'x_max': 15,
+             'y_min': 2,
+             'y_max': 15,
+             'file_id': file1.id,
+             'label_file_id': label_file.id,
+             'type': 'box'
+             },
+            self.session
+        )
+        ann_update2 = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = [],
+            file = file1,
+            do_init_existing_instances = True
+        )
+
+        ann_update2.instance = instance1
+        # Check Error State
+        ann_update2.check_relations_id_existence(None, None, None, None)
+        self.assertTrue('from_id' in ann_update2.log['error'])
+        # Check IDs available
+        ann_update2.log['error'] = {}
+        ann_update2.instance.from_instance_id = 1
+        ann_update2.instance.to_instance_id = 1
+        ann_update2.check_relations_id_existence(ann_update2.instance.from_instance_id,
+                                                 ann_update2.instance.to_instance_id,
+                                                 None,
+                                                 None)
+        self.assertEqual(len(ann_update2.log['error'].keys()), 0)
+        self.assertEqual(len(ann_update2.new_instance_relations_list_no_ids), 0)
+        # Check IDs Not available
+        ann_update2.check_relations_id_existence(None,
+                                                 None,
+                                                 str(uuid.uuid4()),
+                                                 str(uuid.uuid4()))
+        self.assertEqual(len(ann_update2.log['error'].keys()), 0)
+        self.assertEqual(len(ann_update2.new_instance_relations_list_no_ids), 1)
+
+    def test_add_missing_ids_to_new_relations(self):
+        """
+            Tests calss to add_missing_ids_to_new_relations()
+        :return:
+        """
+        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'image'}, self.session)
+        frame = data_mocking.create_file(
+            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
+            self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
+        # 2 Exactly equal instances
+        self.project.label_dict['label_file_id_list'] = [label_file.id]
+        instance1 = data_mocking.create_instance(
+            {'x_min': 1,
+             'x_max': 10,
+             'y_min': 1,
+             'y_max': 10,
+             'file_id': file1.id,
+             'label_file_id': label_file.id,
+             'type': 'relation'
+             },
+            self.session
+        )
+        instance1.creation_ref_id = str(uuid.uuid4())
+        instance2 = data_mocking.create_instance(
+            {'x_min': 2,
+             'x_max': 15,
+             'y_min': 2,
+             'y_max': 15,
+             'file_id': file1.id,
+             'label_file_id': label_file.id,
+             'type': 'box'
+             },
+            self.session
+        )
+        relation = data_mocking.create_instance(
+            {
+                'file_id': file1.id,
+                'label_file_id': None,
+                'type': 'relation'
+            },
+            self.session
+        )
+        relation.hash_instance()
+        old_hash = relation.hash
+
+        instance2.creation_ref_id = str(uuid.uuid4())
+        self.session.commit()
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = [],
+            file = file1,
+            do_init_existing_instances = True
+        )
+        ann_update.new_added_instances = [instance1, instance2]
+        ann_update.new_instance_relations_list_no_ids = [{'instance': relation,
+                                                          'from_ref': instance1.creation_ref_id,
+                                                          'to_ref': instance2.creation_ref_id}]
+        ann_update.add_missing_ids_to_new_relations()
+
+        self.assertEqual(relation.from_instance_id, instance1.id)
+        self.assertEqual(relation.to_instance_id, instance2.id)
+        self.assertNotEqual(old_hash, relation.hash)
+
+    """
+    ======================================================================================================================
+    Everything below here is for large tests validation overall functionality (mainly annotation_update_main). 
+    These all need to be heavily refactored, mocked and broken down.
+    ======================================================================================================================
+    """
+
     def test_duplicate_instance_update_existing_false(self):
         """
         We send duplicate instances with update_existing = False.
@@ -857,226 +1302,6 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         self.assertEqual(new_instance_list[1]['y_max'], inst2['y_max'])
         self.assertIsNotNone(new_instance_list[1]['id'])
 
-    def test_detect_and_remove_collisions(self):
-        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
-        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'video'}, self.session)
-        frame = data_mocking.create_file(
-            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
-            self.session)
-        instance1 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
-            self.session
-        )
-        instance2 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
-            self.session
-        )
-        instance3 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
-            self.session
-        )
-        instance1.hash_instance()
-        instance2.hash_instance()
-        instance3.hash_instance()
-        video_data = {
-            'video_mode': True,
-            'video_file_id': file1.id,
-            'current_frame': frame.frame_number
-        }
-        inst_list = [instance1, instance2, instance3]
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            video_data = video_data,
-            instance_list_new = [],
-            file = file1,
-            do_init_existing_instances = True
-        )
-        result = ann_update.detect_and_remove_collisions(inst_list)
-
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0], instance3)
-
-    def test_update_cache_single_instance_in_list_context(self):
-        """
-            Test that the instance gets serialized correctly and that if the instance has no ID
-            the function does not serializer anything.
-        :return:
-        """
-        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'video'}, self.session)
-        frame = data_mocking.create_file(
-            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
-            self.session)
-        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
-        # 2 Exactly equal instances
-        instance1 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
-            self.session
-        )
-        instance2 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'soft_delete': True,
-             'label_file_id': label_file.id},
-            self.session
-        )
-        self.project.label_dict['label_file_id_list'] = [label_file.id]
-        inst = {
-            'creation_ref_id': str(uuid.uuid4()),
-            'x_min': 1,
-            'y_min': 1,
-            'x_max': 18,
-            'y_max': 18,
-            'soft_delete': False,
-            'label_file_id': label_file.id,
-            'type': 'box'
-        }
-        instance_data = [
-            inst.copy(),
-            inst.copy()
-        ]
-        video_data = {
-            'video_mode': True,
-            'video_file_id': file1.id,
-            'current_frame': frame.frame_number
-        }
-
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            video_data = video_data,
-            instance_list_new = instance_data,
-            file = file1,
-            do_init_existing_instances = True
-        )
-
-        with patch.object(instance1, 'serialize_with_label') as mock_1:
-            ann_update.instance = instance1
-            ann_update.update_cache_single_instance_in_list_context()
-            mock_1.assert_called_once()
-
-        with patch.object(instance2, 'serialize_with_label') as mock_1:
-            instance2.id = None
-            ann_update.instance = instance2
-            ann_update.update_cache_single_instance_in_list_context()
-            self.assertEqual(mock_1.call_count, 0)
-
-    def test_append_new_instance_list_hash(self):
-        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'video'}, self.session)
-        frame = data_mocking.create_file(
-            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
-            self.session)
-        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
-        # 2 Exactly equal instances
-        instance1 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
-            self.session
-        )
-        instance2 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'soft_delete': True,
-             'label_file_id': label_file.id},
-            self.session
-        )
-        self.project.label_dict['label_file_id_list'] = [label_file.id]
-        inst = {
-            'creation_ref_id': str(uuid.uuid4()),
-            'x_min': 1,
-            'y_min': 1,
-            'x_max': 18,
-            'y_max': 18,
-            'soft_delete': False,
-            'label_file_id': label_file.id,
-            'type': 'box'
-        }
-        instance_data = [
-            inst.copy(),
-            inst.copy()
-        ]
-        video_data = {
-            'video_mode': True,
-            'video_file_id': file1.id,
-            'current_frame': frame.frame_number
-        }
-
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            video_data = video_data,
-            instance_list_new = instance_data,
-            file = file1,
-            do_init_existing_instances = True
-        )
-        result = ann_update.append_new_instance_list_hash(instance = instance1)
-        result2 = ann_update.append_new_instance_list_hash(instance = instance2)
-
-        self.assertTrue(result)
-        self.assertFalse(result2)
-
-    def test_order_new_instance_list_by_date(self):
-        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'video'}, self.session)
-        frame = data_mocking.create_file(
-            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
-            self.session)
-        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
-        inst1 = {
-            'creation_ref_id': str(uuid.uuid4()),
-            'x_min': 1,
-            'y_min': 1,
-            'x_max': 18,
-            'y_max': 18,
-            'client_created_time': datetime.datetime(2020, 1, 1),
-            'soft_delete': False,
-            'label_file_id': label_file.id,
-            'type': 'box'
-        }
-        inst2 = {
-            'creation_ref_id': str(uuid.uuid4()),
-            'x_min': 1,
-            'y_min': 1,
-            'x_max': 18,
-            'y_max': 18,
-            'client_created_time': datetime.datetime(2020, 1, 2),
-            'soft_delete': False,
-            'label_file_id': label_file.id,
-            'type': 'box'
-        }
-        inst3 = {
-            'creation_ref_id': str(uuid.uuid4()),
-            'x_min': 1,
-            'y_min': 1,
-            'x_max': 18,
-            'y_max': 18,
-            'client_created_time': datetime.datetime(2020, 1, 3),
-            'soft_delete': False,
-            'label_file_id': label_file.id,
-            'type': 'box'
-        }
-        inst4 = {
-            'creation_ref_id': str(uuid.uuid4()),
-            'x_min': 1,
-            'y_min': 1,
-            'x_max': 18,
-            'y_max': 18,
-            'client_created_time': None,
-            'soft_delete': False,
-            'label_file_id': label_file.id,
-            'type': 'box'
-        }
-        inst_list = [inst1, inst2, inst3, inst4]
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            video_data = None,
-            instance_list_new = inst_list,
-            file = file1,
-            do_init_existing_instances = True
-        )
-        ann_update.instance_list_new = inst_list
-        ann_update.order_new_instances_by_date()
-
-        self.assertEqual(ann_update.instance_list_new[0], inst3)
-        self.assertEqual(ann_update.instance_list_new[1], inst2)
-        self.assertEqual(ann_update.instance_list_new[2], inst1)
-        self.assertEqual(ann_update.instance_list_new[3], inst4)
-
     def test_special__removing_duplicate_instances_in_new_instance_list(self):
         """
             This is an important test to test when the client is sending the same
@@ -1126,95 +1351,282 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
 
         self.assertEqual(len(added_instances), 1)
 
-    def test__check_all_instances_available_in_new_instance_list(self):
+    def test_create_instance_relation(self):
+        """
+            Tests creation of relation of type instance.
+            Tests verifications of from_id to_id fields.
+        :return:
+        """
+        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'image'}, self.session)
+        frame = data_mocking.create_file(
+            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
+            self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
+        # 2 Exactly equal instances
+        self.project.label_dict['label_file_id_list'] = [label_file.id]
+        ref1 = str(uuid.uuid4())
+        ref2 = str(uuid.uuid4())
+        inst1 = {
+            'creation_ref_id': ref1,
+            'x_min': 1,
+            'y_min': 1,
+            'x_max': 18,
+            'y_max': 18,
+            'soft_delete': False,
+            'label_file_id': label_file.id,
+            'type': 'box'
+        }
+        inst2 = {
+            'creation_ref_id': ref2,
+            'x_min': 1,
+            'y_min': 1,
+            'x_max': 54,
+            'y_max': 54,
+            'soft_delete': False,
+            'label_file_id': label_file.id,
+            'type': 'box'
+        }
+        relation = {
+            'from_creation_ref': ref1,
+            'to_creation_ref': ref2,
+            'creation_ref_id': str(uuid.uuid4()),
+            'soft_delete': False,
+            'label_file_id': label_file.id,
+            'type': 'relation'
+        }
+        instance_list = [inst1, inst2, relation]
+        ann_update2 = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = instance_list,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        ann_update2.main()
+        self.session.commit()
+        new_instances = ann_update2.new_added_instances
+        self.assertEqual(len(new_instances), 3)
+        self.assertEqual(len(ann_update2.new_instance_relations_list_no_ids), 1)
+        self.assertEqual(new_instances[2].type, 'relation')
+        self.assertEqual(new_instances[2].from_instance_id, new_instances[0].id)
+        self.assertEqual(new_instances[2].to_instance_id, new_instances[1].id)
+        ## Test Adding Instances With IDs
+        relation2 = {
+            'from_instance_id': new_instances[1].id,
+            'to_instance_id': new_instances[0].id,
+            'creation_ref_id': str(uuid.uuid4()),
+            'soft_delete': False,
+            'label_file_id': label_file.id,
+            'type': 'relation'
+        }
+        self.session.commit()
+        instance_list = [new_instances[0].serialize_with_label(),
+                         new_instances[1].serialize_with_label(),
+                         new_instances[2].serialize_with_label(),
+                         relation2]
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = instance_list,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        ann_update.main()
+        new_instances2 = ann_update.new_added_instances
+        self.assertEqual(len(new_instances2), 1)
+        self.assertEqual(len(ann_update.new_instance_relations_list_no_ids), 0)
+        self.assertEqual(new_instances2[0].type, 'relation')
+        self.assertEqual(new_instances2[0].from_instance_id, new_instances[1].id)
+        self.assertEqual(new_instances2[0].to_instance_id, new_instances[0].id)
+
+
+    def test__saving_untouched_instance_list_does_not_restore(self):
+        """
+            We had a bug that whenever we resaved an instance and there where no changes
+            we would mark the instance as restored even though we were not restoring anything.
+
+            This was because we were not checking the is_new_instance flag in the
+            __validate_user_deletion() function of shared/annotation.py
+
+            This regression test case covers this bug
+        :return:
+        """
+        """
+            Sometimes default values can make the hash change after
+            saving to DB. This test checks that is not happening.
+        :return:
+        """
         file1 = data_mocking.create_file({'project_id': self.project.id}, self.session)
         label_file = data_mocking.create_file({'project_id': self.project.id}, self.session)
-        instance1 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
-            self.session
-        )
-        instance2 = data_mocking.create_instance(
-            {'x_min': 2, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
-            self.session
-        )
+        self.project.label_dict['label_file_id_list'] = [label_file.id]
+        # 1. Initial State 1 Unsaved Instance
+        inst1 = {'type': 'box',
+                 'file_id': file1.id,
+                 'label_file_id': label_file.id,
+                 'soft_delete': False,
+                 'x_min': 10,
+                 'y_min': 10,
+                 'x_max': 28,
+                 'y_max': 28,
+                 'deletion_type': None,
+                 'created_time': '2022-01-12T18:31:59.530816',
+                 'action_type': 'created',
+                 'deleted_time': None,
+                 'change_source': None,
+                 'p1': None,
+                 'p2': None,
+                 'cp': None,
+                 'center_x': None,
+                 'center_y': None,
+                 'creation_ref_id': '10460e33-c02b-459d-a412-ab7b4512gdghf',
+                 'number': None,
+                 'interpolated': False,
+                 'machine_made': False,
+                 'model_id': None,
+                 'model_run_id': None,
+                 'sequence_id': None,
+                 'front_face': None,
+                 'rear_face': None,
+                 'rating': None,
+                 'attribute_groups': None,
+                 'member_created_id': None,
+                 'previous_id': None,
+                 'next_id': None,
+                 'root_id': 1,
+                 'version': 1,
+                 'nodes': [],
+                 'edges': [],
+                 'pause_object': None,
+                 'label_file': {'id': 2, 'hash': None, 'type': 'image', 'state': 'added',
+                                'created_time': '2022-01-12T18:31:59.508361', 'time_last_updated': None,
+                                'ann_is_complete': None, 'original_filename': 'ykzwdu', 'video_id': None,
+                                'video_parent_file_id': None, 'count_instances_changed': None,
+                                'image': {'original_filename': None, 'width': None, 'height': None,
+                                          'soft_delete': False, 'url_signed': None, 'url_signed_thumb': None,
+                                          'annotation_status': None}}
+                 }
+        instance_list = [inst1]
 
-        instance3 = data_mocking.create_instance(
-            {'x_min': 3, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'label_file_id': label_file.id},
-            self.session
-        )
-        instance1.hash_instance()
-        instance2.hash_instance()
-        instance3.hash_instance()
-        old_payload = [instance1, instance2, instance3]
-        new_list_payload = [x.serialize_with_label() for x in old_payload]
-        new_list_payload_wrong = [instance1.serialize_with_label()]
-
-        # Test Case where we don't want to run verification
+        # 2. save the instance.
         ann_update = Annotation_Update(
             session = self.session,
             project = self.project,
-            instance_list_new = new_list_payload,
-            file = file1,
-            do_init_existing_instances = False
-        )
-        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
-
-        self.assertTrue(result)
-
-        # Now test case with validations
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            instance_list_new = new_list_payload,
-            file = file1,
-            do_init_existing_instances = True
-        )
-        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
-
-        self.assertTrue(result)
-
-        # Now test case with validations and a wrong payload
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            instance_list_new = new_list_payload_wrong,
-            file = file1,
-            do_init_existing_instances = True
-        )
-        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
-
-        self.assertTrue(result)
-        self.assertTrue(len(ann_update.log['warning'].keys()) > 0)
-        self.assertTrue('new_instance_list_missing_ids' in ann_update.log['warning'])
-        self.assertTrue('information' in ann_update.log['warning'])
-        self.assertTrue('missing_ids' in ann_update.log['warning'])
-        self.assertTrue(instance2.id in ann_update.log['warning']['missing_ids'])
-        self.assertTrue(instance3.id in ann_update.log['warning']['missing_ids'])
-
-        # Now test case with validations and a wrong payload and some existing deleted instances
-        instance4 = data_mocking.create_instance(
-            {'x_min': 1, 'x_max': 10, 'y_min': 1, 'y_max': 10, 'file_id': file1.id, 'soft_delete': True,
-             'label_file_id': label_file.id},
-            self.session
-        )
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            instance_list_new = new_list_payload_wrong,
+            instance_list_new = instance_list,
             file = file1,
             do_init_existing_instances = True
         )
-        result = ann_update._Annotation_Update__check_all_instances_available_in_new_instance_list()
+        ann_update.main()
 
-        self.assertTrue(result)
-        self.assertTrue(len(ann_update.log['warning'].keys()) > 0)
-        self.assertTrue('new_instance_list_missing_ids' in ann_update.log['warning'])
-        self.assertTrue('information' in ann_update.log['warning'])
-        self.assertTrue('missing_ids' in ann_update.log['warning'])
-        self.assertTrue(instance2.id in ann_update.log['warning']['missing_ids'])
-        self.assertTrue(instance3.id in ann_update.log['warning']['missing_ids'])
-        self.assertTrue(instance4.id not in ann_update.log['warning']['missing_ids'])
+        new_instance_list = [x.serialize_with_label() for x in ann_update.new_added_instances]
+        self.session.commit()
 
+        session2 = sessionMaker.session_factory()
+        new_instance_list[0]['x_min'] += 10
+        new_instance_list[0]['x_max'] += 10
+        new_instance_list[0]['y_max'] += 10
+        new_instance_list[0]['y_min'] += 10
+
+        # 3. Move the instance and resave
+        ann_update2 = Annotation_Update(
+            session = session2,
+            project = self.project,
+            instance_list_new = new_instance_list,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        ann_update2.main()
+        self.assertEqual(len(ann_update2.new_added_instances), 1)
+
+        instance_list_result = ann_update2.file.instance_list
+        new_instance_list = [x.serialize_with_label() for x in instance_list_result]
+        session2.commit()
+        # 4. Resave with no changes
+        ann_update2 = Annotation_Update(
+            session = session2,
+            project = self.project,
+            instance_list_new = new_instance_list,
+            file = file1,
+            do_init_existing_instances = True
+        )
+        ann_update2.main()
+        instance_list_result = ann_update2.file.instance_list
+
+        self.assertEqual(len(instance_list_result), 2)
+        self.assertEqual(len(ann_update2.new_added_instances), 0)
+        self.assertNotEqual(instance_list_result[1].action_type, 'undeleted')
+
+    def test_create_relation_no_ids(self):
+        """
+            Tests creating a relations with no IDS and only ref ids on the payload.
+        :return:
+        """
+        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'image'}, self.session)
+        frame = data_mocking.create_file(
+            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
+            self.session)
+        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
+        self.project.label_dict['label_file_id_list'] = [label_file.id]
+
+        instance_list = [
+            {
+                "id": None,
+                "creation_ref_id": "b246ba1b-07fa-4680-9398-de7d323ee650",
+                "label_file_id": label_file.id,
+                "selected": False,
+                "type": "text_token",
+                "points": [],
+                "soft_delete": False,
+                "start_token": 72,
+                "end_token": 72,
+                "initialized": True,
+                "text_tokenizer": "nltk"
+            },
+            {
+                "id": None,
+                "creation_ref_id": "221eea70-e0ba-433a-a5c5-851213b6ae66",
+                "label_file_id": label_file.id,
+                "type": "text_token",
+                "points": [],
+                "soft_delete": False,
+                "start_token": 76,
+                "end_token": 76,
+                "initialized": True,
+                "text_tokenizer": "nltk"
+            },
+            {
+                "id": None,
+                "creation_ref_id": "bb32076e-91bd-4d70-ac57-c1c115e6e43b",
+                "label_file_id": label_file.id,
+                "selected": False,
+                "number": None,
+                "type": "relation",
+                "points": [],
+                "sequence_id": None,
+                "soft_delete": False,
+                "from_instance_id": None,
+                "to_instance_id": None,
+                "initialized": True,
+                "text_tokenizer": "nltk",
+                "from_creation_ref": "b246ba1b-07fa-4680-9398-de7d323ee650",
+                "to_creation_ref": "221eea70-e0ba-433a-a5c5-851213b6ae66"
+            }
+        ]
+
+        ann_update = Annotation_Update(
+            session = self.session,
+            project = self.project,
+            instance_list_new = instance_list,
+            file = file1,
+            do_init_existing_instances = True
+        )
+
+        ann_update.main()
+
+        self.assertEqual(len(ann_update.log['error'].keys()), 0)
+
+    """
+    Next 2 methods below are for testing hashing functionality
+    """
     def test_hashing_algorithm_changes(self):
         """
             This case handles when the instance.hash() function changes, ie we add or remove
@@ -1371,403 +1783,4 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         ann_update2.main()
         self.assertEqual(len(ann_update2.system_upgrade_hash_changes), 0)
 
-    def test__saving_untouched_instance_list_does_not_restore(self):
-        """
-            We had a bug that whenever we resaved an instance and there where no changes
-            we would mark the instance as restored even though we were not restoring anything.
-
-            This was because we were not checking the is_new_instance flag in the
-            __validate_user_deletion() function of shared/annotation.py
-
-            This regression test case covers this bug
-        :return:
-        """
-        """
-            Sometimes default values can make the hash change after
-            saving to DB. This test checks that is not happening.
-        :return:
-        """
-        file1 = data_mocking.create_file({'project_id': self.project.id}, self.session)
-        label_file = data_mocking.create_file({'project_id': self.project.id}, self.session)
-        self.project.label_dict['label_file_id_list'] = [label_file.id]
-        # 1. Initial State 1 Unsaved Instance
-        inst1 = {'type': 'box',
-                 'file_id': file1.id,
-                 'label_file_id': label_file.id,
-                 'soft_delete': False,
-                 'x_min': 10,
-                 'y_min': 10,
-                 'x_max': 28,
-                 'y_max': 28,
-                 'deletion_type': None,
-                 'created_time': '2022-01-12T18:31:59.530816',
-                 'action_type': 'created',
-                 'deleted_time': None,
-                 'change_source': None,
-                 'p1': None,
-                 'p2': None,
-                 'cp': None,
-                 'center_x': None,
-                 'center_y': None,
-                 'creation_ref_id': '10460e33-c02b-459d-a412-ab7b4512gdghf',
-                 'number': None,
-                 'interpolated': False,
-                 'machine_made': False,
-                 'model_id': None,
-                 'model_run_id': None,
-                 'sequence_id': None,
-                 'front_face': None,
-                 'rear_face': None,
-                 'rating': None,
-                 'attribute_groups': None,
-                 'member_created_id': None,
-                 'previous_id': None,
-                 'next_id': None,
-                 'root_id': 1,
-                 'version': 1,
-                 'nodes': [],
-                 'edges': [],
-                 'pause_object': None,
-                 'label_file': {'id': 2, 'hash': None, 'type': 'image', 'state': 'added',
-                                'created_time': '2022-01-12T18:31:59.508361', 'time_last_updated': None,
-                                'ann_is_complete': None, 'original_filename': 'ykzwdu', 'video_id': None,
-                                'video_parent_file_id': None, 'count_instances_changed': None,
-                                'image': {'original_filename': None, 'width': None, 'height': None,
-                                          'soft_delete': False, 'url_signed': None, 'url_signed_thumb': None,
-                                          'annotation_status': None}}
-                 }
-        instance_list = [inst1]
-
-        # 2. save the instance.
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            instance_list_new = instance_list,
-            file = file1,
-            do_init_existing_instances = True
-        )
-        ann_update.main()
-
-        new_instance_list = [x.serialize_with_label() for x in ann_update.new_added_instances]
-        self.session.commit()
-
-        session2 = sessionMaker.session_factory()
-        new_instance_list[0]['x_min'] += 10
-        new_instance_list[0]['x_max'] += 10
-        new_instance_list[0]['y_max'] += 10
-        new_instance_list[0]['y_min'] += 10
-
-        # 3. Move the instance and resave
-        ann_update2 = Annotation_Update(
-            session = session2,
-            project = self.project,
-            instance_list_new = new_instance_list,
-            file = file1,
-            do_init_existing_instances = True
-        )
-        ann_update2.main()
-        self.assertEqual(len(ann_update2.new_added_instances), 1)
-
-        instance_list_result = ann_update2.file.instance_list
-        new_instance_list = [x.serialize_with_label() for x in instance_list_result]
-        session2.commit()
-        # 4. Resave with no changes
-        ann_update2 = Annotation_Update(
-            session = session2,
-            project = self.project,
-            instance_list_new = new_instance_list,
-            file = file1,
-            do_init_existing_instances = True
-        )
-        ann_update2.main()
-        instance_list_result = ann_update2.file.instance_list
-
-        self.assertEqual(len(instance_list_result), 2)
-        self.assertEqual(len(ann_update2.new_added_instances), 0)
-        self.assertNotEqual(instance_list_result[1].action_type, 'undeleted')
-
-    def test_create_instance_relation(self):
-        """
-            Tests creation of relation of type instance.
-            Tests verifications of from_id to_id fields.
-        :return:
-        """
-        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'image'}, self.session)
-        frame = data_mocking.create_file(
-            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
-            self.session)
-        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
-        # 2 Exactly equal instances
-        self.project.label_dict['label_file_id_list'] = [label_file.id]
-        ref1 = str(uuid.uuid4())
-        ref2 = str(uuid.uuid4())
-        inst1 = {
-            'creation_ref_id': ref1,
-            'x_min': 1,
-            'y_min': 1,
-            'x_max': 18,
-            'y_max': 18,
-            'soft_delete': False,
-            'label_file_id': label_file.id,
-            'type': 'box'
-        }
-        inst2 = {
-            'creation_ref_id': ref2,
-            'x_min': 1,
-            'y_min': 1,
-            'x_max': 54,
-            'y_max': 54,
-            'soft_delete': False,
-            'label_file_id': label_file.id,
-            'type': 'box'
-        }
-        relation = {
-            'from_creation_ref': ref1,
-            'to_creation_ref': ref2,
-            'creation_ref_id': str(uuid.uuid4()),
-            'soft_delete': False,
-            'label_file_id': label_file.id,
-            'type': 'relation'
-        }
-        instance_list = [inst1, inst2, relation]
-        ann_update2 = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            instance_list_new = instance_list,
-            file = file1,
-            do_init_existing_instances = True
-        )
-        ann_update2.main()
-        self.session.commit()
-        new_instances = ann_update2.new_added_instances
-        self.assertEqual(len(new_instances), 3)
-        self.assertEqual(len(ann_update2.new_instance_relations_list_no_ids), 1)
-        self.assertEqual(new_instances[2].type, 'relation')
-        self.assertEqual(new_instances[2].from_instance_id, new_instances[0].id)
-        self.assertEqual(new_instances[2].to_instance_id, new_instances[1].id)
-        ## Test Adding Instances With IDs
-        relation2 = {
-            'from_instance_id': new_instances[1].id,
-            'to_instance_id': new_instances[0].id,
-            'creation_ref_id': str(uuid.uuid4()),
-            'soft_delete': False,
-            'label_file_id': label_file.id,
-            'type': 'relation'
-        }
-        self.session.commit()
-        instance_list = [new_instances[0].serialize_with_label(),
-                         new_instances[1].serialize_with_label(),
-                         new_instances[2].serialize_with_label(),
-                         relation2]
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            instance_list_new = instance_list,
-            file = file1,
-            do_init_existing_instances = True
-        )
-        ann_update.main()
-        new_instances2 = ann_update.new_added_instances
-        self.assertEqual(len(new_instances2), 1)
-        self.assertEqual(len(ann_update.new_instance_relations_list_no_ids), 0)
-        self.assertEqual(new_instances2[0].type, 'relation')
-        self.assertEqual(new_instances2[0].from_instance_id, new_instances[1].id)
-        self.assertEqual(new_instances2[0].to_instance_id, new_instances[0].id)
-
-    def test_check_relations_id_existence(self):
-        """
-            Check calls to check_relations_id_existence
-        :return:
-        """
-        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'image'}, self.session)
-        frame = data_mocking.create_file(
-            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
-            self.session)
-        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
-        # 2 Exactly equal instances
-        self.project.label_dict['label_file_id_list'] = [label_file.id]
-        instance1 = data_mocking.create_instance(
-            {'x_min': 1,
-             'x_max': 10,
-             'y_min': 1,
-             'y_max': 10,
-             'file_id': file1.id,
-             'label_file_id': label_file.id,
-             'type': 'relation'
-             },
-            self.session
-        )
-        instance2 = data_mocking.create_instance(
-            {'x_min': 2,
-             'x_max': 15,
-             'y_min': 2,
-             'y_max': 15,
-             'file_id': file1.id,
-             'label_file_id': label_file.id,
-             'type': 'box'
-             },
-            self.session
-        )
-        ann_update2 = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            instance_list_new = [],
-            file = file1,
-            do_init_existing_instances = True
-        )
-
-        ann_update2.instance = instance1
-        # Check Error State
-        ann_update2.check_relations_id_existence(None, None, None, None)
-        self.assertTrue('from_id' in ann_update2.log['error'])
-        # Check IDs available
-        ann_update2.log['error'] = {}
-        ann_update2.instance.from_instance_id = 1
-        ann_update2.instance.to_instance_id = 1
-        ann_update2.check_relations_id_existence(ann_update2.instance.from_instance_id,
-                                                 ann_update2.instance.to_instance_id,
-                                                 None,
-                                                 None)
-        self.assertEqual(len(ann_update2.log['error'].keys()), 0)
-        self.assertEqual(len(ann_update2.new_instance_relations_list_no_ids), 0)
-        # Check IDs Not available
-        ann_update2.check_relations_id_existence(None,
-                                                 None,
-                                                 str(uuid.uuid4()),
-                                                 str(uuid.uuid4()))
-        self.assertEqual(len(ann_update2.log['error'].keys()), 0)
-        self.assertEqual(len(ann_update2.new_instance_relations_list_no_ids), 1)
-
-    def test_add_missing_ids_to_new_relations(self):
-        """
-            Tests calss to add_missing_ids_to_new_relations()
-        :return:
-        """
-        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'image'}, self.session)
-        frame = data_mocking.create_file(
-            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
-            self.session)
-        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
-        # 2 Exactly equal instances
-        self.project.label_dict['label_file_id_list'] = [label_file.id]
-        instance1 = data_mocking.create_instance(
-            {'x_min': 1,
-             'x_max': 10,
-             'y_min': 1,
-             'y_max': 10,
-             'file_id': file1.id,
-             'label_file_id': label_file.id,
-             'type': 'relation'
-             },
-            self.session
-        )
-        instance1.creation_ref_id = str(uuid.uuid4())
-        instance2 = data_mocking.create_instance(
-            {'x_min': 2,
-             'x_max': 15,
-             'y_min': 2,
-             'y_max': 15,
-             'file_id': file1.id,
-             'label_file_id': label_file.id,
-             'type': 'box'
-             },
-            self.session
-        )
-        relation = data_mocking.create_instance(
-            {
-                'file_id': file1.id,
-                'label_file_id': None,
-                'type': 'relation'
-            },
-            self.session
-        )
-        relation.hash_instance()
-        old_hash = relation.hash
-
-        instance2.creation_ref_id = str(uuid.uuid4())
-        self.session.commit()
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            instance_list_new = [],
-            file = file1,
-            do_init_existing_instances = True
-        )
-        ann_update.new_added_instances = [instance1, instance2]
-        ann_update.new_instance_relations_list_no_ids = [{'instance': relation,
-                                                          'from_ref': instance1.creation_ref_id,
-                                                          'to_ref': instance2.creation_ref_id}]
-        ann_update.add_missing_ids_to_new_relations()
-
-        self.assertEqual(relation.from_instance_id, instance1.id)
-        self.assertEqual(relation.to_instance_id, instance2.id)
-        self.assertNotEqual(old_hash, relation.hash)
-
-    def test_create_relation_no_ids(self):
-        """
-            Tests creating a relations with no IDS and only ref ids on the payload.
-        :return:
-        """
-        file1 = data_mocking.create_file({'project_id': self.project.id, 'type': 'image'}, self.session)
-        frame = data_mocking.create_file(
-            {'project_id': self.project.id, 'type': 'frame', 'video_parent_file_id': file1.id, 'frame_number': 5},
-            self.session)
-        label_file = data_mocking.create_file({'project_id': self.project.id, 'type': 'label'}, self.session)
-        self.project.label_dict['label_file_id_list'] = [label_file.id]
-
-        instance_list = [
-            {
-                "id": None,
-                "creation_ref_id": "b246ba1b-07fa-4680-9398-de7d323ee650",
-                "label_file_id": label_file.id,
-                "selected": False,
-                "type": "text_token",
-                "points": [],
-                "soft_delete": False,
-                "start_token": 72,
-                "end_token": 72,
-                "initialized": True,
-                "text_tokenizer": "nltk"
-            },
-            {
-                "id": None,
-                "creation_ref_id": "221eea70-e0ba-433a-a5c5-851213b6ae66",
-                "label_file_id": label_file.id,
-                "type": "text_token",
-                "points": [],
-                "soft_delete": False,
-                "start_token": 76,
-                "end_token": 76,
-                "initialized": True,
-                "text_tokenizer": "nltk"
-            },
-            {
-                "id": None,
-                "creation_ref_id": "bb32076e-91bd-4d70-ac57-c1c115e6e43b",
-                "label_file_id": label_file.id,
-                "selected": False,
-                "number": None,
-                "type": "relation",
-                "points": [],
-                "sequence_id": None,
-                "soft_delete": False,
-                "from_instance_id": None,
-                "to_instance_id": None,
-                "initialized": True,
-                "text_tokenizer": "nltk",
-                "from_creation_ref": "b246ba1b-07fa-4680-9398-de7d323ee650",
-                "to_creation_ref": "221eea70-e0ba-433a-a5c5-851213b6ae66"
-            }
-        ]
-
-        ann_update = Annotation_Update(
-            session = self.session,
-            project = self.project,
-            instance_list_new = instance_list,
-            file = file1,
-            do_init_existing_instances = True
-        )
-
-        ann_update.main()
-
-        self.assertEqual(len(ann_update.log['error'].keys()), 0)
+    

--- a/default/tests/shared/test_annotation_new.py
+++ b/default/tests/shared/test_annotation_new.py
@@ -14,7 +14,7 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         self.mock_file = MagicMock()
         self.instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
   
-    # TODO: How can we clean this up / re-use all the setup?
+    # TODO: Look at how we can clean up all the patching, ideally some way we can re-use it between tests
 
     @patch('shared.annotation.regular_log.default')
     @patch('shared.annotation.Project.get_by_id')

--- a/default/tests/shared/test_annotation_new.py
+++ b/default/tests/shared/test_annotation_new.py
@@ -1,7 +1,5 @@
 from methods.regular.regular_api import *
 from default.tests.test_utils import testing_setup
-from shared.tests.test_utils import common_actions, data_mocking
-from base64 import b64encode
 from shared.annotation import Annotation_Update
 from unittest.mock import patch, MagicMock, Mock, call
 
@@ -9,16 +7,12 @@ from unittest.mock import patch, MagicMock, Mock, call
 class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
 
     def setUp(self):
-        # TODO: this test is assuming the 'my-sandbox-project' exists and some object have been previously created.
-        # For future tests a mechanism of setting up and tearing down the database should be created.
         super(TestAnnotationUpdate, self).setUp()
         self.mock_session = MagicMock()
         self.mock_project = MagicMock()
         self.mock_member = MagicMock()
         self.mock_file = MagicMock()
-        
-        # TODO: Try this out if we have to instantiate the class often
-        # self.instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
+        self.instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
   
     # TODO: How can we clean this up / re-use all the setup?
 
@@ -100,11 +94,10 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
     @patch('shared.annotation.logger')
     def test_instance_template_main_empty_instance_list_new(self, mock_logger, mock_update_instance_list):
         # Arrange
-        instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
-        instance.instance_list_new = []
+        self.instance.instance_list_new = []
 
         # Act
-        result = instance.instance_template_main()
+        result = self.instance.instance_template_main()
 
         # Assert
         self.assertIsNone(result)
@@ -114,33 +107,31 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
     @patch('shared.annotation.Annotation_Update.update_instance_list')
     def test_instance_template_main_success(self, mock_update_instance_list):
         # Arrange
-        instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
-        instance.instance_list_new = [{'instance_id': 1}, {'instance_id': 2}]
-        instance.per_instance_spec_list = [{'label_file_id': {'required': True}}, {'some_other_key': 'value'}]
+        self.instance.instance_list_new = [{'instance_id': 1}, {'instance_id': 2}]
+        self.instance.per_instance_spec_list = [{'label_file_id': {'required': True}}, {'some_other_key': 'value'}]
         mock_new_added_instances = Mock()
-        instance.new_added_instances = mock_new_added_instances
+        self.instance.new_added_instances = mock_new_added_instances
 
         # Act
-        result = instance.instance_template_main()
+        result = self.instance.instance_template_main()
 
         # Assert
         self.assertEqual(result, mock_new_added_instances)
         mock_update_instance_list.assert_called_with(hash_instances=False, validate_label_file=False, overwrite_existing_instances=True)
-        self.assertEqual(instance.per_instance_spec_list, [{'label_file_id': {'required': False}}, {'some_other_key': 'value'}])
+        self.assertEqual(self.instance.per_instance_spec_list, [{'label_file_id': {'required': False}}, {'some_other_key': 'value'}])
         
     @patch('shared.annotation.logger')
     @patch('shared.annotation.Annotation_Update.update_instance_list')
     @patch('shared.annotation.Annotation_Update.return_orginal_file_type')
     def test_instance_template_main_error_detected(self, mock_return_orginal_file_type, mock_update_instance_list, mock_logger):
         # Arrange
-        instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
         mock_error_log = { "error": { "some_error": "error_message" }, "info": {}, "success": False }
         mock_instance_list = [{'instance_id': 1}, {'instance_id': 2}]
-        instance.instance_list_new = mock_instance_list
-        instance.log["error"] = mock_error_log["error"]
+        self.instance.instance_list_new = mock_instance_list
+        self.instance.log["error"] = mock_error_log["error"]
 
         # Act
-        result = instance.instance_template_main()
+        result = self.instance.instance_template_main()
 
         # Assert
         self.assertEqual(result, mock_return_orginal_file_type.return_value)

--- a/default/tests/shared/test_annotation_new.py
+++ b/default/tests/shared/test_annotation_new.py
@@ -2,7 +2,7 @@ from methods.regular.regular_api import *
 from default.tests.test_utils import testing_setup
 from shared.annotation import Annotation_Update
 from unittest.mock import patch, MagicMock, Mock, call
-
+from unittest import skip
 
 class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
 
@@ -242,10 +242,11 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         self.assertEqual(self.instance.system_upgrade_hash_changes, [])
         mock_logger.info.assert_not_called()
 
-    # TODO: side_effect isnt working here
+    # TODO: the side_effect func isnt working, hash is still set to 'hash1' after the action
+    @skip("side_effect func isnt working as expected")
     @patch('shared.annotation.logger')
     def test_rehash_existing_instances_different_hash(self, mock_logger):
-           # Arrange
+        # Arrange
         mock_instance = Mock(spec=Annotation_Update).return_value
         mock_instance.id = '123'
         mock_instance.hash = 'hash1'
@@ -257,10 +258,8 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         mock_instance.hash_instances.side_effect = side_effect
         mock_instance_list = [mock_instance]
 
-        print("HASH IS: ", mock_instance.hash)
         # Act
         result = self.instance.rehash_existing_instances(mock_instance_list)
-        print("HASH NOW: ", mock_instance.hash)
 
         # Assert
         self.instance.session.add.assert_called_once_with(mock_instance)
@@ -272,22 +271,3 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
                 'hash2'
         ))
         self.assertEqual(result, mock_instance_list)
-
-    # def rehash_existing_instances(self, instance_list):
-    #     result = []
-    #     for instance in instance_list:
-    #         prev_hash = instance.hash
-    #         instance.hash_instance()
-    #         new_hash = instance.hash
-    #         if prev_hash != new_hash:
-    #             logger.info(
-    #                 'Warning: Hashing algorithm upgrade Instance ID: {} has changed \n from: {} \n to: {}'.format(
-    #                     instance.id,
-    #                     prev_hash,
-    #                     new_hash
-    #                 ))
-    #             self.system_upgrade_hash_changes.append([prev_hash, new_hash])
-    #             self.session.add(instance)
-    #         result.append(instance)
-
-    #     return result

--- a/default/tests/shared/test_annotation_new.py
+++ b/default/tests/shared/test_annotation_new.py
@@ -1,0 +1,103 @@
+from methods.regular.regular_api import *
+from default.tests.test_utils import testing_setup
+from shared.tests.test_utils import common_actions, data_mocking
+from base64 import b64encode
+from shared.annotation import Annotation_Update
+from unittest.mock import patch, MagicMock, Mock, call
+
+
+class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
+
+    def setUp(self):
+        # TODO: this test is assuming the 'my-sandbox-project' exists and some object have been previously created.
+        # For future tests a mechanism of setting up and tearing down the database should be created.
+        super(TestAnnotationUpdate, self).setUp()
+  
+    # TODO: How can we clean this up / re-use all the setup?
+
+    @patch('shared.annotation.regular_log.default')
+    @patch('shared.annotation.Project.get_by_id')
+    @patch('shared.annotation.get_member')
+    @patch('shared.annotation.Annotation_Update.get_allowed_label_file_ids')
+    @patch('shared.annotation.Annotation_Update.init_video_input')
+    @patch('shared.annotation.Annotation_Update.task_update')
+    @patch('shared.annotation.Annotation_Update.init_file')
+    @patch('shared.annotation.Annotation_Update.init_existing_instances')
+    @patch('shared.annotation.Annotation_Update.refresh_instance_count')
+    def test_post_init_main_functions_called(self, mock_refresh_instance_count, mock_init_existing_instances, mock_init_file, mock_task_update, mock_init_video_input, mock_get_allowed_label_file_ids, mock_get_member, mock_Project_get_by_id, mock_default_log):
+        # Arrange
+        mock_session = MagicMock()
+        mock_project = MagicMock()
+        mock_member = MagicMock()
+        mock_file = MagicMock()
+
+        # func_calls = Mock()
+        # func_calls.m1, func_calls.m2, func_calls.m3, func_calls.m4, func_calls.m5, func_calls.m6 = mock_get_allowed_label_file_ids, mock_init_video_input, mock_task_update, mock_init_file, mock_init_existing_instances, mock_refresh_instance_count
+
+        # Act
+        instance = Annotation_Update(session=mock_session, file=mock_file, member=mock_member, project=mock_project)
+
+        # Assert
+        self.assertEqual(instance.log, mock_default_log.return_value) # Log was initialized
+        mock_Project_get_by_id.assert_not_called() # Project was not fetched
+        mock_get_member.assert_not_called() # Member was not fetched
+
+        # TODO: This isnt working, got it from here https://stackoverflow.com/questions/32463321/how-to-assert-method-call-order-with-python-mock
+        # func_calls.assert_has_calls([call.m1(), call.m2(), call.m3(), call.m4(), call.m5(), call.m6()])
+        mock_get_allowed_label_file_ids.assert_called_once()
+        self.assertEqual(instance.previous_next_instance_map, {})
+        mock_init_video_input.assert_called_once()
+        mock_task_update.assert_called_once()
+        mock_init_file.assert_called_once()
+        mock_init_existing_instances.assert_called_once()
+        mock_refresh_instance_count.assert_called_once()
+
+    @patch('shared.annotation.Annotation_Update.get_allowed_label_file_ids')
+    @patch('shared.annotation.Annotation_Update.init_video_input')
+    @patch('shared.annotation.Annotation_Update.task_update')
+    @patch('shared.annotation.Annotation_Update.init_file')
+    @patch('shared.annotation.Annotation_Update.init_existing_instances')
+    @patch('shared.annotation.Annotation_Update.refresh_instance_count')
+    def test_post_init_project_creating_for_instance_template(self, mock_refresh_instance_count, mock_init_existing_instances, mock_init_file, mock_task_update, mock_init_video_input, mock_get_allowed_label_file_ids):
+        # Arrange
+        mock_session = MagicMock()
+        mock_file = MagicMock()
+        creating_for_instance_template = True
+
+        # Act
+        Annotation_Update(session=mock_session, file=mock_file, creating_for_instance_template=creating_for_instance_template)
+
+        mock_get_allowed_label_file_ids.assert_not_called()
+        mock_init_video_input.assert_not_called()
+        mock_task_update.assert_not_called()
+        mock_init_file.assert_not_called()
+        mock_init_existing_instances.assert_not_called()
+        mock_refresh_instance_count.assert_not_called()
+
+    @patch('shared.annotation.Project.get_by_id')
+    def test_post_init_project_fetched(self, mock_Project_get_by_id):
+        # Arrange
+        mock_session = MagicMock()
+        mock_file = MagicMock()
+        project_id = 123
+
+        # Act
+        Annotation_Update(session=mock_session, file=mock_file, project_id=project_id)
+
+        # Assert
+        mock_Project_get_by_id.assert_called_once_with(mock_session, project_id)
+
+    @patch('shared.annotation.get_member')
+    def test_post_init_member_fetched(self, mock_get_member):
+        # Arrange
+        mock_session = MagicMock()
+        mock_file = MagicMock()
+        project_id = 123
+
+        # Act
+        Annotation_Update(session=mock_session, file=mock_file, project_id=project_id)
+
+        # Assert
+        mock_get_member.assert_called_once_with(session=mock_session)
+
+

--- a/default/tests/shared/test_annotation_new.py
+++ b/default/tests/shared/test_annotation_new.py
@@ -12,6 +12,13 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         # TODO: this test is assuming the 'my-sandbox-project' exists and some object have been previously created.
         # For future tests a mechanism of setting up and tearing down the database should be created.
         super(TestAnnotationUpdate, self).setUp()
+        self.mock_session = MagicMock()
+        self.mock_project = MagicMock()
+        self.mock_member = MagicMock()
+        self.mock_file = MagicMock()
+        
+        # TODO: Try this out if we have to instantiate the class often
+        # self.instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
   
     # TODO: How can we clean this up / re-use all the setup?
 
@@ -26,16 +33,11 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
     @patch('shared.annotation.Annotation_Update.refresh_instance_count')
     def test_post_init_main_functions_called(self, mock_refresh_instance_count, mock_init_existing_instances, mock_init_file, mock_task_update, mock_init_video_input, mock_get_allowed_label_file_ids, mock_get_member, mock_Project_get_by_id, mock_default_log):
         # Arrange
-        mock_session = MagicMock()
-        mock_project = MagicMock()
-        mock_member = MagicMock()
-        mock_file = MagicMock()
-
         # func_calls = Mock()
         # func_calls.m1, func_calls.m2, func_calls.m3, func_calls.m4, func_calls.m5, func_calls.m6 = mock_get_allowed_label_file_ids, mock_init_video_input, mock_task_update, mock_init_file, mock_init_existing_instances, mock_refresh_instance_count
 
         # Act
-        instance = Annotation_Update(session=mock_session, file=mock_file, member=mock_member, project=mock_project)
+        instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
 
         # Assert
         self.assertEqual(instance.log, mock_default_log.return_value) # Log was initialized
@@ -60,12 +62,10 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
     @patch('shared.annotation.Annotation_Update.refresh_instance_count')
     def test_post_init_project_creating_for_instance_template(self, mock_refresh_instance_count, mock_init_existing_instances, mock_init_file, mock_task_update, mock_init_video_input, mock_get_allowed_label_file_ids):
         # Arrange
-        mock_session = MagicMock()
-        mock_file = MagicMock()
         creating_for_instance_template = True
 
         # Act
-        Annotation_Update(session=mock_session, file=mock_file, creating_for_instance_template=creating_for_instance_template)
+        Annotation_Update(session=self.mock_session, file=self.mock_file, creating_for_instance_template=creating_for_instance_template)
 
         mock_get_allowed_label_file_ids.assert_not_called()
         mock_init_video_input.assert_not_called()
@@ -77,27 +77,77 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
     @patch('shared.annotation.Project.get_by_id')
     def test_post_init_project_fetched(self, mock_Project_get_by_id):
         # Arrange
-        mock_session = MagicMock()
-        mock_file = MagicMock()
         project_id = 123
 
         # Act
-        Annotation_Update(session=mock_session, file=mock_file, project_id=project_id)
+        Annotation_Update(session=self.mock_session, file=self.mock_file, project_id=project_id)
 
         # Assert
-        mock_Project_get_by_id.assert_called_once_with(mock_session, project_id)
+        mock_Project_get_by_id.assert_called_once_with(self.mock_session, project_id)
 
     @patch('shared.annotation.get_member')
     def test_post_init_member_fetched(self, mock_get_member):
         # Arrange
-        mock_session = MagicMock()
-        mock_file = MagicMock()
         project_id = 123
 
         # Act
-        Annotation_Update(session=mock_session, file=mock_file, project_id=project_id)
+        Annotation_Update(session=self.mock_session, file=self.mock_file, project_id=project_id)
 
         # Assert
-        mock_get_member.assert_called_once_with(session=mock_session)
+        mock_get_member.assert_called_once_with(session=self.mock_session)
 
+    @patch('shared.annotation.Annotation_Update.update_instance_list')
+    @patch('shared.annotation.logger')
+    def test_instance_template_main_empty_instance_list_new(self, mock_logger, mock_update_instance_list):
+        # Arrange
+        instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
+        instance.instance_list_new = []
 
+        # Act
+        result = instance.instance_template_main()
+
+        # Assert
+        self.assertIsNone(result)
+        mock_logger.error.assert_called_once_with('Error, please provide instance_list_new {\'error\': {}, \'info\': {}, \'success\': False}')
+        mock_update_instance_list.assert_not_called()
+    
+    @patch('shared.annotation.Annotation_Update.update_instance_list')
+    def test_instance_template_main_success(self, mock_update_instance_list):
+        # Arrange
+        instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
+        instance.instance_list_new = [{'instance_id': 1}, {'instance_id': 2}]
+        instance.per_instance_spec_list = [{'label_file_id': {'required': True}}, {'some_other_key': 'value'}]
+        mock_new_added_instances = Mock()
+        instance.new_added_instances = mock_new_added_instances
+
+        # Act
+        result = instance.instance_template_main()
+
+        # Assert
+        self.assertEqual(result, mock_new_added_instances)
+        mock_update_instance_list.assert_called_with(hash_instances=False, validate_label_file=False, overwrite_existing_instances=True)
+        self.assertEqual(instance.per_instance_spec_list, [{'label_file_id': {'required': False}}, {'some_other_key': 'value'}])
+        
+    @patch('shared.annotation.logger')
+    @patch('shared.annotation.Annotation_Update.update_instance_list')
+    @patch('shared.annotation.Annotation_Update.return_orginal_file_type')
+    def test_instance_template_main_error_detected(self, mock_return_orginal_file_type, mock_update_instance_list, mock_logger):
+        # Arrange
+        instance = Annotation_Update(session=self.mock_session, file=self.mock_file, member=self.mock_member, project=self.mock_project)
+        mock_error_log = { "error": { "some_error": "error_message" }, "info": {}, "success": False }
+        mock_instance_list = [{'instance_id': 1}, {'instance_id': 2}]
+        instance.instance_list_new = mock_instance_list
+        instance.log["error"] = mock_error_log["error"]
+
+        # Act
+        result = instance.instance_template_main()
+
+        # Assert
+        self.assertEqual(result, mock_return_orginal_file_type.return_value)
+        mock_update_instance_list.assert_called_with(hash_instances=False, validate_label_file=False, overwrite_existing_instances=True)
+        expected_logger_calls = [
+            call(f"Error updating annotation {str(mock_error_log)}"),
+            call(f"Instance list is: {mock_instance_list}")
+        ]
+        mock_logger.error.assert_has_calls(expected_logger_calls)
+        

--- a/default/tests/shared/test_annotation_new.py
+++ b/default/tests/shared/test_annotation_new.py
@@ -142,3 +142,41 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
         ]
         mock_logger.error.assert_has_calls(expected_logger_calls)
         
+
+    def test___perform_external_map_action(self):
+        # Arrange
+        self.instance.external_map = Mock()
+        self.instance.external_map_action = 'set_instance_id'
+        self.instance.instance = Mock()
+
+        # Act
+        self.instance._Annotation_Update__perform_external_map_action()
+
+        # Assert
+        self.assertEqual(self.instance.external_map.instance, self.instance.instance)
+        self.instance.session.add.assert_called_once_with(self.instance.external_map)
+
+    def test___perform_external_map_action_wrong_action(self):
+        # Arrange
+        self.instance.external_map = Mock()
+        self.instance.external_map_action = 'something_else'
+        self.instance.instance = Mock()
+
+        # Act
+        self.instance._Annotation_Update__perform_external_map_action()
+
+        # Assert
+        self.assertNotEqual(self.instance.external_map.instance, self.instance.instance)
+        self.instance.session.add.assert_not_called()
+
+    def test___perform_external_map_action_no_external_map(self):
+        # Arrange
+        self.instance.external_map = None
+        self.instance.external_map_action = 'set_instance_id'
+        self.instance.instance = Mock()
+
+        # Act
+        self.instance._Annotation_Update__perform_external_map_action()
+
+        # Assert
+        self.instance.session.add.assert_not_called()

--- a/default/tests/shared/test_annotation_new.py
+++ b/default/tests/shared/test_annotation_new.py
@@ -180,3 +180,49 @@ class TestAnnotationUpdate(testing_setup.DiffgramBaseTestCase):
 
         # Assert
         self.instance.session.add.assert_not_called()
+
+    @patch('shared.annotation.FileStats.update_file_stats_data')
+    def test_instance_list_cache_update(self, mock_update_file_stats_data):
+        # Arrange
+        mock_instance_list_kept_serialized = Mock()
+        self.instance.instance_list_kept_serialized = mock_instance_list_kept_serialized
+
+        # Act
+        self.instance.instance_list_cache_update()
+
+        # Assert
+        self.instance.file.set_cache_by_key.assert_called_once_with(cache_key='instance_list', value=mock_instance_list_kept_serialized)
+        mock_update_file_stats_data.assert_called_once_with(session=self.instance.session, instance_list=mock_instance_list_kept_serialized, file_id=self.instance.file.id, project=self.instance.project)
+
+    @patch('shared.annotation.FileStats.update_file_stats_data')
+    def test_instance_list_cache_update_no_file(self, mock_update_file_stats_data):
+        # Arrange
+        self.instance.file = None
+
+        # Act
+        self.instance.instance_list_cache_update()
+
+        # Assert
+        mock_update_file_stats_data.assert_not_called()
+
+    def test_return_orginal_file_type_video_parent_file(self):
+        # Arrange
+        mock_video_parent_file = Mock()
+        self.instance.video_parent_file = mock_video_parent_file
+
+        # Act
+        result = self.instance.return_orginal_file_type()
+
+        # Assert
+        self.assertEqual(result, mock_video_parent_file)
+
+    def test_return_orginal_file_type_base_file(self):
+        # Arrange
+        self.instance.video_parent_file = None
+
+        # Act
+        result = self.instance.return_orginal_file_type()
+
+        # Assert
+        self.assertEqual(result, self.instance.file)
+

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -458,6 +458,7 @@ class Annotation_Update():
 
         self.refresh_instance_count()
 
+    # Tested
     def instance_template_main(self):
         """
             This is the main flow for creating/updating

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -484,6 +484,7 @@ class Annotation_Update():
 
         return self.new_added_instances
 
+    # Tested
     def __check_all_instances_available_in_new_instance_list(self):
         if not self.do_init_existing_instances:
             return True
@@ -536,18 +537,21 @@ class Annotation_Update():
             # return False
         return True
 
+    # Tested
     def append_new_instance_list_hash(self, instance):
         if instance.soft_delete is False:
             self.new_instance_dict_hash[instance.hash] = instance
             return True
         return False
 
+    # Tested
     def order_new_instances_by_date(self):
         self.instance_list_new.sort(
             key = lambda item: (item.get('client_created_time') is not None, item.get('client_created_time')),
             reverse = True)
         return self.instance_list_new
 
+    # Tested measily, needs a big cleanup
     def annotation_update_main(self):
 
         """
@@ -605,6 +609,7 @@ class Annotation_Update():
             logger.error(f"Error updating annotation {str(self.log)}")
         return self.return_orginal_file_type()
 
+    # TODO: Whats the point of this?
     def main(self):
         return self.annotation_update_main()
 
@@ -724,7 +729,8 @@ class Annotation_Update():
                     task = self.task
                 )
                 self.is_new_file = True
-
+    
+    # Tested
     def detect_and_remove_collisions(self, instance_list):
         result = []
         hashes_dict = {}
@@ -1576,6 +1582,7 @@ class Annotation_Update():
             if instance.get('id') == id:
                 return i
 
+    # Tested
     def update_sequence_id_in_cache_list(self, instance):
         """
             Updates the sequences ID in the cache list.
@@ -1591,6 +1598,7 @@ class Annotation_Update():
             if existing_serialized_instance.get('id') == instance.id:
                 existing_serialized_instance['sequence_id'] = instance.sequence_id
 
+    # Tested
     def update_cache_single_instance_in_list_context(self):
         """
         CAUTION this assumes that instance_list_kept_serialized will exist etc
@@ -1682,6 +1690,7 @@ class Annotation_Update():
             self.file = File.copy_file_from_existing(
                 self.session, directory, self.file)
 
+    # Tested
     def add_missing_ids_to_new_relations(self):
 
         for relation_elm in self.new_instance_relations_list_no_ids:
@@ -1703,6 +1712,7 @@ class Annotation_Update():
             instance.hash_instance()
             self.session.add(instance)
 
+    # Tested
     def check_relations_id_existence(self, from_id, to_id, from_ref, to_ref):
         """
             Checks if current instance is a relations and if ID's are available for saving.
@@ -2045,6 +2055,7 @@ class Annotation_Update():
 
             return sequence
 
+    # Tested
     def check_polygon_points_and_build_bounds(self):
         self.instance.x_min = 99999
         self.instance.x_max = 0

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -553,7 +553,7 @@ class Annotation_Update():
             reverse = True)
         return self.instance_list_new
 
-    # Tested measily, needs a big cleanup
+    # Tested
     def annotation_update_main(self):
 
         """
@@ -758,7 +758,8 @@ class Annotation_Update():
                 self.session.add(inst)
 
         return result
-
+    
+    # Tested
     def rehash_existing_instances(self, instance_list):
         result = []
         for instance in instance_list:

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -430,6 +430,7 @@ class Annotation_Update():
 
     # https://diffgram.readme.io/docs/general-annotation-update
 
+    # Tested
     def __post_init__(self):
 
         self.log = regular_log.default()

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -611,7 +611,6 @@ class Annotation_Update():
             logger.error(f"Error updating annotation {str(self.log)}")
         return self.return_orginal_file_type()
 
-    # TODO: Whats the point of this?
     def main(self):
         return self.annotation_update_main()
 

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -615,6 +615,7 @@ class Annotation_Update():
     def main(self):
         return self.annotation_update_main()
 
+    # Tested
     def __perform_external_map_action(self):
         if not self.external_map:
             return

--- a/shared/annotation.py
+++ b/shared/annotation.py
@@ -624,6 +624,7 @@ class Annotation_Update():
                 self.external_map.instance = self.instance
                 self.session.add(self.external_map)
 
+    # Tested
     def instance_list_cache_update(self):
         """
         High level idea of caching
@@ -660,7 +661,7 @@ class Annotation_Update():
             project = self.project
         )
 
-
+    # Tested
     def return_orginal_file_type(self):
         """
         Not a fan of this setup... but at least this way


### PR DESCRIPTION
Added some new unit tests to Annotation_Update. Putting these on hold for now and instead working on the Annotation_Update refactor, so figure we can just merge the new tests in.

Ignore the huge diff for `default/tests/shared/test_annotation.py`, I just re-ordered the tests so that similar tests were grouped together