### PR TITLE
security: verify JWT signature in OAuth2 base class (CWE-347)

### DIFF
--- a/shared/auth/OAuth2Provider.py
+++ b/shared/auth/OAuth2Provider.py
@@ -101,8 +101,44 @@ class OAuth2ClientBase(metaclass = SingletonABC):
             return False
 
     def get_decoded_jwt_token(self, id_token: str) -> dict:
-        decoded_token = jwt.decode(id_token, verify=False, algorithms='RS256', options={"verify_signature": False})
-        return decoded_token
+        """
+            Decode a JWT token with signature verification using the provider's
+            public key. Falls back to unverified decode only when no public key
+            is configured, with a security warning.
+
+            Security note (CWE-347): Previously this method decoded JWTs without
+            any signature verification, allowing an attacker to forge tokens with
+            arbitrary claims. The token is now verified against the OIDC provider's
+            public key when available.
+        """
+        public_key = getattr(settings, 'OAUTH2_PROVIDER_PUBLIC_KEY', None)
+        if public_key:
+            try:
+                header = "-----BEGIN PUBLIC KEY-----\n"
+                trailer = "\n-----END PUBLIC KEY-----"
+                key = header + str(public_key) + trailer
+                decoded_token = jwt.decode(
+                    id_token,
+                    key=key,
+                    algorithms=['RS256'],
+                    options={"verify_exp": False}  # Expiry is checked separately by id_token_has_expired
+                )
+                return decoded_token
+            except jwt.exceptions.PyJWTError as e:
+                logger.error(f"JWT signature verification failed: {e}")
+                return {}
+        else:
+            logger.warning(
+                "SECURITY WARNING: OAUTH2_PROVIDER_PUBLIC_KEY is not configured. "
+                "JWT signature verification is skipped. This allows token forgery. "
+                "Set OAUTH2_PROVIDER_PUBLIC_KEY to enable signature verification."
+            )
+            decoded_token = jwt.decode(
+                id_token,
+                algorithms=['RS256'],
+                options={"verify_signature": False}
+            )
+            return decoded_token
 
     @abc.abstractmethod
     def get_access_token_from_jwt(self, jwt_data: dict):


### PR DESCRIPTION
## Summary

The `get_decoded_jwt_token()` method in `OAuth2ClientBase` decodes JWT tokens with `verify=False` and `options={"verify_signature": False}`, allowing an attacker to forge tokens with arbitrary claims.

## Security Impact

**CWE-347: Improper Verification of Cryptographic Signature**

This is a critical authentication bypass vulnerability. The unverified JWT decode is called from:

- `permissions.py:171` — `get_user_from_oauth2()` uses `get_decoded_jwt_token()` to extract the `sub` claim and look up the authenticated user
- `permissions.py:82,89,109` — `id_token_has_expired()` calls `get_decoded_jwt_token()` to check token expiry

An attacker can craft a JWT with an arbitrary `sub` claim (pointing to any user) and an `exp` claim far in the future. Since the signature is never verified, the application will accept the forged token and authenticate the attacker as any user.

**Note:** The `KeycloakDiffgramClient.verify_token()` already properly verifies JWT signatures using the provider's public key — this fix brings the same verification to the base class method used in the permissions flow.

## Fix

When `OAUTH2_PROVIDER_PUBLIC_KEY` is configured:
- Verify the JWT signature using the provider's RSA public key
- Return an empty dict on verification failure (safe default)

When no public key is configured:
- Log a clear security warning to alert operators
- Fall back to unverified decode (preserves backward compatibility)

Also removes the deprecated `verify` parameter (replaced by `options` dict in PyJWT >= 2.0).

## Testing

- Existing JWT decode behavior is preserved when public key is configured
- Invalid/forged tokens now correctly fail verification
- Backward compatible with deployments that haven't configured the public key yet (with warning)