### PR TITLE
Remove autoindex context of Increasing the security bar in Ingress-NGINX v1.2.0

### DIFF
--- a/frontend/.nginx/nginx.conf
+++ b/frontend/.nginx/nginx.conf
@@ -14,23 +14,15 @@ http {
 
         location /static/ {
             root  /usr/share/nginx/html/;
-            autoindex on;
-
         }
         location /static/js/ {
             root  /usr/share/nginx/html/;
-            autoindex on;
-
         }
         location /static/css/ {
             root  /usr/share/nginx/html/;
-            autoindex on;
-
         }
         location /static/fonts/ {
             root  /usr/share/nginx/html/;
-            autoindex on;
-
         }
 
     }


### PR DESCRIPTION
remove as per https://kubernetes.io/blog/2022/04/28/ingress-nginx-1-2-0/#ok-but-how-does-this-increase-the-security-of-my-ingress-controller
