### PR TITLE
Fix Cosmetic "Dataset Explorer, after scrolling down a certain amount error"

### DIFF
--- a/frontend/src/components/source_control/dataset_explorer.vue
+++ b/frontend/src/components/source_control/dataset_explorer.vue
@@ -628,12 +628,14 @@ export default Vue.extend({
             this.file_list = response.data.file_list;
           }
           else{
+            // TODO clarify point of this block relative to concat
             for(const file in response.data.file_list){
               if(!this.file_list.find(f => f.id === file.id)){
                 this.file_list.push(file);
               }
             }
             this.file_list = this.file_list.concat(response.data.file_list);
+            this.file_list = this.file_list.filter((file) => typeof file === 'object')
           }
         }
         this.metadata_previous = response.data.metadata;
@@ -643,8 +645,8 @@ export default Vue.extend({
 
       }
       catch (error) {
-        console.error(error)
         if (error.toString() !== 'Cancel'){
+          console.error(error)
           this.query_error = this.$route_api_errors(error)
         }
       }
@@ -675,8 +677,11 @@ export default Vue.extend({
 
     },
     reset_file_selected: function(){
+      console.log(this.file_list)
       for (let file_elm of this.file_list) {
-        file_elm.selected = false;
+        if (typeof file_elm === 'object') {
+          file_elm.selected = false;
+        }
       }
       this.selected_files = []
     },


### PR DESCRIPTION
Fixes
https://github.com/diffgram/diffgram/issues/1571

- This was a "Cosmetic" only item, since the '0' object was not a valid file there was nothing to unselect.
- The root of it injecting the '0' can be solved as part of refactoring the file push and concat block which should be seperate functions.

Additional Context 
- Error: Cannot create property 'selected' on string '0'
- In theory a file object should never be a string '0', however, it seems to be adding this in, so until that root item is solved adding this check to filter out the '0's (which aren't valid file objects)
- In limited testing it only seems to happen once, so some process is adding it in a funny way
For example:
![file list has a zero](https://github.com/diffgram/diffgram/assets/18080164/e99bcb1b-452b-4196-97cf-7f0a50f94ee1)
