### PR TITLE
make healthcheck variable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -106,7 +106,7 @@ services:
     hostname: db
     restart: always
     healthcheck:
-      test: ${HEALTHCHECK_TEST}
+      test: ['CMD-SHELL', ${HEALTHCHECK_TEST_COMMAND}, ${HEALTHCHECK_TEST_ARG_0}, ${HEALTHCHECK_TEST_ARG_1}]
       interval: 30s
       timeout: 60s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -106,7 +106,7 @@ services:
     hostname: db
     restart: always
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready", "-d", "db_prod" ]
+      test: ${HEALTHCHECK_TEST}
       interval: 30s
       timeout: 60s
       retries: 5

--- a/install.py
+++ b/install.py
@@ -524,13 +524,14 @@ class DiffgramInstallTool:
         env_file += f"RABBITMQ_PORT={self.rabbit_port}\n"
 
         if self.local_database:
-            env_file += "POSTGRES_IMAGE=postgres:12.5\n"
+            env_file += "POSTGRES_IMAGE=postgres:16\n"
             env_file += "DATABASE_URL=postgresql+psycopg2://postgres:postgres@db/diffgram\n"
             env_file += "DATABASE_NAME=diffgram\n"
             env_file += "DATABASE_HOST=db\n"
             env_file += "DATABASE_NAME=diffgram\n"
             env_file += "DATABASE_USER=postgres\n"
             env_file += "DATABASE_PASS=postgres\n"
+            env_file += f"HEALTHCHECK_TEST='['CMD-SHELL', 'pg_isready', '-d', 'db_prod']'\n"
 
         else:
             env_file += "POSTGRES_IMAGE=tianon/true\n"
@@ -539,6 +540,7 @@ class DiffgramInstallTool:
             env_file += f"DATABASE_NAME={self.db_name}\n"
             env_file += f"DATABASE_USER={self.db_username}\n"
             env_file += f"DATABASE_PASS={self.db_pass}\n"
+            env_file += f"HEALTHCHECK_TEST='['CMD-SHELL', 'echo', 'Remote db in use. Health check not supported yet.']'\n"
 
         if self.mailgun:
             env_file += f"MAILGUN_KEY={self.mailgun_key}\n"

--- a/install.py
+++ b/install.py
@@ -531,8 +531,9 @@ class DiffgramInstallTool:
             env_file += "DATABASE_NAME=diffgram\n"
             env_file += "DATABASE_USER=postgres\n"
             env_file += "DATABASE_PASS=postgres\n"
-            env_file += f"HEALTHCHECK_TEST='['CMD-SHELL', 'pg_isready', '-d', 'db_prod']'\n"
-
+            env_file += "HEALTHCHECK_TEST_COMMAND=pg_isready\n"
+            env_file += "HEALTHCHECK_TEST_ARG_0=-d\n"
+            env_file += "HEALTHCHECK_TEST_ARG_1=db_prod\n"
         else:
             env_file += "POSTGRES_IMAGE=tianon/true\n"
             env_file += f"DATABASE_URL={self.database_url}\n"
@@ -540,7 +541,9 @@ class DiffgramInstallTool:
             env_file += f"DATABASE_NAME={self.db_name}\n"
             env_file += f"DATABASE_USER={self.db_username}\n"
             env_file += f"DATABASE_PASS={self.db_pass}\n"
-            env_file += f"HEALTHCHECK_TEST='['CMD-SHELL', 'echo', 'Remote db in use. Health check not supported yet.']'\n"
+            env_file += "HEALTHCHECK_TEST_COMMAND=echo\n"
+            env_file += "HEALTHCHECK_TEST_ARG_0=remote_db_in_use\n"
+            env_file += "HEALTHCHECK_TEST_ARG_1=none\n"
 
         if self.mailgun:
             env_file += f"MAILGUN_KEY={self.mailgun_key}\n"


### PR DESCRIPTION
Context of https://github.com/diffgram/diffgram/issues/1615

The backdrop here is:
* Docker compose (local test install option) offers a local or remote db. In the case of remote db being used the health checks appear to be failing.
* `tianon/true` is correct in of itself in theory, however in conjunction with the health check it will fail.

The proposed solution is to make the healthcheck variable. In the remote case it will echo that it's not supported.  That avoids having to have the postgres image loaded etc when remote db is actually being used. that is cleaner and also prevents debug issues or confusions with a db running that's not being used.

Also updated default postgres db for local testing to more modern version POSTGRES_IMAGE=postgres:16