### PR TITLE
Fix global object attribute updates in some contexts

### DIFF
--- a/frontend/src/components/annotation/annotation_ui_factory.vue
+++ b/frontend/src/components/annotation/annotation_ui_factory.vue
@@ -1292,6 +1292,15 @@ export default Vue.extend({
                 video_data,
             }
             const [result, error] = await saveFileAnnotations(this.computed_project_string_id, this.root_file.id, payload)
+
+            AnnotationSavePrechecks.add_ids_to_new_instances_and_delete_old(
+              result,
+              false,
+              this.annotation_ui_context.compound_global_attributes_instance_list,
+              false,
+              false
+            )
+
             this.root_file.instance_list = this.annotation_ui_context.compound_global_attributes_instance_list
             if (error) {
                 console.error(error)

--- a/shared/database/event/event.py
+++ b/shared/database/event/event.py
@@ -324,7 +324,7 @@ class Event(Base):
             session.flush()
         Event.track_user(event, email)
         logger.debug(f'Created event {event.id}:{event.kind}')
-        event.send_to_eventhub()
+        #event.send_to_eventhub()
         event.broadcast()
         return event
 


### PR DESCRIPTION
[Add regressed instance ID update](https://github.com/diffgram/diffgram/commit/12e18f95fe825a3b3c14600320684bad8c4ebe80) 

add_ids_to_new_instances_and_delete_old() is needed for Object level Global attributes too.
In local testing this solved the global attribute update context when saving the same global attributes without reloading

Fixes https://github.com/diffgram/diffgram/issues/1594